### PR TITLE
CUB-based argsort implementation as a device func

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -729,6 +729,14 @@ if(BUILD_TEST)
   set_property(TARGET ${RNG_TEST_KERNELS} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${RNG_TEST_KERNELS} PRIVATE torch ${TORCH_LIBRARIES})
   target_include_directories(${RNG_TEST_KERNELS} PRIVATE "${NVFUSER_ROOT}")
+
+  set(ARGSORT_TEST_KERNELS "argsort_test_kernels")
+  add_library(${ARGSORT_TEST_KERNELS} SHARED ${NVFUSER_ROOT}/tests/cpp/argsort_test_kernels.cu)
+
+  # CUDA 11 does not support C++20, so hard code C++17 here
+  set_property(TARGET ${ARGSORT_TEST_KERNELS} PROPERTY CXX_STANDARD 17)
+  target_link_libraries(${ARGSORT_TEST_KERNELS} PRIVATE torch ${TORCH_LIBRARIES})
+  target_include_directories(${ARGSORT_TEST_KERNELS} PRIVATE "${NVFUSER_ROOT}")
 endif()
 
 function(add_test_without_main TEST_NAME TEST_SRC ADDITIONAL_LINK)
@@ -776,6 +784,9 @@ if(BUILD_TEST)
 
   add_test(test_rng ${NVFUSER_ROOT}/tests/cpp/test_rng.cpp ${RNG_TEST_KERNELS})
   list(APPEND TEST_BINARIES test_rng)
+
+  add_test(test_argsort ${NVFUSER_ROOT}/tests/cpp/test_argsort_device_func.cpp ${ARGSORT_TEST_KERNELS})
+  list(APPEND TEST_BINARIES test_argsort)
 
   set(MULTIDEVICE_TEST_SRCS)
   list(APPEND MULTIDEVICE_TEST_SRCS
@@ -972,6 +983,7 @@ endif()
 # nvfuser runtime files
 set(NVFUSER_RUNTIME_FILES)
 list(APPEND NVFUSER_RUNTIME_FILES
+  ${NVFUSER_ROOT}/runtime/argsort.cu
   ${NVFUSER_ROOT}/runtime/array.cu
   ${NVFUSER_ROOT}/runtime/basic_type_traits.cu
   ${NVFUSER_ROOT}/runtime/bf16_support.cu

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -13,7 +13,7 @@ namespace nvfuser_runtime {
 // Block state constants following nvFuser conventions from fused_reduction.cu
 // Sort Domain - TEMPLATE STATE 0
 //   - Participating in the sort, has values coming in, sorted values coming out
-// Iteration Domain - TEMPLATE STATE 1  
+// Iteration Domain - TEMPLATE STATE 1
 //   - Not participating in the sort, has values across the dimension after sorting
 constexpr __device__ bool isSort(int STATE) {
   return STATE == 0;
@@ -27,7 +27,7 @@ constexpr __device__ bool isIter(int STATE) {
 // Following nvFuser dimensional template parameter pattern like fused_reduction.cu
 template <
     int BLOCK_DIM_X,
-    int BLOCK_DIM_Y, 
+    int BLOCK_DIM_Y,
     int BLOCK_DIM_Z,
     int BLOCK_STATE_X,
     int BLOCK_STATE_Y,
@@ -42,17 +42,17 @@ __device__ void blockArgsort(
     bool descending,
     DataT* shared_mem,
     BlockDimT block_dim) {
-    
+
     // For now, only support all dimensions participating in sort (state=0)
     static_assert(
         isSort(BLOCK_STATE_X) && isSort(BLOCK_STATE_Y) && isSort(BLOCK_STATE_Z),
         "For now, only all sort states are supported");
-    
+
     // CUB BlockRadixSort setup - with proper multi-dimensional block support
     // CUB supports multi-dimensional blocks when BLOCK_DIM_Y and BLOCK_DIM_Z are specified
     using BlockRadixSort = cub::BlockRadixSort<
         DataT,                    // Key type
-        BLOCK_DIM_X,             // X dimension 
+        BLOCK_DIM_X,             // X dimension
         ITEMS_PER_THREAD,        // Items per thread
         nvfuser_index_t,         // Value type (for key-value sorting)
         4,                       // RADIX_BITS (default)
@@ -62,20 +62,20 @@ __device__ void blockArgsort(
         BLOCK_DIM_Y,             // Y dimension
         BLOCK_DIM_Z              // Z dimension
     >;
-    
+
     // Allocate shared memory for CUB operations
     __shared__ typename BlockRadixSort::TempStorage temp_storage;
-    
+
     // Thread ID using all threads in the block (CUB requires full block participation)
     // CUB doesn't support sorting of just blockDim.x, so all threads participate
-    unsigned int thread_id = 
+    unsigned int thread_id =
         index_utils::maskedOffset<true, true, true>(threadIdx, block_dim);
-    
+
     // Initialize indices array: 0, 1, 2, ..., n-1 per thread
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         indices[i] = thread_id * ITEMS_PER_THREAD + i;
     }
-    
+
     // Perform key-value sorting using CUB
     // Keys = input_data, Values = indices
     // After sorting, indices array contains argsort result
@@ -86,4 +86,4 @@ __device__ void blockArgsort(
     }
 }
 
-} // namespace nvfuser_runtime 
+} // namespace nvfuser_runtime

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cub/block/block_radix_sort.cuh>
-#include <cuda_runtime.h>
 
 #include "index_utils.cu"
 

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -2,8 +2,6 @@
 
 #include <cub/block/block_radix_sort.cuh>
 
-#include "index_utils.cu"
-
 namespace nvfuser_runtime {
 
 // Block state constants following nvFuser conventions from fused_reduction.cu

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -1,8 +1,7 @@
-#pragma once
-
 #include <cub/block/block_radix_sort.cuh>
 
 namespace nvfuser_runtime {
+namespace argsort {
 
 // Block state constants following nvFuser conventions from fused_reduction.cu
 // Sort Domain - TEMPLATE STATE 0
@@ -35,7 +34,6 @@ __device__ void blockArgsort(
     int64_t (&indices)[ITEMS_PER_THREAD],
     const DataT (&input_data)[ITEMS_PER_THREAD],
     bool descending,
-    DataT* shared_mem,
     BlockDimT block_dim) {
   // For now, only support all dimensions participating in sort (state=0)
   static_assert(
@@ -88,4 +86,5 @@ __device__ void blockArgsort(
   }
 }
 
+} // namespace argsort
 } // namespace nvfuser_runtime

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cub/block/block_radix_sort.cuh>
+#include <cuda_runtime.h>
+
+// nvFuser index type - must be defined before including index_utils.cu
+using nvfuser_index_t = int64_t;
+
+#include "index_utils.cu"
+
+namespace nvfuser_runtime {
+
+// Block state constants following nvFuser conventions from fused_reduction.cu
+// Sort Domain - TEMPLATE STATE 0
+//   - Participating in the sort, has values coming in, sorted values coming out
+// Iteration Domain - TEMPLATE STATE 1  
+//   - Not participating in the sort, has values across the dimension after sorting
+constexpr __device__ bool isSort(int STATE) {
+  return STATE == 0;
+}
+
+constexpr __device__ bool isIter(int STATE) {
+  return STATE == 1;
+}
+
+// Block-parallel argsort using CUB BlockRadixSort
+// Following nvFuser dimensional template parameter pattern like fused_reduction.cu
+template <
+    int BLOCK_DIM_X,
+    int BLOCK_DIM_Y, 
+    int BLOCK_DIM_Z,
+    int BLOCK_STATE_X,
+    int BLOCK_STATE_Y,
+    int BLOCK_STATE_Z,
+    bool Aligned,
+    typename DataT,
+    int ITEMS_PER_THREAD,
+    typename BlockDimT>
+__device__ void blockArgsort(
+    DataT (&input_data)[ITEMS_PER_THREAD],
+    nvfuser_index_t (&indices)[ITEMS_PER_THREAD],
+    bool descending,
+    DataT* shared_mem,
+    BlockDimT block_dim) {
+    
+    // For now, only support all dimensions participating in sort (state=0)
+    static_assert(
+        isSort(BLOCK_STATE_X) && isSort(BLOCK_STATE_Y) && isSort(BLOCK_STATE_Z),
+        "For now, only all sort states are supported");
+    
+    // CUB BlockRadixSort setup - with proper multi-dimensional block support
+    // CUB supports multi-dimensional blocks when BLOCK_DIM_Y and BLOCK_DIM_Z are specified
+    using BlockRadixSort = cub::BlockRadixSort<
+        DataT,                    // Key type
+        BLOCK_DIM_X,             // X dimension 
+        ITEMS_PER_THREAD,        // Items per thread
+        nvfuser_index_t,         // Value type (for key-value sorting)
+        4,                       // RADIX_BITS (default)
+        true,                    // MEMOIZE_OUTER_SCAN (default for modern architectures)
+        cub::BLOCK_SCAN_WARP_SCANS,  // INNER_SCAN_ALGORITHM (default)
+        cudaSharedMemBankSizeFourByte,  // SMEM_CONFIG (default)
+        BLOCK_DIM_Y,             // Y dimension
+        BLOCK_DIM_Z              // Z dimension
+    >;
+    
+    // Allocate shared memory for CUB operations
+    __shared__ typename BlockRadixSort::TempStorage temp_storage;
+    
+    // Thread ID using all threads in the block (CUB requires full block participation)
+    // CUB doesn't support sorting of just blockDim.x, so all threads participate
+    unsigned int thread_id = 
+        index_utils::maskedOffset<true, true, true>(threadIdx, block_dim);
+    
+    // Initialize indices array: 0, 1, 2, ..., n-1 per thread
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        indices[i] = thread_id * ITEMS_PER_THREAD + i;
+    }
+    
+    // Perform key-value sorting using CUB
+    // Keys = input_data, Values = indices
+    // After sorting, indices array contains argsort result
+    if (descending) {
+        BlockRadixSort(temp_storage).SortDescending(input_data, indices);
+    } else {
+        BlockRadixSort(temp_storage).Sort(input_data, indices);
+    }
+}
+
+} // namespace nvfuser_runtime 

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -3,9 +3,6 @@
 #include <cub/block/block_radix_sort.cuh>
 #include <cuda_runtime.h>
 
-// nvFuser index type - must be defined before including index_utils.cu
-using nvfuser_index_t = int64_t;
-
 #include "index_utils.cu"
 
 namespace nvfuser_runtime {

--- a/runtime/argsort.cu
+++ b/runtime/argsort.cu
@@ -10,7 +10,8 @@ namespace nvfuser_runtime {
 // Sort Domain - TEMPLATE STATE 0
 //   - Participating in the sort, has values coming in, sorted values coming out
 // Iteration Domain - TEMPLATE STATE 1
-//   - Not participating in the sort, has values across the dimension after sorting
+//   - Not participating in the sort, has values across the dimension after
+//   sorting
 constexpr __device__ bool isSort(int STATE) {
   return STATE == 0;
 }
@@ -20,7 +21,8 @@ constexpr __device__ bool isIter(int STATE) {
 }
 
 // Block-parallel argsort using CUB BlockRadixSort
-// Following nvFuser dimensional template parameter pattern like fused_reduction.cu
+// Following nvFuser dimensional template parameter pattern like
+// fused_reduction.cu
 template <
     int BLOCK_DIM_X,
     int BLOCK_DIM_Y,
@@ -38,48 +40,49 @@ __device__ void blockArgsort(
     bool descending,
     DataT* shared_mem,
     BlockDimT block_dim) {
+  // For now, only support all dimensions participating in sort (state=0)
+  static_assert(
+      isSort(BLOCK_STATE_X) && isSort(BLOCK_STATE_Y) && isSort(BLOCK_STATE_Z),
+      "For now, only all sort states are supported");
 
-    // For now, only support all dimensions participating in sort (state=0)
-    static_assert(
-        isSort(BLOCK_STATE_X) && isSort(BLOCK_STATE_Y) && isSort(BLOCK_STATE_Z),
-        "For now, only all sort states are supported");
+  // CUB BlockRadixSort setup - with proper multi-dimensional block support
+  // CUB supports multi-dimensional blocks when BLOCK_DIM_Y and BLOCK_DIM_Z are
+  // specified
+  using BlockRadixSort = cub::BlockRadixSort<
+      DataT, // Key type
+      BLOCK_DIM_X, // X dimension
+      ITEMS_PER_THREAD, // Items per thread
+      nvfuser_index_t, // Value type (for key-value sorting)
+      4, // RADIX_BITS (default)
+      true, // MEMOIZE_OUTER_SCAN (default for modern architectures)
+      cub::BLOCK_SCAN_WARP_SCANS, // INNER_SCAN_ALGORITHM (default)
+      cudaSharedMemBankSizeFourByte, // SMEM_CONFIG (default)
+      BLOCK_DIM_Y, // Y dimension
+      BLOCK_DIM_Z // Z dimension
+      >;
 
-    // CUB BlockRadixSort setup - with proper multi-dimensional block support
-    // CUB supports multi-dimensional blocks when BLOCK_DIM_Y and BLOCK_DIM_Z are specified
-    using BlockRadixSort = cub::BlockRadixSort<
-        DataT,                    // Key type
-        BLOCK_DIM_X,             // X dimension
-        ITEMS_PER_THREAD,        // Items per thread
-        nvfuser_index_t,         // Value type (for key-value sorting)
-        4,                       // RADIX_BITS (default)
-        true,                    // MEMOIZE_OUTER_SCAN (default for modern architectures)
-        cub::BLOCK_SCAN_WARP_SCANS,  // INNER_SCAN_ALGORITHM (default)
-        cudaSharedMemBankSizeFourByte,  // SMEM_CONFIG (default)
-        BLOCK_DIM_Y,             // Y dimension
-        BLOCK_DIM_Z              // Z dimension
-    >;
+  // Allocate shared memory for CUB operations
+  __shared__ typename BlockRadixSort::TempStorage temp_storage;
 
-    // Allocate shared memory for CUB operations
-    __shared__ typename BlockRadixSort::TempStorage temp_storage;
+  // Thread ID using all threads in the block (CUB requires full block
+  // participation) CUB doesn't support sorting of just blockDim.x, so all
+  // threads participate
+  unsigned int thread_id =
+      index_utils::maskedOffset<true, true, true>(threadIdx, block_dim);
 
-    // Thread ID using all threads in the block (CUB requires full block participation)
-    // CUB doesn't support sorting of just blockDim.x, so all threads participate
-    unsigned int thread_id =
-        index_utils::maskedOffset<true, true, true>(threadIdx, block_dim);
+  // Initialize indices array: 0, 1, 2, ..., n-1 per thread
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    indices[i] = thread_id * ITEMS_PER_THREAD + i;
+  }
 
-    // Initialize indices array: 0, 1, 2, ..., n-1 per thread
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        indices[i] = thread_id * ITEMS_PER_THREAD + i;
-    }
-
-    // Perform key-value sorting using CUB
-    // Keys = input_data, Values = indices
-    // After sorting, indices array contains argsort result
-    if (descending) {
-        BlockRadixSort(temp_storage).SortDescending(input_data, indices);
-    } else {
-        BlockRadixSort(temp_storage).Sort(input_data, indices);
-    }
+  // Perform key-value sorting using CUB
+  // Keys = input_data, Values = indices
+  // After sorting, indices array contains argsort result
+  if (descending) {
+    BlockRadixSort(temp_storage).SortDescending(input_data, indices);
+  } else {
+    BlockRadixSort(temp_storage).Sort(input_data, indices);
+  }
 }
 
 } // namespace nvfuser_runtime

--- a/tests/cpp/argsort_test_helper.h
+++ b/tests/cpp/argsort_test_helper.h
@@ -1,0 +1,60 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdint>
+
+namespace nvfuser {
+
+// nvFuser index type
+using nvfuser_index_t = int64_t;
+
+// Function declarations for launching argsort test kernels
+
+template<typename DataT>
+void launch_basic_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending);
+
+template<typename DataT>
+void launch_multi_dim_2d_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending);
+
+template<typename DataT>
+void launch_multi_dim_3d_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending);
+
+void launch_bfloat16_argsort_test_kernel(
+    cudaStream_t stream,
+    __nv_bfloat16* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending);
+
+void launch_convert_float_to_bfloat16(
+    cudaStream_t stream,
+    float* input_float,
+    __nv_bfloat16* output_bfloat,
+    int n);
+
+} // namespace nvfuser 

--- a/tests/cpp/argsort_test_helper.h
+++ b/tests/cpp/argsort_test_helper.h
@@ -57,4 +57,4 @@ void launch_convert_float_to_bfloat16(
     __nv_bfloat16* output_bfloat,
     int n);
 
-} // namespace nvfuser 
+} // namespace nvfuser

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -1,0 +1,306 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+// Warning: this file should not include any header from nvFuser or pytorch
+// (except raw headers). Compiling with nvcc requires avoiding complex headers.
+
+#include <tests/cpp/argsort_test_helper.h>
+
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+// Include the actual nvFuser runtime argsort implementation
+#include "../../runtime/argsort.cu"
+
+namespace nvfuser {
+
+// Test kernels for different configurations
+template<typename DataT, int BLOCK_SIZE, int ITEMS_PER_THREAD>
+__global__ void basic_argsort_test_kernel(
+    DataT* input, 
+    nvfuser_index_t* output_indices,
+    bool descending) {
+    
+    DataT thread_data[ITEMS_PER_THREAD];
+    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+    
+    int thread_id = threadIdx.x;
+    int global_offset = thread_id * ITEMS_PER_THREAD;
+    
+    // Load data for this thread
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        thread_data[i] = input[global_offset + i];
+    }
+    
+    // Perform block-parallel argsort using the actual runtime implementation
+    DataT* dummy_shared_mem = nullptr;
+    nvfuser_runtime::blockArgsort<BLOCK_SIZE, 1, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
+        thread_data, 
+        thread_indices, 
+        descending,
+        dummy_shared_mem,
+        blockDim);
+    
+    // Store results back to global memory
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        output_indices[global_offset + i] = thread_indices[i];
+    }
+}
+
+// Multi-dimensional test kernels
+template<typename DataT, int ITEMS_PER_THREAD>
+__global__ void multi_dim_2d_argsort_test_kernel(
+    DataT* input, 
+    nvfuser_index_t* output_indices,
+    bool descending) {
+    
+    DataT thread_data[ITEMS_PER_THREAD];
+    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+    
+    int thread_id = threadIdx.x + threadIdx.y * blockDim.x;
+    int global_offset = thread_id * ITEMS_PER_THREAD;
+    
+    // Load data for this thread
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        thread_data[i] = input[global_offset + i];
+    }
+    
+    // Test 2D block: 4x2x1 (8 threads total) using actual runtime implementation
+    DataT* dummy_shared_mem = nullptr;
+    nvfuser_runtime::blockArgsort<4, 2, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
+        thread_data, 
+        thread_indices, 
+        descending,
+        dummy_shared_mem,
+        blockDim);
+    
+    // Store results back
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        output_indices[global_offset + i] = thread_indices[i];
+    }
+}
+
+template<typename DataT, int ITEMS_PER_THREAD>
+__global__ void multi_dim_3d_argsort_test_kernel(
+    DataT* input, 
+    nvfuser_index_t* output_indices,
+    bool descending) {
+    
+    DataT thread_data[ITEMS_PER_THREAD];
+    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+    
+    int thread_id = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
+    int global_offset = thread_id * ITEMS_PER_THREAD;
+    
+    // Load data for this thread
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        thread_data[i] = input[global_offset + i];
+    }
+    
+    // Test 3D block: 2x2x2 (8 threads total) using actual runtime implementation
+    DataT* dummy_shared_mem = nullptr;
+    nvfuser_runtime::blockArgsort<2, 2, 2, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
+        thread_data, 
+        thread_indices, 
+        descending,
+        dummy_shared_mem,
+        blockDim);
+    
+    // Store results back
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        output_indices[global_offset + i] = thread_indices[i];
+    }
+}
+
+// BFloat16 specific kernel
+template<int ITEMS_PER_THREAD>
+__global__ void bfloat16_argsort_test_kernel(
+    __nv_bfloat16* input, 
+    nvfuser_index_t* output_indices,
+    bool descending) {
+    
+    __nv_bfloat16 thread_data[ITEMS_PER_THREAD];
+    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+    
+    int thread_id = threadIdx.x;
+    int global_offset = thread_id * ITEMS_PER_THREAD;
+    
+    // Load data for this thread
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        thread_data[i] = input[global_offset + i];
+    }
+    
+    __nv_bfloat16* dummy_shared_mem = nullptr;
+    nvfuser_runtime::blockArgsort<4, 1, 1, 0, 0, 0, true, __nv_bfloat16, ITEMS_PER_THREAD>(
+        thread_data, 
+        thread_indices, 
+        descending,
+        dummy_shared_mem,
+        blockDim);
+    
+    // Store results back to global memory
+    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        output_indices[global_offset + i] = thread_indices[i];
+    }
+}
+
+__global__ void convert_float_to_bfloat16(float* input_float, __nv_bfloat16* output_bfloat, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        output_bfloat[idx] = __float2bfloat16(input_float[idx]);
+    }
+}
+
+// Template launcher functions
+template<typename DataT>
+void launch_basic_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending) {
+    
+    // Use a macro to reduce repetition for all combinations
+    #define LAUNCH_KERNEL(BS, IPT) \
+        if (block_size == BS && items_per_thread == IPT) { \
+            basic_argsort_test_kernel<DataT, BS, IPT><<<1, BS, 0, stream>>>(input, output_indices, descending); \
+            return; \
+        }
+
+    // Original configurations for other tests
+    LAUNCH_KERNEL(4, 2)
+    LAUNCH_KERNEL(16, 4)
+    
+    // Block size 32
+    LAUNCH_KERNEL(32, 1)
+    LAUNCH_KERNEL(32, 2)
+    LAUNCH_KERNEL(32, 3)
+    LAUNCH_KERNEL(32, 4)
+    LAUNCH_KERNEL(32, 5)
+    
+    // Block size 64
+    LAUNCH_KERNEL(64, 1)
+    LAUNCH_KERNEL(64, 2)
+    LAUNCH_KERNEL(64, 3)
+    LAUNCH_KERNEL(64, 4)
+    LAUNCH_KERNEL(64, 5)
+    LAUNCH_KERNEL(64, 8)  // Keep existing configuration
+    
+    // Block size 128
+    LAUNCH_KERNEL(128, 1)
+    LAUNCH_KERNEL(128, 2)
+    LAUNCH_KERNEL(128, 3)
+    LAUNCH_KERNEL(128, 4)
+    LAUNCH_KERNEL(128, 5)
+    LAUNCH_KERNEL(128, 8)  // Keep existing configuration
+    
+    // Block size 256
+    LAUNCH_KERNEL(256, 1)
+    LAUNCH_KERNEL(256, 2)
+    LAUNCH_KERNEL(256, 3)
+    LAUNCH_KERNEL(256, 4)
+    LAUNCH_KERNEL(256, 5)
+    LAUNCH_KERNEL(256, 8)  // Keep existing configuration
+    
+    // Block size 512 (keep existing)
+    LAUNCH_KERNEL(512, 8)
+    
+    #undef LAUNCH_KERNEL
+    
+    // If we get here, the combination is not supported
+    assert(false && "Unsupported block_size/items_per_thread combination");
+}
+
+template<typename DataT>
+void launch_multi_dim_2d_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending) {
+    
+    dim3 block_2d(4, 2, 1);
+    if (items_per_thread == 2) {
+        multi_dim_2d_argsort_test_kernel<DataT, 2><<<1, block_2d, 0, stream>>>(input, output_indices, descending);
+    } else {
+        assert(false && "Unsupported items_per_thread for 2D block");
+    }
+}
+
+template<typename DataT>
+void launch_multi_dim_3d_argsort_test_kernel(
+    cudaStream_t stream,
+    DataT* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending) {
+    
+    dim3 block_3d(2, 2, 2);
+    if (items_per_thread == 2) {
+        multi_dim_3d_argsort_test_kernel<DataT, 2><<<1, block_3d, 0, stream>>>(input, output_indices, descending);
+    } else {
+        assert(false && "Unsupported items_per_thread for 3D block");
+    }
+}
+
+void launch_bfloat16_argsort_test_kernel(
+    cudaStream_t stream,
+    __nv_bfloat16* input,
+    nvfuser_index_t* output_indices,
+    int items_per_thread,
+    bool descending) {
+    
+    if (items_per_thread == 2) {
+        bfloat16_argsort_test_kernel<2><<<1, 4, 0, stream>>>(input, output_indices, descending);
+    } else {
+        assert(false && "Unsupported items_per_thread for bfloat16");
+    }
+}
+
+void launch_convert_float_to_bfloat16(
+    cudaStream_t stream,
+    float* input_float,
+    __nv_bfloat16* output_bfloat,
+    int n) {
+    
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    convert_float_to_bfloat16<<<blocks, threads, 0, stream>>>(input_float, output_bfloat, n);
+}
+
+// Explicit template instantiations
+template void launch_basic_argsort_test_kernel<float>(
+    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
+    int block_size, int items_per_thread, bool descending);
+
+template void launch_basic_argsort_test_kernel<double>(
+    cudaStream_t stream, double* input, nvfuser_index_t* output_indices,
+    int block_size, int items_per_thread, bool descending);
+
+template void launch_basic_argsort_test_kernel<int>(
+    cudaStream_t stream, int* input, nvfuser_index_t* output_indices,
+    int block_size, int items_per_thread, bool descending);
+
+template void launch_basic_argsort_test_kernel<int64_t>(
+    cudaStream_t stream, int64_t* input, nvfuser_index_t* output_indices,
+    int block_size, int items_per_thread, bool descending);
+
+template void launch_multi_dim_2d_argsort_test_kernel<float>(
+    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
+    int items_per_thread, bool descending);
+
+template void launch_multi_dim_3d_argsort_test_kernel<float>(
+    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
+    int items_per_thread, bool descending);
+
+} // namespace nvfuser 

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -14,8 +14,8 @@ using nvfuser_index_t = int64_t;
 
 // nvFuser headers
 #include <tests/cpp/argsort_test_helper.h>
-#include <runtime/index_utils.cu>
 #include <runtime/argsort.cu>
+#include <runtime/index_utils.cu>
 
 // Standard C++ headers
 #include <cassert>
@@ -23,253 +23,239 @@ using nvfuser_index_t = int64_t;
 #include <type_traits>
 
 // CUDA headers
-#include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cuda_runtime.h>
 
 namespace nvfuser {
 
 // Test kernels for different configurations
-template<typename DataT, int BLOCK_SIZE, int ITEMS_PER_THREAD>
+template <typename DataT, int BLOCK_SIZE, int ITEMS_PER_THREAD>
 __global__ void basic_argsort_test_kernel(
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     bool descending) {
+  DataT thread_data[ITEMS_PER_THREAD];
+  int64_t thread_indices[ITEMS_PER_THREAD];
 
-    DataT thread_data[ITEMS_PER_THREAD];
-    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+  int thread_id = threadIdx.x;
+  int global_offset = thread_id * ITEMS_PER_THREAD;
 
-    int thread_id = threadIdx.x;
-    int global_offset = thread_id * ITEMS_PER_THREAD;
+  // Load data for this thread
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    thread_data[i] = input[global_offset + i];
+  }
 
-    // Load data for this thread
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        thread_data[i] = input[global_offset + i];
-    }
+  // Perform block-parallel argsort using the actual runtime implementation
+  DataT* dummy_shared_mem = nullptr;
+  nvfuser_runtime::
+      blockArgsort<BLOCK_SIZE, 1, 1, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
+          thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
 
-    // Perform block-parallel argsort using the actual runtime implementation
-    DataT* dummy_shared_mem = nullptr;
-    nvfuser_runtime::blockArgsort<BLOCK_SIZE, 1, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data,
-        thread_indices,
-        descending,
-        dummy_shared_mem,
-        blockDim);
-
-    // Store results back to global memory
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        output_indices[global_offset + i] = thread_indices[i];
-    }
+  // Store results back to global memory
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    output_indices[global_offset + i] = thread_indices[i];
+  }
 }
 
 // Multi-dimensional test kernels
-template<typename DataT, int ITEMS_PER_THREAD>
+template <typename DataT, int ITEMS_PER_THREAD>
 __global__ void multi_dim_2d_argsort_test_kernel(
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     bool descending) {
+  DataT thread_data[ITEMS_PER_THREAD];
+  int64_t thread_indices[ITEMS_PER_THREAD];
 
-    DataT thread_data[ITEMS_PER_THREAD];
-    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+  int thread_id = threadIdx.x + threadIdx.y * blockDim.x;
+  int global_offset = thread_id * ITEMS_PER_THREAD;
 
-    int thread_id = threadIdx.x + threadIdx.y * blockDim.x;
-    int global_offset = thread_id * ITEMS_PER_THREAD;
+  // Load data for this thread
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    thread_data[i] = input[global_offset + i];
+  }
 
-    // Load data for this thread
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        thread_data[i] = input[global_offset + i];
-    }
+  // Test 2D block: 4x2x1 (8 threads total) using actual runtime implementation
+  DataT* dummy_shared_mem = nullptr;
+  nvfuser_runtime::blockArgsort<4, 2, 1, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
+      thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
 
-    // Test 2D block: 4x2x1 (8 threads total) using actual runtime implementation
-    DataT* dummy_shared_mem = nullptr;
-    nvfuser_runtime::blockArgsort<4, 2, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data,
-        thread_indices,
-        descending,
-        dummy_shared_mem,
-        blockDim);
-
-    // Store results back
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        output_indices[global_offset + i] = thread_indices[i];
-    }
+  // Store results back
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    output_indices[global_offset + i] = thread_indices[i];
+  }
 }
 
-template<typename DataT, int ITEMS_PER_THREAD>
+template <typename DataT, int ITEMS_PER_THREAD>
 __global__ void multi_dim_3d_argsort_test_kernel(
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     bool descending) {
+  DataT thread_data[ITEMS_PER_THREAD];
+  int64_t thread_indices[ITEMS_PER_THREAD];
 
-    DataT thread_data[ITEMS_PER_THREAD];
-    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+  int thread_id = threadIdx.x + threadIdx.y * blockDim.x +
+      threadIdx.z * blockDim.x * blockDim.y;
+  int global_offset = thread_id * ITEMS_PER_THREAD;
 
-    int thread_id = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
-    int global_offset = thread_id * ITEMS_PER_THREAD;
+  // Load data for this thread
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    thread_data[i] = input[global_offset + i];
+  }
 
-    // Load data for this thread
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        thread_data[i] = input[global_offset + i];
-    }
+  // Test 3D block: 2x2x2 (8 threads total) using actual runtime implementation
+  DataT* dummy_shared_mem = nullptr;
+  nvfuser_runtime::blockArgsort<2, 2, 2, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
+      thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
 
-    // Test 3D block: 2x2x2 (8 threads total) using actual runtime implementation
-    DataT* dummy_shared_mem = nullptr;
-    nvfuser_runtime::blockArgsort<2, 2, 2, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data,
-        thread_indices,
-        descending,
-        dummy_shared_mem,
-        blockDim);
-
-    // Store results back
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        output_indices[global_offset + i] = thread_indices[i];
-    }
+  // Store results back
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    output_indices[global_offset + i] = thread_indices[i];
+  }
 }
 
 // BFloat16 specific kernel
-template<int ITEMS_PER_THREAD>
+template <int ITEMS_PER_THREAD>
 __global__ void bfloat16_argsort_test_kernel(
     __nv_bfloat16* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     bool descending) {
+  __nv_bfloat16 thread_data[ITEMS_PER_THREAD];
+  int64_t thread_indices[ITEMS_PER_THREAD];
 
-    __nv_bfloat16 thread_data[ITEMS_PER_THREAD];
-    nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
+  int thread_id = threadIdx.x;
+  int global_offset = thread_id * ITEMS_PER_THREAD;
 
-    int thread_id = threadIdx.x;
-    int global_offset = thread_id * ITEMS_PER_THREAD;
+  // Load data for this thread
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    thread_data[i] = input[global_offset + i];
+  }
 
-    // Load data for this thread
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        thread_data[i] = input[global_offset + i];
-    }
+  __nv_bfloat16* dummy_shared_mem = nullptr;
+  nvfuser_runtime::
+      blockArgsort<4, 1, 1, 0, 0, 0, __nv_bfloat16, ITEMS_PER_THREAD>(
+          thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
 
-    __nv_bfloat16* dummy_shared_mem = nullptr;
-    nvfuser_runtime::blockArgsort<4, 1, 1, 0, 0, 0, true, __nv_bfloat16, ITEMS_PER_THREAD>(
-        thread_data,
-        thread_indices,
-        descending,
-        dummy_shared_mem,
-        blockDim);
-
-    // Store results back to global memory
-    for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        output_indices[global_offset + i] = thread_indices[i];
-    }
+  // Store results back to global memory
+  for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+    output_indices[global_offset + i] = thread_indices[i];
+  }
 }
 
-__global__ void convert_float_to_bfloat16(float* input_float, __nv_bfloat16* output_bfloat, int n) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n) {
-        output_bfloat[idx] = __float2bfloat16(input_float[idx]);
-    }
+__global__ void convert_float_to_bfloat16(
+    float* input_float,
+    __nv_bfloat16* output_bfloat,
+    int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    output_bfloat[idx] = __float2bfloat16(input_float[idx]);
+  }
 }
 
 // Template launcher functions
-template<typename DataT>
+template <typename DataT>
 void launch_basic_argsort_test_kernel(
     cudaStream_t stream,
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     int block_size,
     int items_per_thread,
     bool descending) {
+// Use a macro to reduce repetition for all combinations
+#define LAUNCH_KERNEL(BS, IPT)                                     \
+  if (block_size == BS && items_per_thread == IPT) {               \
+    basic_argsort_test_kernel<DataT, BS, IPT>                      \
+        <<<1, BS, 0, stream>>>(input, output_indices, descending); \
+    return;                                                        \
+  }
 
-    // Use a macro to reduce repetition for all combinations
-    #define LAUNCH_KERNEL(BS, IPT) \
-        if (block_size == BS && items_per_thread == IPT) { \
-            basic_argsort_test_kernel<DataT, BS, IPT><<<1, BS, 0, stream>>>(input, output_indices, descending); \
-            return; \
-        }
+  // Original configurations for other tests
+  LAUNCH_KERNEL(4, 2)
+  LAUNCH_KERNEL(16, 4)
 
-    // Original configurations for other tests
-    LAUNCH_KERNEL(4, 2)
-    LAUNCH_KERNEL(16, 4)
+  // Block size 32
+  LAUNCH_KERNEL(32, 1)
+  LAUNCH_KERNEL(32, 2)
+  LAUNCH_KERNEL(32, 3)
+  LAUNCH_KERNEL(32, 4)
+  LAUNCH_KERNEL(32, 5)
 
-    // Block size 32
-    LAUNCH_KERNEL(32, 1)
-    LAUNCH_KERNEL(32, 2)
-    LAUNCH_KERNEL(32, 3)
-    LAUNCH_KERNEL(32, 4)
-    LAUNCH_KERNEL(32, 5)
+  // Block size 64
+  LAUNCH_KERNEL(64, 1)
+  LAUNCH_KERNEL(64, 2)
+  LAUNCH_KERNEL(64, 3)
+  LAUNCH_KERNEL(64, 4)
+  LAUNCH_KERNEL(64, 5)
+  LAUNCH_KERNEL(64, 8) // Keep existing configuration
 
-    // Block size 64
-    LAUNCH_KERNEL(64, 1)
-    LAUNCH_KERNEL(64, 2)
-    LAUNCH_KERNEL(64, 3)
-    LAUNCH_KERNEL(64, 4)
-    LAUNCH_KERNEL(64, 5)
-    LAUNCH_KERNEL(64, 8)  // Keep existing configuration
+  // Block size 128
+  LAUNCH_KERNEL(128, 1)
+  LAUNCH_KERNEL(128, 2)
+  LAUNCH_KERNEL(128, 3)
+  LAUNCH_KERNEL(128, 4)
+  LAUNCH_KERNEL(128, 5)
+  LAUNCH_KERNEL(128, 8) // Keep existing configuration
 
-    // Block size 128
-    LAUNCH_KERNEL(128, 1)
-    LAUNCH_KERNEL(128, 2)
-    LAUNCH_KERNEL(128, 3)
-    LAUNCH_KERNEL(128, 4)
-    LAUNCH_KERNEL(128, 5)
-    LAUNCH_KERNEL(128, 8)  // Keep existing configuration
+  // Block size 256
+  LAUNCH_KERNEL(256, 1)
+  LAUNCH_KERNEL(256, 2)
+  LAUNCH_KERNEL(256, 3)
+  LAUNCH_KERNEL(256, 4)
+  LAUNCH_KERNEL(256, 5)
+  LAUNCH_KERNEL(256, 8) // Keep existing configuration
 
-    // Block size 256
-    LAUNCH_KERNEL(256, 1)
-    LAUNCH_KERNEL(256, 2)
-    LAUNCH_KERNEL(256, 3)
-    LAUNCH_KERNEL(256, 4)
-    LAUNCH_KERNEL(256, 5)
-    LAUNCH_KERNEL(256, 8)  // Keep existing configuration
+  // Block size 512 (keep existing)
+  LAUNCH_KERNEL(512, 8)
 
-    // Block size 512 (keep existing)
-    LAUNCH_KERNEL(512, 8)
+#undef LAUNCH_KERNEL
 
-    #undef LAUNCH_KERNEL
-
-    // If we get here, the combination is not supported
-    assert(false && "Unsupported block_size/items_per_thread combination");
+  // If we get here, the combination is not supported
+  assert(false && "Unsupported block_size/items_per_thread combination");
 }
 
-template<typename DataT>
+template <typename DataT>
 void launch_multi_dim_2d_argsort_test_kernel(
     cudaStream_t stream,
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     int items_per_thread,
     bool descending) {
-
-    dim3 block_2d(4, 2, 1);
-    if (items_per_thread == 2) {
-        multi_dim_2d_argsort_test_kernel<DataT, 2><<<1, block_2d, 0, stream>>>(input, output_indices, descending);
-    } else {
-        assert(false && "Unsupported items_per_thread for 2D block");
-    }
+  dim3 block_2d(4, 2, 1);
+  if (items_per_thread == 2) {
+    multi_dim_2d_argsort_test_kernel<DataT, 2>
+        <<<1, block_2d, 0, stream>>>(input, output_indices, descending);
+  } else {
+    assert(false && "Unsupported items_per_thread for 2D block");
+  }
 }
 
-template<typename DataT>
+template <typename DataT>
 void launch_multi_dim_3d_argsort_test_kernel(
     cudaStream_t stream,
     DataT* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     int items_per_thread,
     bool descending) {
-
-    dim3 block_3d(2, 2, 2);
-    if (items_per_thread == 2) {
-        multi_dim_3d_argsort_test_kernel<DataT, 2><<<1, block_3d, 0, stream>>>(input, output_indices, descending);
-    } else {
-        assert(false && "Unsupported items_per_thread for 3D block");
-    }
+  dim3 block_3d(2, 2, 2);
+  if (items_per_thread == 2) {
+    multi_dim_3d_argsort_test_kernel<DataT, 2>
+        <<<1, block_3d, 0, stream>>>(input, output_indices, descending);
+  } else {
+    assert(false && "Unsupported items_per_thread for 3D block");
+  }
 }
 
 void launch_bfloat16_argsort_test_kernel(
     cudaStream_t stream,
     __nv_bfloat16* input,
-    nvfuser_index_t* output_indices,
+    int64_t* output_indices,
     int items_per_thread,
     bool descending) {
-
-    if (items_per_thread == 2) {
-        bfloat16_argsort_test_kernel<2><<<1, 4, 0, stream>>>(input, output_indices, descending);
-    } else {
-        assert(false && "Unsupported items_per_thread for bfloat16");
-    }
+  if (items_per_thread == 2) {
+    bfloat16_argsort_test_kernel<2>
+        <<<1, 4, 0, stream>>>(input, output_indices, descending);
+  } else {
+    assert(false && "Unsupported items_per_thread for bfloat16");
+  }
 }
 
 void launch_convert_float_to_bfloat16(
@@ -277,35 +263,57 @@ void launch_convert_float_to_bfloat16(
     float* input_float,
     __nv_bfloat16* output_bfloat,
     int n) {
-
-    int threads = 256;
-    int blocks = (n + threads - 1) / threads;
-    convert_float_to_bfloat16<<<blocks, threads, 0, stream>>>(input_float, output_bfloat, n);
+  int threads = 256;
+  int blocks = (n + threads - 1) / threads;
+  convert_float_to_bfloat16<<<blocks, threads, 0, stream>>>(
+      input_float, output_bfloat, n);
 }
 
 // Explicit template instantiations
 template void launch_basic_argsort_test_kernel<float>(
-    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
-    int block_size, int items_per_thread, bool descending);
+    cudaStream_t stream,
+    float* input,
+    int64_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending);
 
 template void launch_basic_argsort_test_kernel<double>(
-    cudaStream_t stream, double* input, nvfuser_index_t* output_indices,
-    int block_size, int items_per_thread, bool descending);
+    cudaStream_t stream,
+    double* input,
+    int64_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending);
 
 template void launch_basic_argsort_test_kernel<int>(
-    cudaStream_t stream, int* input, nvfuser_index_t* output_indices,
-    int block_size, int items_per_thread, bool descending);
+    cudaStream_t stream,
+    int* input,
+    int64_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending);
 
 template void launch_basic_argsort_test_kernel<int64_t>(
-    cudaStream_t stream, int64_t* input, nvfuser_index_t* output_indices,
-    int block_size, int items_per_thread, bool descending);
+    cudaStream_t stream,
+    int64_t* input,
+    int64_t* output_indices,
+    int block_size,
+    int items_per_thread,
+    bool descending);
 
 template void launch_multi_dim_2d_argsort_test_kernel<float>(
-    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
-    int items_per_thread, bool descending);
+    cudaStream_t stream,
+    float* input,
+    int64_t* output_indices,
+    int items_per_thread,
+    bool descending);
 
 template void launch_multi_dim_3d_argsort_test_kernel<float>(
-    cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
-    int items_per_thread, bool descending);
+    cudaStream_t stream,
+    float* input,
+    int64_t* output_indices,
+    int items_per_thread,
+    bool descending);
 
 } // namespace nvfuser

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -9,6 +9,9 @@
 // Warning: this file should not include any header from nvFuser or pytorch
 // (except raw headers). Compiling with nvcc requires avoiding complex headers.
 
+// Define nvfuser_index_t at global scope for runtime files
+using nvfuser_index_t = int64_t;
+
 // nvFuser headers
 #include <tests/cpp/argsort_test_helper.h>
 #include <runtime/argsort.cu>

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -14,9 +14,12 @@ using nvfuser_index_t = int64_t;
 
 // nvFuser headers
 #include <tests/cpp/argsort_test_helper.h>
-#include <runtime/argsort.cu>
+
+// index_utils.cu needs to be included before argsort because of the dependency
+// from argsort
 #include <runtime/index_utils.cu>
 
+#include <runtime/argsort.cu>
 // Standard C++ headers
 #include <cassert>
 #include <cstdint>
@@ -46,10 +49,9 @@ __global__ void basic_argsort_test_kernel(
   }
 
   // Perform block-parallel argsort using the actual runtime implementation
-  DataT* dummy_shared_mem = nullptr;
-  nvfuser_runtime::
+  nvfuser_runtime::argsort::
       blockArgsort<BLOCK_SIZE, 1, 1, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
-          thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
+          thread_indices, thread_data, descending, blockDim);
 
   // Store results back to global memory
   for (int i = 0; i < ITEMS_PER_THREAD; i++) {
@@ -75,9 +77,9 @@ __global__ void multi_dim_2d_argsort_test_kernel(
   }
 
   // Test 2D block: 4x2x1 (8 threads total) using actual runtime implementation
-  DataT* dummy_shared_mem = nullptr;
-  nvfuser_runtime::blockArgsort<4, 2, 1, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
-      thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
+  nvfuser_runtime::argsort::
+      blockArgsort<4, 2, 1, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
+          thread_indices, thread_data, descending, blockDim);
 
   // Store results back
   for (int i = 0; i < ITEMS_PER_THREAD; i++) {
@@ -103,9 +105,9 @@ __global__ void multi_dim_3d_argsort_test_kernel(
   }
 
   // Test 3D block: 2x2x2 (8 threads total) using actual runtime implementation
-  DataT* dummy_shared_mem = nullptr;
-  nvfuser_runtime::blockArgsort<2, 2, 2, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
-      thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
+  nvfuser_runtime::argsort::
+      blockArgsort<2, 2, 2, 0, 0, 0, DataT, ITEMS_PER_THREAD>(
+          thread_indices, thread_data, descending, blockDim);
 
   // Store results back
   for (int i = 0; i < ITEMS_PER_THREAD; i++) {
@@ -130,10 +132,9 @@ __global__ void bfloat16_argsort_test_kernel(
     thread_data[i] = input[global_offset + i];
   }
 
-  __nv_bfloat16* dummy_shared_mem = nullptr;
-  nvfuser_runtime::
+  nvfuser_runtime::argsort::
       blockArgsort<4, 1, 1, 0, 0, 0, __nv_bfloat16, ITEMS_PER_THREAD>(
-          thread_indices, thread_data, descending, dummy_shared_mem, blockDim);
+          thread_indices, thread_data, descending, blockDim);
 
   // Store results back to global memory
   for (int i = 0; i < ITEMS_PER_THREAD; i++) {

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -26,30 +26,30 @@ namespace nvfuser {
 // Test kernels for different configurations
 template<typename DataT, int BLOCK_SIZE, int ITEMS_PER_THREAD>
 __global__ void basic_argsort_test_kernel(
-    DataT* input, 
+    DataT* input,
     nvfuser_index_t* output_indices,
     bool descending) {
-    
+
     DataT thread_data[ITEMS_PER_THREAD];
     nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
-    
+
     int thread_id = threadIdx.x;
     int global_offset = thread_id * ITEMS_PER_THREAD;
-    
+
     // Load data for this thread
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         thread_data[i] = input[global_offset + i];
     }
-    
+
     // Perform block-parallel argsort using the actual runtime implementation
     DataT* dummy_shared_mem = nullptr;
     nvfuser_runtime::blockArgsort<BLOCK_SIZE, 1, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data, 
-        thread_indices, 
+        thread_data,
+        thread_indices,
         descending,
         dummy_shared_mem,
         blockDim);
-    
+
     // Store results back to global memory
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         output_indices[global_offset + i] = thread_indices[i];
@@ -59,30 +59,30 @@ __global__ void basic_argsort_test_kernel(
 // Multi-dimensional test kernels
 template<typename DataT, int ITEMS_PER_THREAD>
 __global__ void multi_dim_2d_argsort_test_kernel(
-    DataT* input, 
+    DataT* input,
     nvfuser_index_t* output_indices,
     bool descending) {
-    
+
     DataT thread_data[ITEMS_PER_THREAD];
     nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
-    
+
     int thread_id = threadIdx.x + threadIdx.y * blockDim.x;
     int global_offset = thread_id * ITEMS_PER_THREAD;
-    
+
     // Load data for this thread
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         thread_data[i] = input[global_offset + i];
     }
-    
+
     // Test 2D block: 4x2x1 (8 threads total) using actual runtime implementation
     DataT* dummy_shared_mem = nullptr;
     nvfuser_runtime::blockArgsort<4, 2, 1, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data, 
-        thread_indices, 
+        thread_data,
+        thread_indices,
         descending,
         dummy_shared_mem,
         blockDim);
-    
+
     // Store results back
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         output_indices[global_offset + i] = thread_indices[i];
@@ -91,30 +91,30 @@ __global__ void multi_dim_2d_argsort_test_kernel(
 
 template<typename DataT, int ITEMS_PER_THREAD>
 __global__ void multi_dim_3d_argsort_test_kernel(
-    DataT* input, 
+    DataT* input,
     nvfuser_index_t* output_indices,
     bool descending) {
-    
+
     DataT thread_data[ITEMS_PER_THREAD];
     nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
-    
+
     int thread_id = threadIdx.x + threadIdx.y * blockDim.x + threadIdx.z * blockDim.x * blockDim.y;
     int global_offset = thread_id * ITEMS_PER_THREAD;
-    
+
     // Load data for this thread
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         thread_data[i] = input[global_offset + i];
     }
-    
+
     // Test 3D block: 2x2x2 (8 threads total) using actual runtime implementation
     DataT* dummy_shared_mem = nullptr;
     nvfuser_runtime::blockArgsort<2, 2, 2, 0, 0, 0, true, DataT, ITEMS_PER_THREAD>(
-        thread_data, 
-        thread_indices, 
+        thread_data,
+        thread_indices,
         descending,
         dummy_shared_mem,
         blockDim);
-    
+
     // Store results back
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         output_indices[global_offset + i] = thread_indices[i];
@@ -124,29 +124,29 @@ __global__ void multi_dim_3d_argsort_test_kernel(
 // BFloat16 specific kernel
 template<int ITEMS_PER_THREAD>
 __global__ void bfloat16_argsort_test_kernel(
-    __nv_bfloat16* input, 
+    __nv_bfloat16* input,
     nvfuser_index_t* output_indices,
     bool descending) {
-    
+
     __nv_bfloat16 thread_data[ITEMS_PER_THREAD];
     nvfuser_index_t thread_indices[ITEMS_PER_THREAD];
-    
+
     int thread_id = threadIdx.x;
     int global_offset = thread_id * ITEMS_PER_THREAD;
-    
+
     // Load data for this thread
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         thread_data[i] = input[global_offset + i];
     }
-    
+
     __nv_bfloat16* dummy_shared_mem = nullptr;
     nvfuser_runtime::blockArgsort<4, 1, 1, 0, 0, 0, true, __nv_bfloat16, ITEMS_PER_THREAD>(
-        thread_data, 
-        thread_indices, 
+        thread_data,
+        thread_indices,
         descending,
         dummy_shared_mem,
         blockDim);
-    
+
     // Store results back to global memory
     for (int i = 0; i < ITEMS_PER_THREAD; i++) {
         output_indices[global_offset + i] = thread_indices[i];
@@ -169,7 +169,7 @@ void launch_basic_argsort_test_kernel(
     int block_size,
     int items_per_thread,
     bool descending) {
-    
+
     // Use a macro to reduce repetition for all combinations
     #define LAUNCH_KERNEL(BS, IPT) \
         if (block_size == BS && items_per_thread == IPT) { \
@@ -180,14 +180,14 @@ void launch_basic_argsort_test_kernel(
     // Original configurations for other tests
     LAUNCH_KERNEL(4, 2)
     LAUNCH_KERNEL(16, 4)
-    
+
     // Block size 32
     LAUNCH_KERNEL(32, 1)
     LAUNCH_KERNEL(32, 2)
     LAUNCH_KERNEL(32, 3)
     LAUNCH_KERNEL(32, 4)
     LAUNCH_KERNEL(32, 5)
-    
+
     // Block size 64
     LAUNCH_KERNEL(64, 1)
     LAUNCH_KERNEL(64, 2)
@@ -195,7 +195,7 @@ void launch_basic_argsort_test_kernel(
     LAUNCH_KERNEL(64, 4)
     LAUNCH_KERNEL(64, 5)
     LAUNCH_KERNEL(64, 8)  // Keep existing configuration
-    
+
     // Block size 128
     LAUNCH_KERNEL(128, 1)
     LAUNCH_KERNEL(128, 2)
@@ -203,7 +203,7 @@ void launch_basic_argsort_test_kernel(
     LAUNCH_KERNEL(128, 4)
     LAUNCH_KERNEL(128, 5)
     LAUNCH_KERNEL(128, 8)  // Keep existing configuration
-    
+
     // Block size 256
     LAUNCH_KERNEL(256, 1)
     LAUNCH_KERNEL(256, 2)
@@ -211,12 +211,12 @@ void launch_basic_argsort_test_kernel(
     LAUNCH_KERNEL(256, 4)
     LAUNCH_KERNEL(256, 5)
     LAUNCH_KERNEL(256, 8)  // Keep existing configuration
-    
+
     // Block size 512 (keep existing)
     LAUNCH_KERNEL(512, 8)
-    
+
     #undef LAUNCH_KERNEL
-    
+
     // If we get here, the combination is not supported
     assert(false && "Unsupported block_size/items_per_thread combination");
 }
@@ -228,7 +228,7 @@ void launch_multi_dim_2d_argsort_test_kernel(
     nvfuser_index_t* output_indices,
     int items_per_thread,
     bool descending) {
-    
+
     dim3 block_2d(4, 2, 1);
     if (items_per_thread == 2) {
         multi_dim_2d_argsort_test_kernel<DataT, 2><<<1, block_2d, 0, stream>>>(input, output_indices, descending);
@@ -244,7 +244,7 @@ void launch_multi_dim_3d_argsort_test_kernel(
     nvfuser_index_t* output_indices,
     int items_per_thread,
     bool descending) {
-    
+
     dim3 block_3d(2, 2, 2);
     if (items_per_thread == 2) {
         multi_dim_3d_argsort_test_kernel<DataT, 2><<<1, block_3d, 0, stream>>>(input, output_indices, descending);
@@ -259,7 +259,7 @@ void launch_bfloat16_argsort_test_kernel(
     nvfuser_index_t* output_indices,
     int items_per_thread,
     bool descending) {
-    
+
     if (items_per_thread == 2) {
         bfloat16_argsort_test_kernel<2><<<1, 4, 0, stream>>>(input, output_indices, descending);
     } else {
@@ -272,7 +272,7 @@ void launch_convert_float_to_bfloat16(
     float* input_float,
     __nv_bfloat16* output_bfloat,
     int n) {
-    
+
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
     convert_float_to_bfloat16<<<blocks, threads, 0, stream>>>(input_float, output_bfloat, n);
@@ -303,4 +303,4 @@ template void launch_multi_dim_3d_argsort_test_kernel<float>(
     cudaStream_t stream, float* input, nvfuser_index_t* output_indices,
     int items_per_thread, bool descending);
 
-} // namespace nvfuser 
+} // namespace nvfuser

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -14,6 +14,7 @@ using nvfuser_index_t = int64_t;
 
 // nvFuser headers
 #include <tests/cpp/argsort_test_helper.h>
+#include <runtime/index_utils.cu>
 #include <runtime/argsort.cu>
 
 // Standard C++ headers

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -9,17 +9,18 @@
 // Warning: this file should not include any header from nvFuser or pytorch
 // (except raw headers). Compiling with nvcc requires avoiding complex headers.
 
+// nvFuser headers
 #include <tests/cpp/argsort_test_helper.h>
+#include <runtime/argsort.cu>
 
+// Standard C++ headers
 #include <cassert>
 #include <cstdint>
 #include <type_traits>
 
+// CUDA headers
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
-
-// Include the actual nvFuser runtime argsort implementation
-#include <runtime/argsort.cu>
 
 namespace nvfuser {
 

--- a/tests/cpp/argsort_test_kernels.cu
+++ b/tests/cpp/argsort_test_kernels.cu
@@ -19,7 +19,7 @@
 #include <cuda_bf16.h>
 
 // Include the actual nvFuser runtime argsort implementation
-#include "../../runtime/argsort.cu"
+#include <runtime/argsort.cu>
 
 namespace nvfuser {
 

--- a/tests/cpp/test_argsort_device_func.cpp
+++ b/tests/cpp/test_argsort_device_func.cpp
@@ -26,19 +26,19 @@ using ArgSortComprehensiveTest = NVFuserFixtureParamTest<std::pair<int, int>>;
 
 // Helper function to validate sorting correctness
 template<typename DataT>
-bool validate_argsort_order(const std::vector<DataT>& input_data, 
+bool validate_argsort_order(const std::vector<DataT>& input_data,
                            const std::vector<nvfuser_index_t>& indices,
                            bool descending = false) {
-    
+
     int n = input_data.size();
-    
+
     // Check valid range
     for (int i = 0; i < n; i++) {
         if (indices[i] < 0 || indices[i] >= n) {
             return false;
         }
     }
-    
+
     // Check permutation
     std::vector<bool> used(n, false);
     for (int i = 0; i < n; i++) {
@@ -47,12 +47,12 @@ bool validate_argsort_order(const std::vector<DataT>& input_data,
         }
         used[indices[i]] = true;
     }
-    
+
     // Check sorting order
     for (int i = 1; i < n; i++) {
         DataT prev_val = input_data[indices[i-1]];
         DataT curr_val = input_data[indices[i]];
-        
+
         if (descending) {
             if (curr_val > prev_val) {
                 return false;
@@ -63,7 +63,7 @@ bool validate_argsort_order(const std::vector<DataT>& input_data,
             }
         }
     }
-    
+
     return true;
 }
 
@@ -72,36 +72,36 @@ TEST_F(ArgSortDeviceFuncTest, BasicArgsortFloat) {
     const int BLOCK_SIZE = 4;
     const int ITEMS_PER_THREAD = 2;
     const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
-    
+
     std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
-    
+
     auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
     auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-    
+
     // Test ascending
     launch_basic_argsort_test_kernel<float>(
         at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(), 
-        output_tensor.data_ptr<nvfuser_index_t>(), 
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
         BLOCK_SIZE, ITEMS_PER_THREAD, false);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-    
+
     EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    
+
     // Test descending
     launch_basic_argsort_test_kernel<float>(
         at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(), 
-        output_tensor.data_ptr<nvfuser_index_t>(), 
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
         BLOCK_SIZE, ITEMS_PER_THREAD, true);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     output_cpu = output_tensor.cpu();
-    output_indices.assign(output_cpu.data_ptr<nvfuser_index_t>(), 
+    output_indices.assign(output_cpu.data_ptr<nvfuser_index_t>(),
                          output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
     EXPECT_TRUE(validate_argsort_order(test_data, output_indices, true));
 }
@@ -111,67 +111,67 @@ TEST_F(ArgSortDeviceFuncTest, DataTypeSupport) {
     const int BLOCK_SIZE = 4;
     const int ITEMS_PER_THREAD = 2;
     const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
-    
+
     // Test double
     {
         std::vector<double> test_data = {5.5, 2.1, 8.3, 1.7, 7.2, 3.9, 6.4, 4.8};
-        
+
         auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
         auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        
+
         launch_basic_argsort_test_kernel<double>(
             at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<double>(), 
-            output_tensor.data_ptr<nvfuser_index_t>(), 
+            input_tensor.data_ptr<double>(),
+            output_tensor.data_ptr<nvfuser_index_t>(),
             BLOCK_SIZE, ITEMS_PER_THREAD, false);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-        
+
         auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-        
+
         EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
     }
-    
+
     // Test int
     {
         std::vector<int> test_data = {5, 2, 8, 1, 7, 3, 6, 4};
-        
+
         auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0));
         auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        
+
         launch_basic_argsort_test_kernel<int>(
             at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<int>(), 
-            output_tensor.data_ptr<nvfuser_index_t>(), 
+            input_tensor.data_ptr<int>(),
+            output_tensor.data_ptr<nvfuser_index_t>(),
             BLOCK_SIZE, ITEMS_PER_THREAD, false);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-        
+
         auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-        
+
         EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
     }
-    
+
     // Test int64_t
     {
         std::vector<int64_t> test_data = {5L, 2L, 8L, 1L, 7L, 3L, 6L, 4L};
-        
+
         auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
         auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        
+
         launch_basic_argsort_test_kernel<int64_t>(
             at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<int64_t>(), 
-            output_tensor.data_ptr<nvfuser_index_t>(), 
+            input_tensor.data_ptr<int64_t>(),
+            output_tensor.data_ptr<nvfuser_index_t>(),
             BLOCK_SIZE, ITEMS_PER_THREAD, false);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-        
+
         auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-        
+
         EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
     }
 }
@@ -179,50 +179,50 @@ TEST_F(ArgSortDeviceFuncTest, DataTypeSupport) {
 // Multi-dimensional block tests
 TEST_F(ArgSortDeviceFuncTest, MultiDimensionalBlocks) {
     const int ITEMS_PER_THREAD = 2;
-    
+
     // Test 2D block: 4x2x1 (8 threads total)
     {
         const int total_elements = 8 * ITEMS_PER_THREAD;
         std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
                                        9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
-        
+
         auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
         auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        
+
         launch_multi_dim_2d_argsort_test_kernel<float>(
             at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<float>(), 
-            output_tensor.data_ptr<nvfuser_index_t>(), 
+            input_tensor.data_ptr<float>(),
+            output_tensor.data_ptr<nvfuser_index_t>(),
             ITEMS_PER_THREAD, false);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-        
+
         auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-        
+
         EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
     }
-    
+
     // Test 3D block: 2x2x2 (8 threads total)
     {
         const int total_elements = 8 * ITEMS_PER_THREAD;
         std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
                                        9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
-        
+
         auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
         auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        
+
         launch_multi_dim_3d_argsort_test_kernel<float>(
             at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<float>(), 
-            output_tensor.data_ptr<nvfuser_index_t>(), 
+            input_tensor.data_ptr<float>(),
+            output_tensor.data_ptr<nvfuser_index_t>(),
             ITEMS_PER_THREAD, false);
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-        
+
         auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-        
+
         EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
     }
 }
@@ -231,36 +231,36 @@ TEST_F(ArgSortDeviceFuncTest, MultiDimensionalBlocks) {
 TEST_F(ArgSortDeviceFuncTest, BFloat16Support) {
     const int ITEMS_PER_THREAD = 2;
     const int total_elements = 4 * ITEMS_PER_THREAD;
-    
+
     // Test data as floats (will convert to bfloat16)
     std::vector<float> test_data_float = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
-    
-    // Create tensors and convert float to bfloat16  
+
+    // Create tensors and convert float to bfloat16
     auto temp_float_tensor = at::tensor(test_data_float, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
     auto input_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0));
     auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-    
+
     // Launch conversion kernel
     launch_convert_float_to_bfloat16(
         at::cuda::getCurrentCUDAStream(),
-        temp_float_tensor.data_ptr<float>(), 
-        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()), 
+        temp_float_tensor.data_ptr<float>(),
+        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
         total_elements);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     // Launch argsort kernel
     launch_bfloat16_argsort_test_kernel(
         at::cuda::getCurrentCUDAStream(),
-        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()), 
-        output_tensor.data_ptr<nvfuser_index_t>(), 
+        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
+        output_tensor.data_ptr<nvfuser_index_t>(),
         ITEMS_PER_THREAD, false);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     // Copy results back
     auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-    
+
     // Validate against original float data (since bfloat16 conversion should preserve order)
     EXPECT_TRUE(validate_argsort_order(test_data_float, output_indices, false));
 }
@@ -269,42 +269,42 @@ TEST_F(ArgSortDeviceFuncTest, BFloat16Support) {
 TEST_P(ArgSortComprehensiveTest, ComprehensiveValidation) {
     auto [BLOCK_SIZE, ITEMS_PER_THREAD] = GetParam();
     const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
-    
+
     // Generate random test data using at::randn
     auto input_tensor = at::randn({total_elements}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
     auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-    
+
     // Copy input data to CPU for validation
     auto input_cpu = input_tensor.cpu();
-    std::vector<float> test_data(input_cpu.data_ptr<float>(), 
+    std::vector<float> test_data(input_cpu.data_ptr<float>(),
                                 input_cpu.data_ptr<float>() + total_elements);
-    
+
     // Test ascending
     launch_basic_argsort_test_kernel<float>(
         at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(), 
-        output_tensor.data_ptr<nvfuser_index_t>(), 
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
         BLOCK_SIZE, ITEMS_PER_THREAD, false);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> ascending_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+    std::vector<nvfuser_index_t> ascending_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-    
+
     EXPECT_TRUE(validate_argsort_order(test_data, ascending_indices, false));
-    
+
     // Test descending
     launch_basic_argsort_test_kernel<float>(
         at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(), 
-        output_tensor.data_ptr<nvfuser_index_t>(), 
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
         BLOCK_SIZE, ITEMS_PER_THREAD, true);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
-    
+
     output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> descending_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+    std::vector<nvfuser_index_t> descending_indices(output_cpu.data_ptr<nvfuser_index_t>(),
                                                    output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-    
+
     EXPECT_TRUE(validate_argsort_order(test_data, descending_indices, true));
 }
 
@@ -315,7 +315,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(
         // Block size 32
         std::make_pair(32, 1), std::make_pair(32, 2), std::make_pair(32, 3), std::make_pair(32, 4), std::make_pair(32, 5),
-        // Block size 64  
+        // Block size 64
         std::make_pair(64, 1), std::make_pair(64, 2), std::make_pair(64, 3), std::make_pair(64, 4), std::make_pair(64, 5),
         // Block size 128
         std::make_pair(128, 1), std::make_pair(128, 2), std::make_pair(128, 3), std::make_pair(128, 4), std::make_pair(128, 5),
@@ -326,4 +326,4 @@ INSTANTIATE_TEST_SUITE_P(
         return "BlockSize" + std::to_string(info.param.first) + "_ItemsPerThread" + std::to_string(info.param.second);
     });
 
-} // namespace nvfuser 
+} // namespace nvfuser

--- a/tests/cpp/test_argsort_device_func.cpp
+++ b/tests/cpp/test_argsort_device_func.cpp
@@ -1,0 +1,329 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gtest/gtest.h>
+
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+#include <tests/cpp/argsort_test_helper.h>
+
+#include <vector>
+#include <algorithm>
+#include <random>
+#include <ATen/cuda/CUDAContext.h>
+
+namespace nvfuser {
+
+using ArgSortDeviceFuncTest = NVFuserTest;
+
+// Parameterized test fixture for comprehensive validation
+using ArgSortComprehensiveTest = NVFuserFixtureParamTest<std::pair<int, int>>;
+
+// Helper function to validate sorting correctness
+template<typename DataT>
+bool validate_argsort_order(const std::vector<DataT>& input_data, 
+                           const std::vector<nvfuser_index_t>& indices,
+                           bool descending = false) {
+    
+    int n = input_data.size();
+    
+    // Check valid range
+    for (int i = 0; i < n; i++) {
+        if (indices[i] < 0 || indices[i] >= n) {
+            return false;
+        }
+    }
+    
+    // Check permutation
+    std::vector<bool> used(n, false);
+    for (int i = 0; i < n; i++) {
+        if (used[indices[i]]) {
+            return false;
+        }
+        used[indices[i]] = true;
+    }
+    
+    // Check sorting order
+    for (int i = 1; i < n; i++) {
+        DataT prev_val = input_data[indices[i-1]];
+        DataT curr_val = input_data[indices[i]];
+        
+        if (descending) {
+            if (curr_val > prev_val) {
+                return false;
+            }
+        } else {
+            if (curr_val < prev_val) {
+                return false;
+            }
+        }
+    }
+    
+    return true;
+}
+
+// Basic functionality test
+TEST_F(ArgSortDeviceFuncTest, BasicArgsortFloat) {
+    const int BLOCK_SIZE = 4;
+    const int ITEMS_PER_THREAD = 2;
+    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+    
+    std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
+    
+    auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    
+    // Test ascending
+    launch_basic_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(), 
+        output_tensor.data_ptr<nvfuser_index_t>(), 
+        BLOCK_SIZE, ITEMS_PER_THREAD, false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                               output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    
+    // Test descending
+    launch_basic_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(), 
+        output_tensor.data_ptr<nvfuser_index_t>(), 
+        BLOCK_SIZE, ITEMS_PER_THREAD, true);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    output_cpu = output_tensor.cpu();
+    output_indices.assign(output_cpu.data_ptr<nvfuser_index_t>(), 
+                         output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, true));
+}
+
+// Data type support test
+TEST_F(ArgSortDeviceFuncTest, DataTypeSupport) {
+    const int BLOCK_SIZE = 4;
+    const int ITEMS_PER_THREAD = 2;
+    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+    
+    // Test double
+    {
+        std::vector<double> test_data = {5.5, 2.1, 8.3, 1.7, 7.2, 3.9, 6.4, 4.8};
+        
+        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        
+        launch_basic_argsort_test_kernel<double>(
+            at::cuda::getCurrentCUDAStream(),
+            input_tensor.data_ptr<double>(), 
+            output_tensor.data_ptr<nvfuser_index_t>(), 
+            BLOCK_SIZE, ITEMS_PER_THREAD, false);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        
+        auto output_cpu = output_tensor.cpu();
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+        
+        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    }
+    
+    // Test int
+    {
+        std::vector<int> test_data = {5, 2, 8, 1, 7, 3, 6, 4};
+        
+        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0));
+        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        
+        launch_basic_argsort_test_kernel<int>(
+            at::cuda::getCurrentCUDAStream(),
+            input_tensor.data_ptr<int>(), 
+            output_tensor.data_ptr<nvfuser_index_t>(), 
+            BLOCK_SIZE, ITEMS_PER_THREAD, false);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        
+        auto output_cpu = output_tensor.cpu();
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+        
+        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    }
+    
+    // Test int64_t
+    {
+        std::vector<int64_t> test_data = {5L, 2L, 8L, 1L, 7L, 3L, 6L, 4L};
+        
+        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        
+        launch_basic_argsort_test_kernel<int64_t>(
+            at::cuda::getCurrentCUDAStream(),
+            input_tensor.data_ptr<int64_t>(), 
+            output_tensor.data_ptr<nvfuser_index_t>(), 
+            BLOCK_SIZE, ITEMS_PER_THREAD, false);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        
+        auto output_cpu = output_tensor.cpu();
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+        
+        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    }
+}
+
+// Multi-dimensional block tests
+TEST_F(ArgSortDeviceFuncTest, MultiDimensionalBlocks) {
+    const int ITEMS_PER_THREAD = 2;
+    
+    // Test 2D block: 4x2x1 (8 threads total)
+    {
+        const int total_elements = 8 * ITEMS_PER_THREAD;
+        std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
+                                       9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
+        
+        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        
+        launch_multi_dim_2d_argsort_test_kernel<float>(
+            at::cuda::getCurrentCUDAStream(),
+            input_tensor.data_ptr<float>(), 
+            output_tensor.data_ptr<nvfuser_index_t>(), 
+            ITEMS_PER_THREAD, false);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        
+        auto output_cpu = output_tensor.cpu();
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+        
+        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    }
+    
+    // Test 3D block: 2x2x2 (8 threads total)
+    {
+        const int total_elements = 8 * ITEMS_PER_THREAD;
+        std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
+                                       9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
+        
+        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+        
+        launch_multi_dim_3d_argsort_test_kernel<float>(
+            at::cuda::getCurrentCUDAStream(),
+            input_tensor.data_ptr<float>(), 
+            output_tensor.data_ptr<nvfuser_index_t>(), 
+            ITEMS_PER_THREAD, false);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        
+        auto output_cpu = output_tensor.cpu();
+        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+        
+        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+    }
+}
+
+// BFloat16 support test
+TEST_F(ArgSortDeviceFuncTest, BFloat16Support) {
+    const int ITEMS_PER_THREAD = 2;
+    const int total_elements = 4 * ITEMS_PER_THREAD;
+    
+    // Test data as floats (will convert to bfloat16)
+    std::vector<float> test_data_float = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
+    
+    // Create tensors and convert float to bfloat16  
+    auto temp_float_tensor = at::tensor(test_data_float, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+    auto input_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0));
+    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    
+    // Launch conversion kernel
+    launch_convert_float_to_bfloat16(
+        at::cuda::getCurrentCUDAStream(),
+        temp_float_tensor.data_ptr<float>(), 
+        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()), 
+        total_elements);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    // Launch argsort kernel
+    launch_bfloat16_argsort_test_kernel(
+        at::cuda::getCurrentCUDAStream(),
+        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()), 
+        output_tensor.data_ptr<nvfuser_index_t>(), 
+        ITEMS_PER_THREAD, false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    // Copy results back
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                               output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    
+    // Validate against original float data (since bfloat16 conversion should preserve order)
+    EXPECT_TRUE(validate_argsort_order(test_data_float, output_indices, false));
+}
+
+// Parameterized comprehensive validation test
+TEST_P(ArgSortComprehensiveTest, ComprehensiveValidation) {
+    auto [BLOCK_SIZE, ITEMS_PER_THREAD] = GetParam();
+    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+    
+    // Generate random test data using at::randn
+    auto input_tensor = at::randn({total_elements}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    
+    // Copy input data to CPU for validation
+    auto input_cpu = input_tensor.cpu();
+    std::vector<float> test_data(input_cpu.data_ptr<float>(), 
+                                input_cpu.data_ptr<float>() + total_elements);
+    
+    // Test ascending
+    launch_basic_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(), 
+        output_tensor.data_ptr<nvfuser_index_t>(), 
+        BLOCK_SIZE, ITEMS_PER_THREAD, false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> ascending_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                  output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    
+    EXPECT_TRUE(validate_argsort_order(test_data, ascending_indices, false));
+    
+    // Test descending
+    launch_basic_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(), 
+        output_tensor.data_ptr<nvfuser_index_t>(), 
+        BLOCK_SIZE, ITEMS_PER_THREAD, true);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    
+    output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> descending_indices(output_cpu.data_ptr<nvfuser_index_t>(), 
+                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    
+    EXPECT_TRUE(validate_argsort_order(test_data, descending_indices, true));
+}
+
+// Instantiate parameterized tests
+INSTANTIATE_TEST_SUITE_P(
+    BlockSizeAndItemsPerThread,
+    ArgSortComprehensiveTest,
+    testing::Values(
+        // Block size 32
+        std::make_pair(32, 1), std::make_pair(32, 2), std::make_pair(32, 3), std::make_pair(32, 4), std::make_pair(32, 5),
+        // Block size 64  
+        std::make_pair(64, 1), std::make_pair(64, 2), std::make_pair(64, 3), std::make_pair(64, 4), std::make_pair(64, 5),
+        // Block size 128
+        std::make_pair(128, 1), std::make_pair(128, 2), std::make_pair(128, 3), std::make_pair(128, 4), std::make_pair(128, 5),
+        // Block size 256
+        std::make_pair(256, 1), std::make_pair(256, 2), std::make_pair(256, 3), std::make_pair(256, 4), std::make_pair(256, 5)
+    ),
+    [](const testing::TestParamInfo<std::pair<int, int>>& info) {
+        return "BlockSize" + std::to_string(info.param.first) + "_ItemsPerThread" + std::to_string(info.param.second);
+    });
+
+} // namespace nvfuser 

--- a/tests/cpp/test_argsort_device_func.cpp
+++ b/tests/cpp/test_argsort_device_func.cpp
@@ -8,14 +8,14 @@
 
 #include <gtest/gtest.h>
 
+#include <tests/cpp/argsort_test_helper.h>
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
-#include <tests/cpp/argsort_test_helper.h>
 
-#include <vector>
+#include <ATen/cuda/CUDAContext.h>
 #include <algorithm>
 #include <random>
-#include <ATen/cuda/CUDAContext.h>
+#include <vector>
 
 namespace nvfuser {
 
@@ -25,287 +25,376 @@ using ArgSortDeviceFuncTest = NVFuserTest;
 using ArgSortComprehensiveTest = NVFuserFixtureParamTest<std::pair<int, int>>;
 
 // Helper function to validate sorting correctness
-template<typename DataT>
-bool validate_argsort_order(const std::vector<DataT>& input_data,
-                           const std::vector<nvfuser_index_t>& indices,
-                           bool descending = false) {
+template <typename DataT>
+bool validate_argsort_order(
+    const std::vector<DataT>& input_data,
+    const std::vector<nvfuser_index_t>& indices,
+    bool descending = false) {
+  int n = input_data.size();
 
-    int n = input_data.size();
-
-    // Check valid range
-    for (int i = 0; i < n; i++) {
-        if (indices[i] < 0 || indices[i] >= n) {
-            return false;
-        }
+  // Check valid range
+  for (int i = 0; i < n; i++) {
+    if (indices[i] < 0 || indices[i] >= n) {
+      return false;
     }
+  }
 
-    // Check permutation
-    std::vector<bool> used(n, false);
-    for (int i = 0; i < n; i++) {
-        if (used[indices[i]]) {
-            return false;
-        }
-        used[indices[i]] = true;
+  // Check permutation
+  std::vector<bool> used(n, false);
+  for (int i = 0; i < n; i++) {
+    if (used[indices[i]]) {
+      return false;
     }
+    used[indices[i]] = true;
+  }
 
-    // Check sorting order
-    for (int i = 1; i < n; i++) {
-        DataT prev_val = input_data[indices[i-1]];
-        DataT curr_val = input_data[indices[i]];
+  // Check sorting order
+  for (int i = 1; i < n; i++) {
+    DataT prev_val = input_data[indices[i - 1]];
+    DataT curr_val = input_data[indices[i]];
 
-        if (descending) {
-            if (curr_val > prev_val) {
-                return false;
-            }
-        } else {
-            if (curr_val < prev_val) {
-                return false;
-            }
-        }
+    if (descending) {
+      if (curr_val > prev_val) {
+        return false;
+      }
+    } else {
+      if (curr_val < prev_val) {
+        return false;
+      }
     }
+  }
 
-    return true;
+  return true;
 }
 
 // Basic functionality test
 TEST_F(ArgSortDeviceFuncTest, BasicArgsortFloat) {
-    const int BLOCK_SIZE = 4;
-    const int ITEMS_PER_THREAD = 2;
-    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+  const int BLOCK_SIZE = 4;
+  const int ITEMS_PER_THREAD = 2;
+  const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
 
-    std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
+  std::vector<float> test_data = {
+      5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
 
-    auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+  auto input_tensor = at::tensor(
+      test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-    // Test ascending
-    launch_basic_argsort_test_kernel<float>(
-        at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(),
-        output_tensor.data_ptr<nvfuser_index_t>(),
-        BLOCK_SIZE, ITEMS_PER_THREAD, false);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Test ascending
+  launch_basic_argsort_test_kernel<float>(
+      at::cuda::getCurrentCUDAStream(),
+      input_tensor.data_ptr<float>(),
+      output_tensor.data_ptr<nvfuser_index_t>(),
+      BLOCK_SIZE,
+      ITEMS_PER_THREAD,
+      false);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                               output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+  auto output_cpu = output_tensor.cpu();
+  std::vector<nvfuser_index_t> output_indices(
+      output_cpu.data_ptr<nvfuser_index_t>(),
+      output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
 
-    // Test descending
-    launch_basic_argsort_test_kernel<float>(
-        at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(),
-        output_tensor.data_ptr<nvfuser_index_t>(),
-        BLOCK_SIZE, ITEMS_PER_THREAD, true);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Test descending
+  launch_basic_argsort_test_kernel<float>(
+      at::cuda::getCurrentCUDAStream(),
+      input_tensor.data_ptr<float>(),
+      output_tensor.data_ptr<nvfuser_index_t>(),
+      BLOCK_SIZE,
+      ITEMS_PER_THREAD,
+      true);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    output_cpu = output_tensor.cpu();
-    output_indices.assign(output_cpu.data_ptr<nvfuser_index_t>(),
-                         output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
-    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, true));
+  output_cpu = output_tensor.cpu();
+  output_indices.assign(
+      output_cpu.data_ptr<nvfuser_index_t>(),
+      output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+  EXPECT_TRUE(validate_argsort_order(test_data, output_indices, true));
 }
 
 // Data type support test
 TEST_F(ArgSortDeviceFuncTest, DataTypeSupport) {
-    const int BLOCK_SIZE = 4;
-    const int ITEMS_PER_THREAD = 2;
-    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+  const int BLOCK_SIZE = 4;
+  const int ITEMS_PER_THREAD = 2;
+  const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
 
-    // Test double
-    {
-        std::vector<double> test_data = {5.5, 2.1, 8.3, 1.7, 7.2, 3.9, 6.4, 4.8};
+  // Test double
+  {
+    std::vector<double> test_data = {5.5, 2.1, 8.3, 1.7, 7.2, 3.9, 6.4, 4.8};
 
-        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
-        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto input_tensor = at::tensor(
+        test_data, at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+    auto output_tensor = at::empty(
+        {total_elements},
+        at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-        launch_basic_argsort_test_kernel<double>(
-            at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<double>(),
-            output_tensor.data_ptr<nvfuser_index_t>(),
-            BLOCK_SIZE, ITEMS_PER_THREAD, false);
-        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    launch_basic_argsort_test_kernel<double>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<double>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
+        BLOCK_SIZE,
+        ITEMS_PER_THREAD,
+        false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-        auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(
+        output_cpu.data_ptr<nvfuser_index_t>(),
+        output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    }
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  }
 
-    // Test int
-    {
-        std::vector<int> test_data = {5, 2, 8, 1, 7, 3, 6, 4};
+  // Test int
+  {
+    std::vector<int> test_data = {5, 2, 8, 1, 7, 3, 6, 4};
 
-        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0));
-        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto input_tensor = at::tensor(
+        test_data, at::TensorOptions().dtype(at::kInt).device(at::kCUDA, 0));
+    auto output_tensor = at::empty(
+        {total_elements},
+        at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-        launch_basic_argsort_test_kernel<int>(
-            at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<int>(),
-            output_tensor.data_ptr<nvfuser_index_t>(),
-            BLOCK_SIZE, ITEMS_PER_THREAD, false);
-        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    launch_basic_argsort_test_kernel<int>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<int>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
+        BLOCK_SIZE,
+        ITEMS_PER_THREAD,
+        false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-        auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(
+        output_cpu.data_ptr<nvfuser_index_t>(),
+        output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    }
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  }
 
-    // Test int64_t
-    {
-        std::vector<int64_t> test_data = {5L, 2L, 8L, 1L, 7L, 3L, 6L, 4L};
+  // Test int64_t
+  {
+    std::vector<int64_t> test_data = {5L, 2L, 8L, 1L, 7L, 3L, 6L, 4L};
 
-        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
-        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto input_tensor = at::tensor(
+        test_data, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto output_tensor = at::empty(
+        {total_elements},
+        at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-        launch_basic_argsort_test_kernel<int64_t>(
-            at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<int64_t>(),
-            output_tensor.data_ptr<nvfuser_index_t>(),
-            BLOCK_SIZE, ITEMS_PER_THREAD, false);
-        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    launch_basic_argsort_test_kernel<int64_t>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<int64_t>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
+        BLOCK_SIZE,
+        ITEMS_PER_THREAD,
+        false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-        auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(
+        output_cpu.data_ptr<nvfuser_index_t>(),
+        output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    }
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  }
 }
 
 // Multi-dimensional block tests
 TEST_F(ArgSortDeviceFuncTest, MultiDimensionalBlocks) {
-    const int ITEMS_PER_THREAD = 2;
+  const int ITEMS_PER_THREAD = 2;
 
-    // Test 2D block: 4x2x1 (8 threads total)
-    {
-        const int total_elements = 8 * ITEMS_PER_THREAD;
-        std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
-                                       9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
+  // Test 2D block: 4x2x1 (8 threads total)
+  {
+    const int total_elements = 8 * ITEMS_PER_THREAD;
+    std::vector<float> test_data = {
+        5.0f,
+        2.0f,
+        8.0f,
+        1.0f,
+        7.0f,
+        3.0f,
+        6.0f,
+        4.0f,
+        9.0f,
+        0.5f,
+        3.5f,
+        7.5f,
+        2.5f,
+        8.5f,
+        1.5f,
+        6.5f};
 
-        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto input_tensor = at::tensor(
+        test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+    auto output_tensor = at::empty(
+        {total_elements},
+        at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-        launch_multi_dim_2d_argsort_test_kernel<float>(
-            at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<float>(),
-            output_tensor.data_ptr<nvfuser_index_t>(),
-            ITEMS_PER_THREAD, false);
-        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    launch_multi_dim_2d_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
+        ITEMS_PER_THREAD,
+        false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-        auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(
+        output_cpu.data_ptr<nvfuser_index_t>(),
+        output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    }
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  }
 
-    // Test 3D block: 2x2x2 (8 threads total)
-    {
-        const int total_elements = 8 * ITEMS_PER_THREAD;
-        std::vector<float> test_data = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f,
-                                       9.0f, 0.5f, 3.5f, 7.5f, 2.5f, 8.5f, 1.5f, 6.5f};
+  // Test 3D block: 2x2x2 (8 threads total)
+  {
+    const int total_elements = 8 * ITEMS_PER_THREAD;
+    std::vector<float> test_data = {
+        5.0f,
+        2.0f,
+        8.0f,
+        1.0f,
+        7.0f,
+        3.0f,
+        6.0f,
+        4.0f,
+        9.0f,
+        0.5f,
+        3.5f,
+        7.5f,
+        2.5f,
+        8.5f,
+        1.5f,
+        6.5f};
 
-        auto input_tensor = at::tensor(test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-        auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+    auto input_tensor = at::tensor(
+        test_data, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+    auto output_tensor = at::empty(
+        {total_elements},
+        at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-        launch_multi_dim_3d_argsort_test_kernel<float>(
-            at::cuda::getCurrentCUDAStream(),
-            input_tensor.data_ptr<float>(),
-            output_tensor.data_ptr<nvfuser_index_t>(),
-            ITEMS_PER_THREAD, false);
-        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    launch_multi_dim_3d_argsort_test_kernel<float>(
+        at::cuda::getCurrentCUDAStream(),
+        input_tensor.data_ptr<float>(),
+        output_tensor.data_ptr<nvfuser_index_t>(),
+        ITEMS_PER_THREAD,
+        false);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-        auto output_cpu = output_tensor.cpu();
-        std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+    auto output_cpu = output_tensor.cpu();
+    std::vector<nvfuser_index_t> output_indices(
+        output_cpu.data_ptr<nvfuser_index_t>(),
+        output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-        EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
-    }
+    EXPECT_TRUE(validate_argsort_order(test_data, output_indices, false));
+  }
 }
 
 // BFloat16 support test
 TEST_F(ArgSortDeviceFuncTest, BFloat16Support) {
-    const int ITEMS_PER_THREAD = 2;
-    const int total_elements = 4 * ITEMS_PER_THREAD;
+  const int ITEMS_PER_THREAD = 2;
+  const int total_elements = 4 * ITEMS_PER_THREAD;
 
-    // Test data as floats (will convert to bfloat16)
-    std::vector<float> test_data_float = {5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
+  // Test data as floats (will convert to bfloat16)
+  std::vector<float> test_data_float = {
+      5.0f, 2.0f, 8.0f, 1.0f, 7.0f, 3.0f, 6.0f, 4.0f};
 
-    // Create tensors and convert float to bfloat16
-    auto temp_float_tensor = at::tensor(test_data_float, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-    auto input_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0));
-    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+  // Create tensors and convert float to bfloat16
+  auto temp_float_tensor = at::tensor(
+      test_data_float,
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  auto input_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0));
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-    // Launch conversion kernel
-    launch_convert_float_to_bfloat16(
-        at::cuda::getCurrentCUDAStream(),
-        temp_float_tensor.data_ptr<float>(),
-        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
-        total_elements);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Launch conversion kernel
+  launch_convert_float_to_bfloat16(
+      at::cuda::getCurrentCUDAStream(),
+      temp_float_tensor.data_ptr<float>(),
+      reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
+      total_elements);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    // Launch argsort kernel
-    launch_bfloat16_argsort_test_kernel(
-        at::cuda::getCurrentCUDAStream(),
-        reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
-        output_tensor.data_ptr<nvfuser_index_t>(),
-        ITEMS_PER_THREAD, false);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Launch argsort kernel
+  launch_bfloat16_argsort_test_kernel(
+      at::cuda::getCurrentCUDAStream(),
+      reinterpret_cast<__nv_bfloat16*>(input_tensor.data_ptr()),
+      output_tensor.data_ptr<nvfuser_index_t>(),
+      ITEMS_PER_THREAD,
+      false);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    // Copy results back
-    auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> output_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                               output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+  // Copy results back
+  auto output_cpu = output_tensor.cpu();
+  std::vector<nvfuser_index_t> output_indices(
+      output_cpu.data_ptr<nvfuser_index_t>(),
+      output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-    // Validate against original float data (since bfloat16 conversion should preserve order)
-    EXPECT_TRUE(validate_argsort_order(test_data_float, output_indices, false));
+  // Validate against original float data (since bfloat16 conversion should
+  // preserve order)
+  EXPECT_TRUE(validate_argsort_order(test_data_float, output_indices, false));
 }
 
 // Parameterized comprehensive validation test
 TEST_P(ArgSortComprehensiveTest, ComprehensiveValidation) {
-    auto [BLOCK_SIZE, ITEMS_PER_THREAD] = GetParam();
-    const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
+  auto [BLOCK_SIZE, ITEMS_PER_THREAD] = GetParam();
+  const int total_elements = BLOCK_SIZE * ITEMS_PER_THREAD;
 
-    // Generate random test data using at::randn
-    auto input_tensor = at::randn({total_elements}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
-    auto output_tensor = at::empty({total_elements}, at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
+  // Generate random test data using at::randn
+  auto input_tensor = at::randn(
+      {total_elements},
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0));
 
-    // Copy input data to CPU for validation
-    auto input_cpu = input_tensor.cpu();
-    std::vector<float> test_data(input_cpu.data_ptr<float>(),
-                                input_cpu.data_ptr<float>() + total_elements);
+  // Copy input data to CPU for validation
+  auto input_cpu = input_tensor.cpu();
+  std::vector<float> test_data(
+      input_cpu.data_ptr<float>(),
+      input_cpu.data_ptr<float>() + total_elements);
 
-    // Test ascending
-    launch_basic_argsort_test_kernel<float>(
-        at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(),
-        output_tensor.data_ptr<nvfuser_index_t>(),
-        BLOCK_SIZE, ITEMS_PER_THREAD, false);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Test ascending
+  launch_basic_argsort_test_kernel<float>(
+      at::cuda::getCurrentCUDAStream(),
+      input_tensor.data_ptr<float>(),
+      output_tensor.data_ptr<nvfuser_index_t>(),
+      BLOCK_SIZE,
+      ITEMS_PER_THREAD,
+      false);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    auto output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> ascending_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                  output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+  auto output_cpu = output_tensor.cpu();
+  std::vector<nvfuser_index_t> ascending_indices(
+      output_cpu.data_ptr<nvfuser_index_t>(),
+      output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-    EXPECT_TRUE(validate_argsort_order(test_data, ascending_indices, false));
+  EXPECT_TRUE(validate_argsort_order(test_data, ascending_indices, false));
 
-    // Test descending
-    launch_basic_argsort_test_kernel<float>(
-        at::cuda::getCurrentCUDAStream(),
-        input_tensor.data_ptr<float>(),
-        output_tensor.data_ptr<nvfuser_index_t>(),
-        BLOCK_SIZE, ITEMS_PER_THREAD, true);
-    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  // Test descending
+  launch_basic_argsort_test_kernel<float>(
+      at::cuda::getCurrentCUDAStream(),
+      input_tensor.data_ptr<float>(),
+      output_tensor.data_ptr<nvfuser_index_t>(),
+      BLOCK_SIZE,
+      ITEMS_PER_THREAD,
+      true);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    output_cpu = output_tensor.cpu();
-    std::vector<nvfuser_index_t> descending_indices(output_cpu.data_ptr<nvfuser_index_t>(),
-                                                   output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
+  output_cpu = output_tensor.cpu();
+  std::vector<nvfuser_index_t> descending_indices(
+      output_cpu.data_ptr<nvfuser_index_t>(),
+      output_cpu.data_ptr<nvfuser_index_t>() + total_elements);
 
-    EXPECT_TRUE(validate_argsort_order(test_data, descending_indices, true));
+  EXPECT_TRUE(validate_argsort_order(test_data, descending_indices, true));
 }
 
 // Instantiate parameterized tests
@@ -314,16 +403,32 @@ INSTANTIATE_TEST_SUITE_P(
     ArgSortComprehensiveTest,
     testing::Values(
         // Block size 32
-        std::make_pair(32, 1), std::make_pair(32, 2), std::make_pair(32, 3), std::make_pair(32, 4), std::make_pair(32, 5),
+        std::make_pair(32, 1),
+        std::make_pair(32, 2),
+        std::make_pair(32, 3),
+        std::make_pair(32, 4),
+        std::make_pair(32, 5),
         // Block size 64
-        std::make_pair(64, 1), std::make_pair(64, 2), std::make_pair(64, 3), std::make_pair(64, 4), std::make_pair(64, 5),
+        std::make_pair(64, 1),
+        std::make_pair(64, 2),
+        std::make_pair(64, 3),
+        std::make_pair(64, 4),
+        std::make_pair(64, 5),
         // Block size 128
-        std::make_pair(128, 1), std::make_pair(128, 2), std::make_pair(128, 3), std::make_pair(128, 4), std::make_pair(128, 5),
+        std::make_pair(128, 1),
+        std::make_pair(128, 2),
+        std::make_pair(128, 3),
+        std::make_pair(128, 4),
+        std::make_pair(128, 5),
         // Block size 256
-        std::make_pair(256, 1), std::make_pair(256, 2), std::make_pair(256, 3), std::make_pair(256, 4), std::make_pair(256, 5)
-    ),
+        std::make_pair(256, 1),
+        std::make_pair(256, 2),
+        std::make_pair(256, 3),
+        std::make_pair(256, 4),
+        std::make_pair(256, 5)),
     [](const testing::TestParamInfo<std::pair<int, int>>& info) {
-        return "BlockSize" + std::to_string(info.param.first) + "_ItemsPerThread" + std::to_string(info.param.second);
+      return "BlockSize" + std::to_string(info.param.first) +
+          "_ItemsPerThread" + std::to_string(info.param.second);
     });
 
 } // namespace nvfuser


### PR DESCRIPTION
This PR adds a device function of argsort using CUB.

See [here](https://docs.google.com/document/d/1vd2YQtOPqvhFQuHu0BNM7X1F8HKoOUkq1f5yNFwTnyo/edit?tab=t.0#heading=h.mkxhhy66h6e) for the background.

This PR only adds the device function and unit tests. The device function is not yet used from generated code, which will be done in a follow-up (#4598).