### PR TITLE
Minor change on enumerate to iterate on signed index

### DIFF
--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -762,7 +762,7 @@ class enumerate_view : public std::ranges::view_interface<enumerate_view<V>> {
         std::forward_iterator_tag>;
 
     base_iterator current_;
-    std::size_t index_;
+    int64_t index_;
 
     iterator_base() = default;
     iterator_base(base_iterator current, std::size_t index)


### PR DESCRIPTION
Because

```
root@9f70c885dbce:/opt/pytorch/nvfuser# g++-13 -std=c++2b -Wall -o test m.cc
root@9f70c885dbce:/opt/pytorch/nvfuser# ./test
1
root@9f70c885dbce:/opt/pytorch/nvfuser# cat m.cc 
#include<ranges>
#include<vector>
#include<type_traits>
#include<iostream>

int main(int argc, char* argv[]) {
  std::vector<int> vec = {0};
  for (const auto& [i, v] : std::ranges::enumerate_view(vec)) {
    std::cout << std::is_signed_v<decltype(i)> << std::endl;
  }
}
```

On a separate note I have to explicitly cast the index into `int64_t` in order to avoid signed vs unsigned comparison.