### PR TITLE
adding fallback for grouped_mm

### DIFF
--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -87,7 +87,7 @@ bool isTvOp(const Expr* expr) {
   if (std::ranges::any_of(expr->outputs(), [](Val* v) { return isTV(v); }) &&
       (expr->isOneOf<
           ArgsortOp,
-          GroupedMMOp,
+          GroupedMmaOp,
           TopKOp,
           UnaryOp,
           BinaryOp,

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -105,7 +105,7 @@ class Val;
   f(SliceOp);                     \
   f(Split);                       \
   f(ArgsortOp);                   \
-  f(GroupedMMOp);                 \
+  f(GroupedMmaOp);                 \
   f(TopKOp);                      \
   f(Merge);                       \
   f(Swizzle);                     \

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -105,7 +105,7 @@ class Val;
   f(SliceOp);                     \
   f(Split);                       \
   f(ArgsortOp);                   \
-  f(GroupedMmaOp);                 \
+  f(GroupedMmaOp);                \
   f(TopKOp);                      \
   f(Merge);                       \
   f(Swizzle);                     \

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2875,7 +2875,8 @@ class ArgsortOp : public Expr {
 //! the starting index of each group in the mat1 and mat2 tensors.
 //!
 //! Given the number of groups as G, the operation conceptually runs G matmuls.
-//! There are three configurations of grouping, reflected by ranks of input matrices:
+//! There are three configurations of grouping, reflected by ranks of input
+//! matrices:
 //!
 //! Notation 1: prefix_sum_padded_offset = numpy.cumsum([0] + offsets)
 //! Notation 2: f(i) = prefix_sum_offsets(i) : prefix_sum_offsets(i+1)

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2886,12 +2886,12 @@ class ArgsortOp : public Expr {
 //!
 //!     Case 1: grouped k-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ k, n ] , offsets[ g ]
-//!                   scale1[ m, g ], scale2[ g, n]
+//!                   scale1[ g, m, k' ], scale2[ g, k', n]
 //!       requires: sum(offsets) == k
 //!       math:
 //!       for i in (0...g):
-//!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ 0:m, i ])
-//!                             @(mat2[ f(i), 0:n ] * scale2[ i, 0:n ])
+//!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ i, 0:m, 0:k' ])
+//!                             @(mat2[ f(i), 0:n ] * scale2[ i, 0:k', 0:n ])
 //!
 //!     Case 2: grouped m-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ g, k, n ] , offsets[ g ]
@@ -2899,8 +2899,8 @@ class ArgsortOp : public Expr {
 //!       requires: sum(offsets) == m
 //!       math:
 //!       for i in (0...g):
-//!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), k' ])
-//!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, k', 0:n ])
+//!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), 0:k' ])
+//!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, 0:k', 0:n ])
 //!
 //!     Case 3: grouped n-dimension:
 //!       input rank: mat1[ g, m, k ] @ mat2[ k, n ] , offsets[ g ]
@@ -2908,8 +2908,8 @@ class ArgsortOp : public Expr {
 //!       requires: sum(offsets) == n
 //!       math:
 //!       for i in (0...g):
-//!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, k' ])
-//!                           @(mat2[ 0:k, f(i) ] * scale2[ k', f(i) ])
+//!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, 0:k' ])
+//!                           @(mat2[ 0:k, f(i) ] * scale2[ 0:k', f(i) ])
 //!
 class GroupedMmaOp : public Expr {
  public:

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2890,12 +2890,14 @@ class ArgsortOp : public Expr {
 //!         scale factor has size k' on k-dimension.
 //!         For mxfp8, k' = k // 32. Each scale factor is shared by 32
 //!         consecutive elements.
+//! Note 2: output could have a reduction axis rk if k is not broadcast on
+//! inputs.
 //!
 //!     Case 1: grouped k-dimension:
 //!       inputs: mat1[ m, k ] @ mat2[ k, n ] , offsets[ g ]
 //!               scale1[ g, m, k' ], scale2[ g, k', n]
 //!       requires: offsets[g-1] == k
-//!       output: out[ g, m, n ]
+//!       output: out[ g, m, n, [rk]]
 //!
 //!       math:
 //!       for i in range(g):
@@ -2906,7 +2908,7 @@ class ArgsortOp : public Expr {
 //!       inputs: mat1[ m, k ] @ mat2[ g, k, n ] , offsets[ g ]
 //!               scale1[ m, k' ], scale2[ g, k', n ]
 //!       requires: offsets[g-1] == m
-//!       output: out[ m, n ]
+//!       output: out[ m, n, [rk]]
 //!
 //!       math:
 //!       for i in range(g):
@@ -2917,7 +2919,7 @@ class ArgsortOp : public Expr {
 //!       inputs: mat1[ g, m, k ] @ mat2[ k, n ] , offsets[ g ]
 //!               scale1[ g, m, k' ], scale2[ k', n ]
 //!       requires: offsets[g-1] == n
-//!       output: out[ m, n ]
+//!       output: out[ m, n, [rk]]
 //!
 //!       math:
 //!       for i in range(g):

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2937,7 +2937,7 @@ class GroupedMmaOp : public Expr {
       const std::vector<PolymorphicValue>& inputs) const override;
 
   // Get output matrix
-  TensorView* output() const {
+  TensorView* out() const {
     return output(0)->as<TensorView>();
   }
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2870,6 +2870,8 @@ class ArgsortOp : public Expr {
 //! - mat1: first input tensor
 //! - mat2: second input tensor
 //! - offsets: 1D offsets tensor
+//! - scale1: scale tensor for mat1 (optional)
+//! - scale2: scale tensor for mat2 (optional)
 //!
 //! The offsets tensor is a 1D tensor of shape (num_groups + 1) that specifies
 //! the starting index of each group in the mat1 and mat2 tensors.
@@ -2884,24 +2886,30 @@ class ArgsortOp : public Expr {
 //!
 //!     Case 1: grouped k-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ k, n ] , offsets[ g ]
+//!                   scale1[ g*m, 1 ], scale2[ 1, g*n]
 //!       requires: sum(offsets) == k
 //!       math:
 //!       for i in (0...g):
-//!         out[ i, 0:m, 0:n ] = mat1[ 0:m, f(i) ] @ mat2[ f(i), 0:n ]
+//!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ i*m:i*m+m, 0 ])
+//!                             @(mat2[ f(i), 0:n ] * scale2[ 0, i*n:i*n+n ])
 //!
 //!     Case 2: grouped m-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ g, k, n ] , offsets[ g ]
+//!                   scale1[ m, k ], scale2[ g, k, n ]
 //!       requires: sum(offsets) == m
 //!       math:
 //!       for i in (0...g):
-//!         out[ f(i), 0:n ] = mat1[ f(i), 0:k ] @ mat2[ 0:k, 0:n ]
+//!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), 0:k ])
+//!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, 0:k, 0:n ])
 //!
 //!     Case 3: grouped n-dimension:
 //!       input rank: mat1[ g, m, k ] @ mat2[ k, n ] , offsets[ g ]
+//!                   scale1[ g, m, k ], scale2[ k, n ]
 //!       requires: sum(offsets) == n
 //!       math:
 //!       for i in (0...g):
-//!         out[ 0:m, f(i) ] = mat1[ 0:m, 0:k ] @ mat2[ 0:k, f(i) ]
+//!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, 0:k ])
+//!                           @(mat2[ 0:k, f(i) ] * scale2[ 0:k, f(i) ])
 //!
 class GroupedMmaOp : public Expr {
  public:

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2886,30 +2886,30 @@ class ArgsortOp : public Expr {
 //!
 //!     Case 1: grouped k-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ k, n ] , offsets[ g ]
-//!                   scale1[ g*m, 1 ], scale2[ 1, g*n]
+//!                   scale1[ m, g ], scale2[ g, n]
 //!       requires: sum(offsets) == k
 //!       math:
 //!       for i in (0...g):
-//!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ i*m:i*m+m, 0 ])
-//!                             @(mat2[ f(i), 0:n ] * scale2[ 0, i*n:i*n+n ])
+//!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ 0:m, i ])
+//!                             @(mat2[ f(i), 0:n ] * scale2[ i, 0:n ])
 //!
 //!     Case 2: grouped m-dimension:
 //!       input rank: mat1[ m, k ] @ mat2[ g, k, n ] , offsets[ g ]
-//!                   scale1[ m, k ], scale2[ g, k, n ]
+//!                   scale1[ m, k' ], scale2[ g, k', n ]
 //!       requires: sum(offsets) == m
 //!       math:
 //!       for i in (0...g):
-//!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), 0:k ])
-//!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, 0:k, 0:n ])
+//!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), k' ])
+//!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, k', 0:n ])
 //!
 //!     Case 3: grouped n-dimension:
 //!       input rank: mat1[ g, m, k ] @ mat2[ k, n ] , offsets[ g ]
-//!                   scale1[ g, m, k ], scale2[ k, n ]
+//!                   scale1[ g, m, k' ], scale2[ k', n ]
 //!       requires: sum(offsets) == n
 //!       math:
 //!       for i in (0...g):
-//!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, 0:k ])
-//!                           @(mat2[ 0:k, f(i) ] * scale2[ 0:k, f(i) ])
+//!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, k' ])
+//!                           @(mat2[ 0:k, f(i) ] * scale2[ k', f(i) ])
 //!
 class GroupedMmaOp : public Expr {
  public:

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2879,7 +2879,8 @@ class ArgsortOp : public Expr {
 //! There are three configurations of grouping, reflected by ranks of input
 //! matrices:
 //!
-//! Note 0: f(i) = offset(i-1) : offset(i)
+//! Note 0: f(0) = 0 : offset[0]
+//!         f(i) = offset(i-1) : offset(i), when i >= 1;
 //!         f(i) is a slice with length equal to offsets[i] - offsets[i-1]
 //! Note 1: scales don't need to follow broadcast rules against corresponding
 //!         matrices on the k-dimension. Accelerators utilize blocked scales
@@ -2891,7 +2892,7 @@ class ArgsortOp : public Expr {
 //!       output: out[ g, m, n ]
 //!
 //!       math:
-//!       for i in (0...g):
+//!       for i in range(g):
 //!         out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ i, 0:m, 0:k' ])
 //!                             @(mat2[ f(i), 0:n ] * scale2[ i, 0:k', 0:n ])
 //!
@@ -2902,7 +2903,7 @@ class ArgsortOp : public Expr {
 //!       output: out[ m, n ]
 //!
 //!       math:
-//!       for i in (0...g):
+//!       for i in range(g):
 //!         out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), 0:k' ])
 //!                           @(mat2[ i, 0:k, 0:n ] * scale2[ i, 0:k', 0:n ])
 //!
@@ -2913,7 +2914,7 @@ class ArgsortOp : public Expr {
 //!       output: out[ m, n ]
 //!
 //!       math:
-//!       for i in (0...g):
+//!       for i in range(g):
 //!         out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, 0:k' ])
 //!                           @(mat2[ 0:k, f(i) ] * scale2[ 0:k', f(i) ])
 //!

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2878,16 +2878,16 @@ class ArgsortOp : public Expr {
 //! num_cols).
 //!
 //! The output tensor is a 2D tensor of shape (num_groups, num_rows, num_cols).
-class GroupedMMOp : public Expr {
+class GroupedMmaOp : public Expr {
  public:
   using Expr::Expr;
 
-  GroupedMMOp(IrBuilderPasskey, Val* out, Val* mat1, Val* mat2, Val* offsets);
+  GroupedMmaOp(IrBuilderPasskey, Val* out, Val* mat1, Val* mat2, Val* offsets);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
   const char* getOpString() const override {
-    return "GroupedMMOp";
+    return "GroupedMmaOp";
   }
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2983,13 +2983,16 @@ class GroupedMmaOp : public Expr {
   // Get the IterDomain for the k-dimension of the second input matrix
   IterDomain* getKDimOfMatrix2() const;
 
-  // Get the IterDomain for the group dimension of the first input matrix, returns nullptr if not present
+  // Get the IterDomain for the group dimension of the first input matrix,
+  // returns nullptr if not present
   std::optional<IterDomain*> getGroupDimOfMatrix1() const;
 
-  // Get the IterDomain for the group dimension of the second input matrix, returns nullptr if not present
+  // Get the IterDomain for the group dimension of the second input matrix,
+  // returns nullptr if not present
   std::optional<IterDomain*> getGroupDimOfMatrix2() const;
 
-  // Get the IterDomain for the group dimension of the output matrix, returns nullptr if not present
+  // Get the IterDomain for the group dimension of the output matrix, returns
+  // nullptr if not present
   std::optional<IterDomain*> getGroupDimOfOutput() const;
 };
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2907,7 +2907,14 @@ class GroupedMmaOp : public Expr {
  public:
   using Expr::Expr;
 
-  GroupedMmaOp(IrBuilderPasskey, Val* out, Val* mat1, Val* mat2, Val* offsets, Val* scale1 = nullptr, Val* scale2 = nullptr);
+  GroupedMmaOp(
+      IrBuilderPasskey,
+      Val* out,
+      Val* mat1,
+      Val* mat2,
+      Val* offsets,
+      Val* scale1 = nullptr,
+      Val* scale2 = nullptr);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -2907,7 +2907,7 @@ class GroupedMmaOp : public Expr {
  public:
   using Expr::Expr;
 
-  GroupedMmaOp(IrBuilderPasskey, Val* out, Val* mat1, Val* mat2, Val* offsets);
+  GroupedMmaOp(IrBuilderPasskey, Val* out, Val* mat1, Val* mat2, Val* offsets, Val* scale1 = nullptr, Val* scale2 = nullptr);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -2933,6 +2933,22 @@ class GroupedMmaOp : public Expr {
   TensorView* offsets() const {
     return input(2)->as<TensorView>();
   }
+  TensorView* scale1() const {
+    if (inputs().size() == 5) {
+      return input(3)->as<TensorView>();
+    }
+    return nullptr;
+  }
+  TensorView* scale2() const {
+    if (inputs().size() == 5) {
+      return input(4)->as<TensorView>();
+    }
+    return nullptr;
+  }
+  bool hasScale() const {
+    return attribute<bool>(0);
+  }
+
   IterDomain* getKIDOfMat1() const;
   IterDomain* getKIDOfMat2() const;
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5887,7 +5887,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     // scale factor handling
     if (out()->nDims() == 2) {
       // case 1, aten API expects collapsed 1D scale with group dimension on the slower side.
-      scale1_tensor = scale1_tensor.transpose(1, 2).contiguous().transpose(1, 2).reshape(-1);
+      scale1_tensor = scale1_tensor.transpose(0, 1).contiguous().transpose(0, 1).reshape(-1);
       scale2_tensor = scale2_tensor.contiguous().reshape(-1);
     } else {
       // case 2 and 3, aten doesn't allow broadcast on k dimension. squeeze those out.

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5861,16 +5861,16 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   }
 
   NVF_ERROR(
-      scale1.is<at::Tensor>(),
+      inputs[3].is<at::Tensor>(),
       "GroupedMmaOp expects tensor input at position 3 but got ",
-      scale1.type().name());
+      inputs[3].type().name());
   NVF_ERROR(
-      scale2.is<at::Tensor>(),
+      inputs[4].is<at::Tensor>(),
       "GroupedMmaOp expects tensor input at position 4 but got ",
-      scale2.type().name());
+      inputs[4].type().name());
 
-  const auto& scale1 = inputs[3];
-  const auto& scale2 = inputs[4];
+  const auto& scale1 = inputs[3].as<at::Tensor>();
+  const auto& scale2 = inputs[4].as<at::Tensor>();
   // Note: at::_scaled_grouped_mm requires k dimension to be the fastest on both
   // input matrices.
   auto mat1_k_last = mat1.contiguous();

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5793,7 +5793,7 @@ GroupedMmaOp::GroupedMmaOp(
 
   bool has_scale1 = scale1 != nullptr;
   NVF_CHECK(
-      has_scale1 && (scale2 != nullptr),
+      has_scale1 == (scale2 != nullptr),
       "scale1 and scale2 needs to be non-null or both null, got has_scale1 : ",
       has_scale1 ? "true" : "false",
       " has_scale2 : ",

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5877,7 +5877,25 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     // TODO: at::_scaled_grouped_mm has requirements on mat1 and mat2's memory
     // layout, as well as a different interpretation on broadcast scales. We
     // need to shoe horn it in
-    NVF_ERROR(false, "GroupedMmaOp with scale is not implementedyet");
+
+    // mat2 needs to be strided to have k dimension as the fastest dimension;
+    auto mat1_contiguous = mat1.as<at::Tensor>().contiguous();
+    auto mat2_k_last = mat2.as<at::Tensor>().transpose(1, 2).contiguous().transpose(1, 2);
+
+    auto scale1_tensor = scale1.as<at::Tensor>();
+    auto scale2_tensor = scale2.as<at::Tensor>();
+    // scale factor handling
+    if (out->nDims() == 2) {
+      // case 1, aten API expects collapsed 1D scale with group dimension on the slower side.
+      scale1_tensor = scale1_tensor.transpose().contiguous().transpose().reshape(-1);
+      scale2_tensor = scale2_tensor.contiguous().reshape(-1);
+    } else {
+      // case 2 and 3, aten doesn't allow broadcast on k dimension. squeeze those out.
+      scale1_tensor = scale1_tensor.squeeze(-1);
+      scale2_tensor = scale2_tensor.squeeze(-2);
+    }
+    result = at::_scaled_grouped_mm(
+        mat1_contiguous, mat2_k_last, offsets.as<at::Tensor>(), scale1_tensor, scale2_tensor);
   }
   return {result};
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5870,7 +5870,8 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       scale2.is<at::Tensor>(),
       "GroupedMmaOp expects tensor input at position 4 but got ",
       scale2.type().name());
-  // Note: at::_scaled_grouped_mm requires k dimension to be the fastest on both input matrices.
+  // Note: at::_scaled_grouped_mm requires k dimension to be the fastest on both
+  // input matrices.
   auto mat1_k_last = mat1.as<at::Tensor>().contiguous();
   auto mat2_k_last =
       mat2.as<at::Tensor>().transpose(-1, -2).contiguous().transpose(-1, -2);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5856,8 +5856,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       "GroupedMmaOp expects tensor input at position 2 but got ",
       offsets.type().name());
 
+  at::Tensor result;
   if (!hasScale()) {
-    auto result = at::_grouped_mm(
+    result = at::_grouped_mm(
         mat1.as<at::Tensor>(), mat2.as<at::Tensor>(), offsets.as<at::Tensor>());
   } else {
     const auto& scale1 = inputs[3];

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5877,7 +5877,10 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   // at::_scaled_grouped_mm limitation
   NVF_CHECK(
       scale1.size(-1) == 1 && scale2.size(-2) == 1,
-      "Scale1 and scale2 must have size 1 at the k dimension. Got ", scale1.sizes(), " and ", scale2.sizes());
+      "Scale1 and scale2 must have size 1 at the k dimension. Got ",
+      scale1.sizes(),
+      " and ",
+      scale2.sizes());
   // scale factor handling
   // see NOTE -- [ Grouped Matrix Multiplication semantics ]
   if (TensorDomain::noReductions(out()->getLogicalDomain()).size() == 3) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5791,11 +5791,14 @@ GroupedMmaOp::GroupedMmaOp(
   addInput(mat2);
   addInput(offsets);
 
-  bool has_scale = scale1 != nullptr;
+  bool has_scale1 = scale1 != nullptr;
   NVF_CHECK(
-      has_scale && (scale2 != nullptr),
-      "scale1 and scale2 needs to be non-null or both null");
-  if (has_scale) {
+      has_scale2 && (scale2 != nullptr),
+      "scale1 and scale2 needs to be non-null or both null, got has_scale1 : ",
+      has_scale1 ? "true" : "false",
+      " has_scale2 : ",
+      scale2 != nullptr ? "true" : "false");
+  if (has_scale1) {
     NVF_CHECK(
         scale1->getValType().value() == ValType::TensorView,
         "Scale1 must be a TensorView");

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5885,9 +5885,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     auto scale1_tensor = scale1.as<at::Tensor>();
     auto scale2_tensor = scale2.as<at::Tensor>();
     // scale factor handling
-    if (out->nDims() == 2) {
+    if (out()->nDims() == 2) {
       // case 1, aten API expects collapsed 1D scale with group dimension on the slower side.
-      scale1_tensor = scale1_tensor.transpose().contiguous().transpose().reshape(-1);
+      scale1_tensor = scale1_tensor.transpose(1, 2).contiguous().transpose(1, 2).reshape(-1);
       scale2_tensor = scale2_tensor.contiguous().reshape(-1);
     } else {
       // case 2 and 3, aten doesn't allow broadcast on k dimension. squeeze those out.

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5854,7 +5854,11 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
 
   at::Tensor result;
   if (!hasScale()) {
+    // NOTE: at::_grouped_mm only supports bfloat16 as output at this moment,
+    // otherwise we should have requested the output dtype directly instead of
+    // casting the output afterwards.
     result = at::_grouped_mm(mat1, mat2, offsets);
+    result = result.to(data_type_to_aten(out()->dtype()));
     return {result};
   }
 
@@ -5893,6 +5897,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     scale1 = scale1.squeeze(-1);
     scale2 = scale2.squeeze(-2);
   }
+  // NOTE: at::_scaled_grouped_mm only supports bfloat16 as output at this
+  // moment, otherwise we should have requested the output dtype directly
+  // instead of casting the output afterwards.
   result = at::_scaled_grouped_mm(
       mat1_k_last,
       mat2_k_last,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5895,7 +5895,8 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       scale2_tensor = scale2_tensor.squeeze(-2);
     }
     result = at::_scaled_grouped_mm(
-        mat1_contiguous, mat2_k_last, offsets.as<at::Tensor>(), scale1_tensor, scale2_tensor);
+        mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), None, None, at::BFloat16);
+    result = result.to(data_type_to_aten(out()->dtype()));
   }
   return {result};
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5821,7 +5821,7 @@ std::string GroupedMmaOp::toString(int indent_size) const {
 }
 
 std::string GroupedMmaOp::toInlineString(int indent_size) const {
-  NVF_CHECK(false, "Tensor op can not be printed inline");
+  NVF_THROW("Tensor op can not be printed inline.");
 }
 
 std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
@@ -5878,7 +5878,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   // at::_scaled_grouped_mm limitation
   NVF_CHECK(
       scale1.size(-1) == 1 && scale2.size(-2) == 1,
-      "Scale1 and scale2 must have size 1 at the k dimension");
+      "Scale1 and scale2 must have size 1 at the k dimension. Got ", scale1.sizes(), " and ", scale2.sizes());
   // scale factor handling
   // see NOTE -- [ Grouped Matrix Multiplication semantics ]
   if (out()->nDims() == 3) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5379,13 +5379,13 @@ class RuntimeReductionFinder : kir::ConstIrVisitor {
   bool is_found_ = false;
 };
 
-std::optional<IterDomain*> returnFirstIfRankThree(const TensorView* tv) {
+IterDomain* returnFirstIfRankThree(const TensorView* tv) {
   const auto& logical_domain =
       TensorDomain::noReductions(tv->getLogicalDomain());
   if (logical_domain.size() == 3) {
     return logical_domain.at(0);
   } else {
-    return std::nullopt;
+    return nullptr;
   }
 }
 } // namespace
@@ -5923,18 +5923,18 @@ IterDomain* GroupedMmaOp::getKDimOfMatrix2() const {
   return logical_domain.at(logical_domain.size() - 1);
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfMatrix1() const {
-  // mat1 is [g, m, k] or [m, k]
-  return returnFirstIfRankThree(mat1());
+IterDomain* GroupedMmaOp::getGroupDimOfMatrix1() const {
+  // matrix1 is [g, m, k] or [m, k]
+  return returnFirstIfRankThree(matrix1());
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfMatrix2() const {
-  // mat2 is [g, k, n] or [k, n]
-  return returnFirstIfRankThree(mat2());
+IterDomain* GroupedMmaOp::getGroupDimOfMatrix2() const {
+  // matrix2 is [g, k, n] or [k, n]
+  return returnFirstIfRankThree(matrix2());
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfOutput() const {
-  // mat2 is [g, k, n] or [k, n]
+IterDomain* GroupedMmaOp::getGroupDimOfOutput() const {
+  // output is [g, m, n] or [m, n]
   return returnFirstIfRankThree(out());
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5808,8 +5808,8 @@ GroupedMmaOp::GroupedMmaOp(
 std::string GroupedMmaOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << " = GroupedMmaOp("
-                          << "mat1=" << mat1()->toString() << ", "
-                          << "mat2=" << mat2()->toString() << ", "
+                          << "mat1=" << matrix1()->toString() << ", "
+                          << "mat2=" << matrix2()->toString() << ", "
                           << "offsets=" << offsets()->toString();
   if (hasScale()) {
     ss << ", "
@@ -5912,14 +5912,14 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
 IterDomain* GroupedMmaOp::getKDimOfMatrix1() const {
   // mat1 is [g, m, k] or [m, k]
   const auto& logical_domain =
-      TensorDomain::noReductions(mat1()->getLogicalDomain());
+      TensorDomain::noReductions(matrix1()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 
 IterDomain* GroupedMmaOp::getKDimOfMatrix2() const {
   // mat2 is [g, k, n] or [k, n]
   const auto& logical_domain =
-      TensorDomain::noReductions(mat2()->getLogicalDomain());
+      TensorDomain::noReductions(matrix2()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5845,7 +5845,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
 
   NVF_ERROR(
       mat2.is<at::Tensor>(),
-      "GroupedMmaOp expects tensor input at position 1 but got ",
+      "GroupedMmaOp expects tensor input at position4 but got ",
       mat2.type().name());
 
   NVF_ERROR(
@@ -5857,7 +5857,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   if (!hasScale()) {
     result = at::_grouped_mm(
         mat1.as<at::Tensor>(), mat2.as<at::Tensor>(), offsets.as<at::Tensor>());
-  } else {
+    return {result};
+  }
+
     const auto& scale1 = inputs[3];
     const auto& scale2 = inputs[4];
     NVF_ERROR(
@@ -5895,7 +5897,6 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     result = at::_scaled_grouped_mm(
         mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), std::nullopt, std::nullopt, at::ScalarType::BFloat16);
     result = result.to(data_type_to_aten(out()->dtype()));
-  }
   return {result};
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5792,12 +5792,18 @@ GroupedMmaOp::GroupedMmaOp(
   addInput(offsets);
 
   bool has_scale = scale1 != nullptr;
-  NVF_CHECK(has_scale && (scale2 != nullptr), "scale1 and scale2 needs to be non-null or both null");
+  NVF_CHECK(
+      has_scale && (scale2 != nullptr),
+      "scale1 and scale2 needs to be non-null or both null");
   if (has_scale) {
-    NVF_CHECK(scale1->getValType().value() == ValType::TensorView, "Scale1 must be a TensorView");
-    NVF_CHECK(scale2->getValType().value() == ValType::TensorView, "Scale2 must be a TensorView");
+    NVF_CHECK(
+        scale1->getValType().value() == ValType::TensorView,
+        "Scale1 must be a TensorView");
+    NVF_CHECK(
+        scale2->getValType().value() == ValType::TensorView,
+        "Scale2 must be a TensorView");
     addInput(scale1);
-    addInput(scale2); 
+    addInput(scale2);
   }
   addDataAttribute(has_scale);
 }
@@ -5809,7 +5815,9 @@ std::string GroupedMmaOp::toString(int indent_size) const {
                           << "mat2=" << mat2()->toString() << ", "
                           << "offsets=" << offsets()->toString();
   if (hasScale()) {
-    ss << ", " << "scale1=" << scale1()->toString() << ", " << "scale2=" << scale2()->toString();
+    ss << ", "
+       << "scale1=" << scale1()->toString() << ", "
+       << "scale2=" << scale2()->toString();
   }
   ss << ")\n";
   return ss.str();
@@ -5825,7 +5833,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   NVF_ERROR(
       (inputs.size() == 3 && !hasScale()) || (inputs.size() == 5 && hasScale()),
       "GroupedMmaOp expects 3 or 5 inputs but received ",
-      inputs.size(), " with scale flag: ", hasScale() ? "true" : "false");
+      inputs.size(),
+      " with scale flag: ",
+      hasScale() ? "true" : "false");
 
   const auto& mat1 = inputs[0];
   const auto& mat2 = inputs[1];
@@ -5852,9 +5862,17 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   } else {
     const auto& scale1 = inputs[3];
     const auto& scale2 = inputs[4];
-    NVF_ERROR(scale1.is<at::Tensor>(), "GroupedMmaOp expects tensor input at position 3 but got ", scale1.type().name());
-    NVF_ERROR(scale2.is<at::Tensor>(), "GroupedMmaOp expects tensor input at position 4 but got ", scale2.type().name());
-    // TODO: at::_scaled_grouped_mm has requirements on mat1 and mat2's memory layout, as well as a different interpretation on broadcast scales. We need to shoe horn it in
+    NVF_ERROR(
+        scale1.is<at::Tensor>(),
+        "GroupedMmaOp expects tensor input at position 3 but got ",
+        scale1.type().name());
+    NVF_ERROR(
+        scale2.is<at::Tensor>(),
+        "GroupedMmaOp expects tensor input at position 4 but got ",
+        scale2.type().name());
+    // TODO: at::_scaled_grouped_mm has requirements on mat1 and mat2's memory
+    // layout, as well as a different interpretation on broadcast scales. We
+    // need to shoe horn it in
     NVF_ERROR(false, "GroupedMmaOp with scale is not implementedyet");
   }
   return {result};

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5792,12 +5792,6 @@ GroupedMmaOp::GroupedMmaOp(
   addInput(offsets);
 
   bool has_scale1 = scale1 != nullptr;
-  NVF_CHECK(
-      has_scale1 == (scale2 != nullptr),
-      "scale1 and scale2 needs to be non-null or both null, got has_scale1 : ",
-      has_scale1 ? "true" : "false",
-      " has_scale2 : ",
-      scale2 != nullptr ? "true" : "false");
   if (has_scale1) {
     NVF_CHECK(
         scale1->getValType().value() == ValType::TensorView,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5793,7 +5793,7 @@ GroupedMmaOp::GroupedMmaOp(
 
   bool has_scale1 = scale1 != nullptr;
   NVF_CHECK(
-      has_scale2 && (scale2 != nullptr),
+      has_scale1 && (scale2 != nullptr),
       "scale1 and scale2 needs to be non-null or both null, got has_scale1 : ",
       has_scale1 ? "true" : "false",
       " has_scale2 : ",
@@ -5808,7 +5808,7 @@ GroupedMmaOp::GroupedMmaOp(
     addInput(scale1);
     addInput(scale2);
   }
-  addDataAttribute(has_scale);
+  addDataAttribute(has_scale1);
 }
 
 std::string GroupedMmaOp::toString(int indent_size) const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5794,8 +5794,8 @@ GroupedMmaOp::GroupedMmaOp(
   bool has_scale1 = scale1 != nullptr;
   if (has_scale1) {
     NVF_CHECK(
-        scale1->getValType().value() == ValType::TensorView,
-        "Scale1 must be a TensorView");
+        scale1->isA<TensorView>(),
+        "`scale1` must be a TensorView, but got: ", scale1);
     NVF_CHECK(
         scale2->getValType().value() == ValType::TensorView,
         "Scale2 must be a TensorView");

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5880,7 +5880,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       "Scale1 and scale2 must have size 1 at the k dimension. Got ", scale1.sizes(), " and ", scale2.sizes());
   // scale factor handling
   // see NOTE -- [ Grouped Matrix Multiplication semantics ]
-  if (out()->nDims() == 3) {
+  if (TensorDomain::noReductions(out()->getLogicalDomain()).size() == 3) {
     // case 1, aten API expects collapsed 1D scale with group dimension on the
     // slower side.
     scale1 = scale1.reshape(-1);

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5874,9 +5874,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     // layout, as well as a different interpretation on broadcast scales. We
     // need to shoe horn it in
 
-    // mat2 needs to be strided to have k dimension as the fastest dimension;
     auto mat1_contiguous = mat1.as<at::Tensor>().contiguous();
-    auto mat2_k_last = mat2.as<at::Tensor>().transpose(1, 2).contiguous().transpose(1, 2);
+    // mat2 needs to be strided to have k dimension as the fastest dimension;
+    auto mat2_k_last = mat2.as<at::Tensor>().transpose(-1, -2).contiguous().transpose(-1, -2);
 
     auto scale1_tensor = scale1.as<at::Tensor>();
     auto scale2_tensor = scale2.as<at::Tensor>();

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5900,31 +5900,31 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
   return {result};
 }
 
-IterDomain* GroupedMmaOp::getKIDOfMat1() const {
+IterDomain* GroupedMmaOp::getKDimOfMatrix1() const {
   // mat1 is [g, m, k] or [m, k]
   const auto& logical_domain =
       TensorDomain::noReductions(mat1()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 
-IterDomain* GroupedMmaOp::getKIDOfMat2() const {
+IterDomain* GroupedMmaOp::getKDimOfMatrix2() const {
   // mat2 is [g, k, n] or [k, n]
   const auto& logical_domain =
       TensorDomain::noReductions(mat2()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGIDOfMat1() const {
+std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfMatrix1() const {
   // mat1 is [g, m, k] or [m, k]
   return returnFirstIfRankThree(mat1());
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGIDOfMat2() const {
+std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfMatrix2() const {
   // mat2 is [g, k, n] or [k, n]
   return returnFirstIfRankThree(mat2());
 }
 
-std::optional<IterDomain*> GroupedMmaOp::getGIDOfOutput() const {
+std::optional<IterDomain*> GroupedMmaOp::getGroupDimOfOutput() const {
   // mat2 is [g, k, n] or [k, n]
   return returnFirstIfRankThree(out());
 }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5774,18 +5774,10 @@ GroupedMmaOp::GroupedMmaOp(
     Val* scale1,
     Val* scale2)
     : Expr(passkey) {
-  NVF_ERROR(
-      out->getValType().value() == ValType::TensorView,
-      "Output must be a TensorView");
-  NVF_ERROR(
-      mat1->getValType().value() == ValType::TensorView,
-      "First input must be a TensorView");
-  NVF_ERROR(
-      mat2->getValType().value() == ValType::TensorView,
-      "Second input must be a TensorView");
-  NVF_ERROR(
-      offsets->getValType().value() == ValType::TensorView,
-      "Offsets must be a TensorView");
+  NVF_ERROR(out->isA<TensorView>(), "Output must be a TensorView");
+  NVF_ERROR(mat1->isA<TensorView>(), "First input must be a TensorView");
+  NVF_ERROR(mat2->isA<TensorView>(), "Second input must be a TensorView");
+  NVF_ERROR(offsets->isA<TensorView>(), "Offsets must be a TensorView");
   addOutput(out);
   addInput(mat1);
   addInput(mat2);
@@ -5795,10 +5787,9 @@ GroupedMmaOp::GroupedMmaOp(
   if (has_scale1) {
     NVF_CHECK(
         scale1->isA<TensorView>(),
-        "`scale1` must be a TensorView, but got: ", scale1);
-    NVF_CHECK(
-        scale2->getValType().value() == ValType::TensorView,
-        "Scale2 must be a TensorView");
+        "`scale1` must be a TensorView, but got: ",
+        scale1);
+    NVF_CHECK(scale2->isA<TensorView>(), "Scale2 must be a TensorView");
     addInput(scale1);
     addInput(scale2);
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5302,7 +5302,8 @@ class RuntimeReductionFinder : kir::ConstIrVisitor {
 };
 
 std::optional<IterDomain*> returnFirstIfRankThree(const TensorView* tv) {
-  const auto& logical_domain = tv->getLogicalDomain();
+  const auto& logical_domain =
+      TensorDomain::noReductions(tv->getLogicalDomain());
   if (logical_domain.size() == 3) {
     return logical_domain.at(0);
   } else {
@@ -5758,16 +5759,16 @@ std::vector<PolymorphicValue> GroupedMMOp::evaluate(
 
 IterDomain* GroupedMMOp::getKIDOfMat1() const {
   // mat1 is [g, m, k] or [m, k]
-  const auto& logical_domain = mat1()->getLogicalDomain();
-  return TensorDomain::noReductions(
-      logical_domain.at(logical_domain.size()) - 1);
+  const auto& logical_domain =
+      TensorDomain::noReductions(mat1()->getLogicalDomain());
+  return logical_domain.at(logical_domain.size() - 1);
 }
 
 IterDomain* GroupedMMOp::getKIDOfMat2() const {
   // mat2 is [g, k, n] or [k, n]
-  const auto& logical_domain = mat2()->getLogicalDomain();
-  return TensorDomain::noReductions(
-      logical_domain.at(logical_domain.size()) - 1);
+  const auto& logical_domain =
+      TensorDomain::noReductions(mat2()->getLogicalDomain());
+  return logical_domain.at(logical_domain.size() - 1);
 }
 
 std::optional<IterDomain*> GroupedMMOp::getGIDOfMat1() const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5855,8 +5855,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
 
   at::Tensor result;
   if (!hasScale()) {
-    result = at::_grouped_mm(
-        mat1, mat2, offsets);
+    result = at::_grouped_mm(mat1, mat2, offsets);
     return {result};
   }
 
@@ -5869,13 +5868,12 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       "GroupedMmaOp expects tensor input at position 4 but got ",
       inputs[4].type().name());
 
-  const auto& scale1 = inputs[3].as<at::Tensor>();
-  const auto& scale2 = inputs[4].as<at::Tensor>();
+  auto scale1 = inputs[3].as<at::Tensor>();
+  auto scale2 = inputs[4].as<at::Tensor>();
   // Note: at::_scaled_grouped_mm requires k dimension to be the fastest on both
   // input matrices.
   auto mat1_k_last = mat1.contiguous();
-  auto mat2_k_last =
-      mat2.transpose(-1, -2).contiguous().transpose(-1, -2);
+  auto mat2_k_last = mat2.transpose(-1, -2).contiguous().transpose(-1, -2);
 
   // at::_scaled_grouped_mm limitation
   NVF_CHECK(

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5817,6 +5817,7 @@ std::string GroupedMmaOp::toInlineString(int indent_size) const {
 std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
+#if NVF_TORCH_VERSION_NO_LESS(2, 8, 0)
   NVF_ERROR(
       (inputs.size() == 3 && !hasScale()) || (inputs.size() == 5 && hasScale()),
       "GroupedMmaOp expects 3 or 5 inputs but received ",
@@ -5902,6 +5903,9 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       at::ScalarType::BFloat16);
   result = result.to(data_type_to_aten(out()->dtype()));
   return {result};
+#else
+  NVF_THROW("GroupedMmaOp is not supported prior to PyTorch 2.8.");
+#endif
 }
 
 IterDomain* GroupedMmaOp::getKDimOfMatrix1() const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5802,7 +5802,6 @@ GroupedMmaOp::GroupedMmaOp(
     addInput(scale1);
     addInput(scale2);
   }
-  addDataAttribute(has_scale1);
 }
 
 std::string GroupedMmaOp::toString(int indent_size) const {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5895,7 +5895,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       scale2_tensor = scale2_tensor.squeeze(-2);
     }
     result = at::_scaled_grouped_mm(
-        mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), std::nullopt, std::nullopt, at::BFloat16);
+        mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), std::nullopt, std::nullopt, at::ScalarType::BFloat16);
     result = result.to(data_type_to_aten(out()->dtype()));
   }
   return {result};

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5895,7 +5895,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
       scale2_tensor = scale2_tensor.squeeze(-2);
     }
     result = at::_scaled_grouped_mm(
-        mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), None, None, at::BFloat16);
+        mat1_contiguous, mat2_k_last, scale1_tensor, scale2_tensor, offsets.as<at::Tensor>(), std::nullopt, std::nullopt, at::BFloat16);
     result = result.to(data_type_to_aten(out()->dtype()));
   }
   return {result};

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5687,7 +5687,7 @@ std::vector<PolymorphicValue> TopKOp::evaluate(
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(TopKOp)
 
-GroupedMMOp::GroupedMMOp(
+GroupedMmaOp::GroupedMmaOp(
     IrBuilderPasskey passkey,
     Val* out,
     Val* mat1,
@@ -5712,25 +5712,25 @@ GroupedMMOp::GroupedMMOp(
   addInput(offsets);
 }
 
-std::string GroupedMMOp::toString(int indent_size) const {
+std::string GroupedMmaOp::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << out()->toString() << " = GroupedMMOp("
+  indent(ss, indent_size) << out()->toString() << " = GroupedMmaOp("
                           << "mat1=" << mat1()->toString() << ", "
                           << "mat2=" << mat2()->toString() << ", "
                           << "offsets=" << offsets()->toString() << ")\n";
   return ss.str();
 }
 
-std::string GroupedMMOp::toInlineString(int indent_size) const {
+std::string GroupedMmaOp::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
-std::vector<PolymorphicValue> GroupedMMOp::evaluate(
+std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   NVF_ERROR(
       inputs.size() == 3,
-      "GroupedMMOp expects 3 inputs but received ",
+      "GroupedMmaOp expects 3 inputs but received ",
       inputs.size());
 
   const auto& mat1 = inputs[0];
@@ -5739,17 +5739,17 @@ std::vector<PolymorphicValue> GroupedMMOp::evaluate(
 
   NVF_ERROR(
       mat1.is<at::Tensor>(),
-      "GroupedMMOp expects tensor input at position 0 but got ",
+      "GroupedMmaOp expects tensor input at position 0 but got ",
       mat1.type().name());
 
   NVF_ERROR(
       mat2.is<at::Tensor>(),
-      "GroupedMMOp expects tensor input at position 1 but got ",
+      "GroupedMmaOp expects tensor input at position 1 but got ",
       mat2.type().name());
 
   NVF_ERROR(
       offsets.is<at::Tensor>(),
-      "GroupedMMOp expects tensor input at position 2 but got ",
+      "GroupedMmaOp expects tensor input at position 2 but got ",
       offsets.type().name());
 
   auto result = at::_grouped_mm(
@@ -5757,35 +5757,35 @@ std::vector<PolymorphicValue> GroupedMMOp::evaluate(
   return {result};
 }
 
-IterDomain* GroupedMMOp::getKIDOfMat1() const {
+IterDomain* GroupedMmaOp::getKIDOfMat1() const {
   // mat1 is [g, m, k] or [m, k]
   const auto& logical_domain =
       TensorDomain::noReductions(mat1()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 
-IterDomain* GroupedMMOp::getKIDOfMat2() const {
+IterDomain* GroupedMmaOp::getKIDOfMat2() const {
   // mat2 is [g, k, n] or [k, n]
   const auto& logical_domain =
       TensorDomain::noReductions(mat2()->getLogicalDomain());
   return logical_domain.at(logical_domain.size() - 1);
 }
 
-std::optional<IterDomain*> GroupedMMOp::getGIDOfMat1() const {
+std::optional<IterDomain*> GroupedMmaOp::getGIDOfMat1() const {
   // mat1 is [g, m, k] or [m, k]
   return returnFirstIfRankThree(mat1());
 }
 
-std::optional<IterDomain*> GroupedMMOp::getGIDOfMat2() const {
+std::optional<IterDomain*> GroupedMmaOp::getGIDOfMat2() const {
   // mat2 is [g, k, n] or [k, n]
   return returnFirstIfRankThree(mat2());
 }
 
-std::optional<IterDomain*> GroupedMMOp::getGIDOfOutput() const {
+std::optional<IterDomain*> GroupedMmaOp::getGIDOfOutput() const {
   // mat2 is [g, k, n] or [k, n]
   return returnFirstIfRankThree(out());
 }
 
-NVFUSER_DEFINE_CLONE_AND_CREATE(GroupedMMOp)
+NVFUSER_DEFINE_CLONE_AND_CREATE(GroupedMmaOp)
 
 } // namespace nvfuser

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -372,8 +372,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       if (ndims_out == 2) {
         // mapping m dimension;
         updatePairwiseLogicalDomainMap(
-            producer_logical.at(std::ssize(producer_logical) - 2),
-            consumer_root.at(std::ssize(consumer_root) - 2));
+            producer_logical.at(std::ssize(producer_logical) - 1),
+            consumer_root.at(0));
       }
     } else if (producer_tv_->sameAs(op->scale2())) {
       if (ndims_out == 2) {

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -388,7 +388,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(last_producer_idx), consumer_root.back());
       }
-    } else if (producer_tv_->sameAs(op->matrix2())) {
+    } else if (producer_tv_ == op->matrix2()) {
       // mapping n dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx),
@@ -398,13 +398,13 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(last_producer_idx - 1), consumer_root.back());
       }
-    } else if (producer_tv_->sameAs(op->offsets())) {
+    } else if (producer_tv_ == op->offsets()) {
       // mapping g dimension;
       if (has_g) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));
       }
-    } else if (producer_tv_->sameAs(op->scale1())) {
+    } else if (producer_tv_ == op->scale1()) {
       // mapping m dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx), consumer_root.at(0));
@@ -419,7 +419,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(last_producer_idx), consumer_root.back());
       }
-    } else if (producer_tv_->sameAs(op->scale2())) {
+    } else if (producer_tv_ == op->scale2()) {
       // mapping n dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx),

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -374,13 +374,29 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(std::ssize(producer_logical) - 1),
             consumer_root.at(0));
+      } else if (ndims_out == 3) {
+        // mapping g and m dimension;
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(0),
+            consumer_root.at(0));
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(1),
+            consumer_root.at(1));
       }
     } else if (producer_tv_->sameAs(op->scale2())) {
       if (ndims_out == 2) {
-        // mapping k dimension;
+        // mapping n dimension;
         updatePairwiseLogicalDomainMap(
             producer_logical.at(std::ssize(producer_logical) - 1),
             consumer_root.at(std::ssize(consumer_root) - 1));
+      } else if (ndims_out == 3) {
+        // mapping g and n dimension;
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(0),
+            consumer_root.at(0));
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(-1),
+            consumer_root.at(-1));
       }
     } else {
       NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -352,12 +352,12 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   if (GroupedMmaOp* op =
           dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
     auto ndims_out = consumer_root.size();
-    if (producer_tv_->sameAs(op->mat1())) {
+    if (producer_tv_->sameAs(op->matrix1())) {
       // mapping m dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(std::ssize(producer_logical) - 2),
           consumer_root.at(std::ssize(consumer_root) - 2));
-    } else if (producer_tv_->sameAs(op->mat2())) {
+    } else if (producer_tv_->sameAs(op->matrix2())) {
       // mapping k dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(std::ssize(producer_logical) - 1),

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -369,34 +369,26 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
             producer_logical.at(0), consumer_root.at(0));
       }
     } else if (producer_tv_->sameAs(op->scale1())) {
-      if (ndims_out == 2) {
-        // mapping m dimension;
-        updatePairwiseLogicalDomainMap(
-            producer_logical.at(std::ssize(producer_logical) - 1),
-            consumer_root.at(0));
-      } else if (ndims_out == 3) {
-        // mapping g and m dimension;
+      // mapping m dimension;
+      updatePairwiseLogicalDomainMap(
+          producer_logical.at(std::ssize(producer_logical) - 1),
+          consumer_root.at(0));
+      if (ndims_out == 3) {
+        // mapping g dimension;
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0),
             consumer_root.at(0));
-        updatePairwiseLogicalDomainMap(
-            producer_logical.at(1),
-            consumer_root.at(1));
       }
     } else if (producer_tv_->sameAs(op->scale2())) {
-      if (ndims_out == 2) {
-        // mapping n dimension;
-        updatePairwiseLogicalDomainMap(
-            producer_logical.at(std::ssize(producer_logical) - 1),
-            consumer_root.at(std::ssize(consumer_root) - 1));
-      } else if (ndims_out == 3) {
-        // mapping g and n dimension;
+      // mapping n dimension;
+      updatePairwiseLogicalDomainMap(
+          producer_logical.at(std::ssize(producer_logical) - 1),
+          consumer_root.at(std::ssize(consumer_root) - 1));
+      if (ndims_out == 3) {
+        // mapping g dimension;
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0),
             consumer_root.at(0));
-        updatePairwiseLogicalDomainMap(
-            producer_logical.at(-1),
-            consumer_root.at(-1));
       }
     } else {
       NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -349,8 +349,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   }
 
   // TODO: refactor to use getNonMappingDomainInfo instead.
-  if (GroupedMMOp* op =
-          dynamic_cast<GroupedMMOp*>(consumer_tv_->definition())) {
+  if (GroupedMmaOp* op =
+          dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
     auto ndims_out = consumer_root.size();
     bool mapped = false;
     int index_in = -1;

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -396,8 +396,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       if (ndims_out == 3) {
         // mapping g dimension;
         updatePairwiseLogicalDomainMap(
-            producer_logical.at(0),
-            consumer_root.at(0));
+            producer_logical.at(0), consumer_root.at(0));
       }
     } else if (producer_tv_->sameAs(op->scale2())) {
       // mapping n dimension;
@@ -407,8 +406,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       if (ndims_out == 3) {
         // mapping g dimension;
         updatePairwiseLogicalDomainMap(
-            producer_logical.at(0),
-            consumer_root.at(0));
+            producer_logical.at(0), consumer_root.at(0));
       }
     } else {
       NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -373,7 +373,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     int64_t ndims_out = std::ssize(consumer_root);
     // [rk] is the reduction axis for the matmul operation, it only exists if k
     // is not broadcast.
-    bool* has_rk = consumer_root.back()->isReduction();
+    bool has_rk = consumer_root.back()->isReduction();
     int64_t out_non_rk_last_idx = has_rk ? ndims_out - 2 : ndims_out - 1;
 
     int64_t last_producer_idx = std::ssize(producer_logical) - 1;

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -369,8 +369,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   }
 
   // TODO: refactor to use getNonMappingDomainInfo instead.
-  if (auto* op =
-          dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
+  if (auto* op = dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
     auto ndims_out = consumer_root.size();
     if (producer_tv_->sameAs(op->matrix1())) {
       // mapping m dimension;

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -370,6 +370,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
 
   // TODO: refactor to use getNonMappingDomainInfo instead.
   if (auto* op = dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
+    bool has_g = TensorDomain::noReductions(consumer_root).size() == 3;
     int64_t ndims_out = std::ssize(consumer_root);
     // [rk] is the reduction axis for the matmul operation, it only exists if k
     // is not broadcast.
@@ -399,7 +400,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       }
     } else if (producer_tv_->sameAs(op->offsets())) {
       // mapping g dimension;
-      if (ndims_out == 3) {
+      if (has_g) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));
       }
@@ -408,7 +409,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx), consumer_root.at(0));
       // mapping g dimension;
-      if (ndims_out == 3) {
+      if (has_g) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));
       }
@@ -422,7 +423,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx),
           consumer_root.at(out_non_rk_last_idx));
-      if (ndims_out == 3) {
+      if (has_g) {
         // mapping g dimension;
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -378,7 +378,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
           producer_logical.at(std::ssize(producer_logical) - 2),
           consumer_root.at(std::ssize(consumer_root) - 2));
     } else if (producer_tv_->sameAs(op->matrix2())) {
-      // mapping k dimension;
+      // mapping n dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(std::ssize(producer_logical) - 1),
           consumer_root.at(std::ssize(consumer_root) - 1));

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -355,28 +355,32 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     if (producer_tv_->sameAs(op->mat1())) {
       // mapping m dimension;
       updatePairwiseLogicalDomainMap(
-          producer_logical.at(std::ssize(producer_logical) - 2), consumer_root.at(std::ssize(consumer_root) - 2));
+          producer_logical.at(std::ssize(producer_logical) - 2),
+          consumer_root.at(std::ssize(consumer_root) - 2));
     } else if (producer_tv_->sameAs(op->mat2())) {
       // mapping k dimension;
       updatePairwiseLogicalDomainMap(
-          producer_logical.at(std::ssize(producer_logical) - 1), consumer_root.at(std::ssize(consumer_root) - 1));
+          producer_logical.at(std::ssize(producer_logical) - 1),
+          consumer_root.at(std::ssize(consumer_root) - 1));
     } else if (producer_tv_->sameAs(op->offsets())) {
       // mapping g dimension;
       if (ndims_out == 3) {
-      updatePairwiseLogicalDomainMap(
-          producer_logical.at(0), consumer_root.at(0));
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(0), consumer_root.at(0));
       }
     } else if (producer_tv_->sameAs(op->scale1())) {
       if (ndims_out == 2) {
         // mapping m dimension;
         updatePairwiseLogicalDomainMap(
-            producer_logical.at(std::ssize(producer_logical) - 2), consumer_root.at(std::ssize(consumer_root) - 2));
+            producer_logical.at(std::ssize(producer_logical) - 2),
+            consumer_root.at(std::ssize(consumer_root) - 2));
       }
     } else if (producer_tv_->sameAs(op->scale2())) {
       if (ndims_out == 2) {
-      // mapping k dimension;
-      updatePairwiseLogicalDomainMap(
-          producer_logical.at(std::ssize(producer_logical) - 1), consumer_root.at(std::ssize(consumer_root) - 1));
+        // mapping k dimension;
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(std::ssize(producer_logical) - 1),
+            consumer_root.at(std::ssize(consumer_root) - 1));
       }
     } else {
       NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -369,7 +369,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   }
 
   // TODO: refactor to use getNonMappingDomainInfo instead.
-  if (GroupedMmaOp* op =
+  if (auto* op =
           dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
     auto ndims_out = consumer_root.size();
     if (producer_tv_->sameAs(op->matrix1())) {
@@ -409,7 +409,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
             producer_logical.at(0), consumer_root.at(0));
       }
     } else {
-      NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");
+      NVF_THROW("Producer did not match any GroupedMmaOp input.");
     }
     return dom_map;
   }

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -378,7 +378,7 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     int64_t out_non_rk_last_idx = has_rk ? ndims_out - 2 : ndims_out - 1;
 
     int64_t last_producer_idx = std::ssize(producer_logical) - 1;
-    if (producer_tv_->sameAs(op->matrix1())) {
+    if (producer_tv_ == op->matrix1()) {
       // mapping m dimension;
       updatePairwiseLogicalDomainMap(
           producer_logical.at(last_producer_idx - 1),

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -413,7 +413,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));
       }
-      // mapping rk/k dimension;
+      // Note: since scale factor k' doesn't have to have the same extent as k,
+      // we only map it to rk/k dimension if map_different_extents_ is true.
       if (map_different_extents_ && has_rk) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(last_producer_idx), consumer_root.back());
@@ -428,7 +429,8 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
         updatePairwiseLogicalDomainMap(
             producer_logical.at(0), consumer_root.at(0));
       }
-      // mapping rk/k dimension;
+      // Note: since scale factor k' doesn't have to have the same extent as k,
+      // we only map it to rk/k dimension if map_different_extents_ is true.
       if (map_different_extents_ && has_rk) {
         updatePairwiseLogicalDomainMap(
             producer_logical.at(last_producer_idx - 1), consumer_root.back());

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -352,30 +352,34 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
   if (GroupedMmaOp* op =
           dynamic_cast<GroupedMmaOp*>(consumer_tv_->definition())) {
     auto ndims_out = consumer_root.size();
-    bool mapped = false;
-    int index_in = -1;
-    int index_out = -1;
     if (producer_tv_->sameAs(op->mat1())) {
       // mapping m dimension;
-      index_in = std::ssize(producer_logical) - 2;
-      index_out = std::ssize(consumer_root) - 2;
-      mapped = true;
+      updatePairwiseLogicalDomainMap(
+          producer_logical.at(std::ssize(producer_logical) - 2), consumer_root.at(std::ssize(consumer_root) - 2));
     } else if (producer_tv_->sameAs(op->mat2())) {
       // mapping k dimension;
-      index_in = std::ssize(producer_logical) - 1;
-      index_out = std::ssize(consumer_root) - 1;
-      mapped = true;
+      updatePairwiseLogicalDomainMap(
+          producer_logical.at(std::ssize(producer_logical) - 1), consumer_root.at(std::ssize(consumer_root) - 1));
     } else if (producer_tv_->sameAs(op->offsets())) {
       // mapping g dimension;
       if (ndims_out == 3) {
-        index_in = 0;
-        index_out = 0;
-        mapped = true;
-      }
-    }
-    if (mapped) {
       updatePairwiseLogicalDomainMap(
-          producer_logical.at(index_in), consumer_root.at(index_out));
+          producer_logical.at(0), consumer_root.at(0));
+      }
+    } else if (producer_tv_->sameAs(op->scale1())) {
+      if (ndims_out == 2) {
+        // mapping m dimension;
+        updatePairwiseLogicalDomainMap(
+            producer_logical.at(std::ssize(producer_logical) - 2), consumer_root.at(std::ssize(consumer_root) - 2));
+      }
+    } else if (producer_tv_->sameAs(op->scale2())) {
+      if (ndims_out == 2) {
+      // mapping k dimension;
+      updatePairwiseLogicalDomainMap(
+          producer_logical.at(std::ssize(producer_logical) - 1), consumer_root.at(std::ssize(consumer_root) - 1));
+      }
+    } else {
+      NVF_ERROR(false, "Producer did not match any GroupedMmaOp input.");
     }
     return dom_map;
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2352,7 +2352,7 @@ TensorView* createGroupedMmaOutput(
     out_domain.push_back(
         ops::newOutputIterDomain(
             {k_id_mat1, k_id_mat2},
-            /*force_iter_type=*/IterType::Reduction);
+            /*force_iter_type=*/IterType::Reduction));
   }
 
   auto* out = IrBuilder::create<TensorView>(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2355,15 +2355,15 @@ TensorView* scaled_grouped_mm(
     TensorView* offsets,
     TensorView* scale1,
     TensorView* scale2) {
-  // NOTE: backend has requirements for scale tensor's broadcast pattern.
-  NVF_CHECK(
-      scale1->nDims() == mat1->nDims(),
-      "scale1 needs to be the same rank as mat1");
-  NVF_CHECK(
-      scale2->nDims() == mat2->nDims(),
-      "scale2 needs to be the same rank as mat2");
 
   TensorView* out = create_grouped_mm_output(mat1, mat2, offsets);
+  NVF_CHECK(
+      scale1->nDims() == max(mat1->nDims(), out->nDims()),
+      "scale1 needs to be the same rank as mat1");
+  NVF_CHECK(
+      scale2->nDims() == max(mat2->nDims(), out->nDims()),
+      "scale2 needs to be the same rank as mat2");
+
   IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
 
   return out;

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2401,21 +2401,21 @@ TensorView* grouped_mm(
       "mat1 rank: ",
       mat1_rank,
       ", out rank: ",
-      out_rank);
+      out_rank,
       ", scale1 rank: ",
       scale1_rank);
-      NVF_CHECK_EQ(
-          scale2_rank,
-          std::max(mat2_rank, out_rank),
-          "mat2 rank: ",
-          mat2_rank,
-          ", out rank: ",
-          out_rank,
-          ", scale2 rank: ",
-          scale2_rank);
+  NVF_CHECK_EQ(
+      scale2_rank,
+      std::max(mat2_rank, out_rank),
+      "mat2 rank: ",
+      mat2_rank,
+      ", out rank: ",
+      out_rank,
+      ", scale2 rank: ",
+      scale2_rank);
 
-      IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
-      return out;
+  IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
+  return out;
 }
 
 TopKResult topk(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2316,7 +2316,7 @@ TensorView* create_grouped_mm_output(
 
   std::vector<IterDomain*> out_domain;
 
-  if (mat1->nDims() == 2 && mat2->nDims() == 2) {
+  if (mat1_domain.size() == 2 && mat2_domain.size() == 2) {
     out_domain = {
         offs_domain[0]->cloneWithoutRFactor(),
         mat1_domain[0]->cloneWithoutRFactor(),
@@ -2330,8 +2330,8 @@ TensorView* create_grouped_mm_output(
         mat1_domain[0]->cloneWithoutRFactor(),
         mat2_domain[2]->cloneWithoutRFactor()};
   } else {
-    NVF_ERROR(
-        false, "Two 3D tensors should use bmm/matmul instead of grouped_mm");
+    NVF_THROW(
+        "Unexpected operand ranks. If two 3D tensors, you should use bmm/matmul instead of grouped_mm: ", mat1, " and ", mat2);
   }
 
   auto* out = IrBuilder::create<TensorView>(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2395,14 +2395,12 @@ TensorView* grouped_mm(
   int64_t out_rank =
       std::ssize(TensorDomain::noReductions(out->getLogicalDomain()));
 
-  NVF_CHECK(
-      scale1_rank == std::max(mat1_rank, out_rank),
-      "scale 1 rank is incorrect, mat1 rank: ",
+  NVF_CHECK_EQ(
+      scale1_rank, std::max(mat1_rank, out_rank),
+      "mat1 rank: ",
       mat1_rank,
       ", out rank: ",
-      out_rank,
-      " but scale 1 rank: ",
-      scale1_rank);
+      out_rank);
   NVF_CHECK(
       scale2_rank == std::max(mat2_rank, out_rank),
       "scale 2 rank is incorrect, mat2 rank: ",

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2326,7 +2326,7 @@ TensorView* create_grouped_mm_output(
     mat1_domain[1]->cloneWithoutRFactor(),
     mat2_domain[1]->cloneWithoutRFactor()};
   } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
-    out_domain = 
+    out_domain = {
     mat1_domain[0]->cloneWithoutRFactor(),
     mat2_domain[2]->cloneWithoutRFactor()};
   } else {

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2358,10 +2358,10 @@ TensorView* scaled_grouped_mm(
 
   TensorView* out = create_grouped_mm_output(mat1, mat2, offsets);
   NVF_CHECK(
-      scale1->nDims() == max(mat1->nDims(), out->nDims()),
+      scale1->nDims() == std::max(mat1->nDims(), out->nDims()),
       "scale1 needs to be the same rank as mat1");
   NVF_CHECK(
-      scale2->nDims() == max(mat2->nDims(), out->nDims()),
+      scale2->nDims() == std::max(mat2->nDims(), out->nDims()),
       "scale2 needs to be the same rank as mat2");
 
   IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2317,18 +2317,18 @@ TensorView* create_grouped_mm_output(
   std::vector<IterDomain*> out_domain;
 
   if (mat1->nDims() == 2 && mat2->nDims() == 2) {
-    out_domain.reserve(3);
-    out_domain.push_back(offs_domain[0]->cloneWithoutRFactor());
-    out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
-    out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
+    out_domain = {
+    offs_domain[0]->cloneWithoutRFactor(),
+    mat1_domain[0]->cloneWithoutRFactor(),
+    mat2_domain[1]->cloneWithoutRFactor()};
   } else if (mat1->nDims() == 3 && mat2->nDims() == 2) {
-    out_domain.reserve(2);
-    out_domain.push_back(mat1_domain[1]->cloneWithoutRFactor());
-    out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
+    out_domain = {
+    mat1_domain[1]->cloneWithoutRFactor(),
+    mat2_domain[1]->cloneWithoutRFactor()};
   } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
-    out_domain.reserve(2);
-    out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
-    out_domain.push_back(mat2_domain[2]->cloneWithoutRFactor());
+    out_domain = 
+    mat1_domain[0]->cloneWithoutRFactor(),
+    mat2_domain[2]->cloneWithoutRFactor()};
   } else {
     NVF_ERROR(
         false, "Two 3D tensors should use bmm/matmul instead of grouped_mm");

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2349,10 +2349,9 @@ TensorView* createGroupedMmaOutput(
   // Following the semantics of matmul, output has a reduction axis rk if k is
   // not broadcast
   if (!k_id_mat1->isBroadcast()) {
-    out_domain.push_back(
-        ops::newOutputIterDomain(
-            {k_id_mat1, k_id_mat2},
-            /*force_iter_type=*/IterType::Reduction));
+    out_domain.push_back(ops::newOutputIterDomain(
+        {k_id_mat1, k_id_mat2},
+        /*force_iter_type=*/IterType::Reduction));
   }
 
   auto* out = IrBuilder::create<TensorView>(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2284,62 +2284,62 @@ TensorView* argsort(
 }
 
 namespace {
-  TensorView* create_grouped_mm_output(
+TensorView* create_grouped_mm_output(
     TensorView* mat1,
     TensorView* mat2,
     TensorView* offsets,
     std::optional<DataType> dtype) {
-    // Create output tensor for grouped matrix multiplication
-    // For simplicity, assume same structure as mat1 for batch dimensions
-    auto mat1_domain = TensorDomain::noReductions(mat1->getLogicalDomain());
-    auto mat2_domain = TensorDomain::noReductions(mat2->getLogicalDomain());
-    auto offs_domain = TensorDomain::noReductions(offsets->getLogicalDomain());
+  // Create output tensor for grouped matrix multiplication
+  // For simplicity, assume same structure as mat1 for batch dimensions
+  auto mat1_domain = TensorDomain::noReductions(mat1->getLogicalDomain());
+  auto mat2_domain = TensorDomain::noReductions(mat2->getLogicalDomain());
+  auto offs_domain = TensorDomain::noReductions(offsets->getLogicalDomain());
 
-    NVF_CHECK(offs_domain.size() == 1, "offsets needs to be 1-D for grouped mm");
+  NVF_CHECK(offs_domain.size() == 1, "offsets needs to be 1-D for grouped mm");
 
-    std::vector<IterDomain*> out_domain;
+  std::vector<IterDomain*> out_domain;
 
-    // For grouped MM, determine output shape based on mat1 and mat2 structures
-    // case 1:
-    //   mat1   [m, k]
-    //   mat2   [k, n]
-    //   offset [g]
-    //   output -> [g, m, n]
-    // case 2:
-    //   mat1   [g, m, k]
-    //   mat2   [k, n]
-    //   offset [g]
-    //   output -> [m, n]
-    // case 3:
-    //   mat1   [m, k]
-    //   mat2   [g, k, n]
-    //   offset [g]
-    //   output -> [m, n]
-    if (mat1->nDims() == 2 && mat2->nDims() == 2) {
-      out_domain.reserve(3);
-      out_domain.push_back(offs_domain[0]->cloneWithoutRFactor());
-      out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
-      out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
-    } else if (mat1->nDims() == 3 && mat2->nDims() == 2) {
-      out_domain.reserve(2);
-      out_domain.push_back(mat1_domain[1]->cloneWithoutRFactor());
-      out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
-    } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
-      out_domain.reserve(2);
-      out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
-      out_domain.push_back(mat2_domain[2]->cloneWithoutRFactor());
-    } else {
-      NVF_ERROR(
-          false, "Two 3D tensors should use bmm/matmul instead of grouped_mm");
-    }
-
-    TensorView* out = IrBuilder::create<TensorView>(
-        IrBuilder::create<TensorDomain>(
-            out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
-        dtype.has_value() ? dtype.value() : mat1->getDataType().value());
-    return out;
+  // For grouped MM, determine output shape based on mat1 and mat2 structures
+  // case 1:
+  //   mat1   [m, k]
+  //   mat2   [k, n]
+  //   offset [g]
+  //   output -> [g, m, n]
+  // case 2:
+  //   mat1   [g, m, k]
+  //   mat2   [k, n]
+  //   offset [g]
+  //   output -> [m, n]
+  // case 3:
+  //   mat1   [m, k]
+  //   mat2   [g, k, n]
+  //   offset [g]
+  //   output -> [m, n]
+  if (mat1->nDims() == 2 && mat2->nDims() == 2) {
+    out_domain.reserve(3);
+    out_domain.push_back(offs_domain[0]->cloneWithoutRFactor());
+    out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
+    out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
+  } else if (mat1->nDims() == 3 && mat2->nDims() == 2) {
+    out_domain.reserve(2);
+    out_domain.push_back(mat1_domain[1]->cloneWithoutRFactor());
+    out_domain.push_back(mat2_domain[1]->cloneWithoutRFactor());
+  } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
+    out_domain.reserve(2);
+    out_domain.push_back(mat1_domain[0]->cloneWithoutRFactor());
+    out_domain.push_back(mat2_domain[2]->cloneWithoutRFactor());
+  } else {
+    NVF_ERROR(
+        false, "Two 3D tensors should use bmm/matmul instead of grouped_mm");
   }
+
+  TensorView* out = IrBuilder::create<TensorView>(
+      IrBuilder::create<TensorDomain>(
+          out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
+      dtype.has_value() ? dtype.value() : mat1->getDataType().value());
+  return out;
 }
+} // namespace
 
 TensorView* grouped_mm(
     TensorView* mat1,
@@ -2348,7 +2348,6 @@ TensorView* grouped_mm(
     TensorView* scale1,
     TensorView* scale2,
     std::optional<DataType> dtype) {
-
   bool has_scale = scale1 != nullptr;
   NVF_CHECK(
       has_scale == (scale2 != nullptr),
@@ -2362,10 +2361,16 @@ TensorView* grouped_mm(
   if (has_scale) {
     NVF_CHECK(
         scale1->nDims() == std::max(mat1->nDims(), out->nDims()),
-        "scale1 rank is incorrect, mat1 rank: ", mat1->nDims(), " and out rank: ", out->nDims());
+        "scale1 rank is incorrect, mat1 rank: ",
+        mat1->nDims(),
+        " and out rank: ",
+        out->nDims());
     NVF_CHECK(
         scale2->nDims() == std::max(mat2->nDims(), out->nDims()),
-        "scale2 rank is incorrect, mat2 rank: ", mat2->nDims(), " and out rank: ", out->nDims());
+        "scale2 rank is incorrect, mat2 rank: ",
+        mat2->nDims(),
+        " and out rank: ",
+        out->nDims());
     IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
     return out;
   }

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2336,7 +2336,7 @@ TensorView* grouped_mm(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       mat1->getDataType().value());
 
-  IrBuilder::create<GroupedMMOp>(out, mat1, mat2, offsets);
+  IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets);
   return out;
 }
 

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2331,7 +2331,11 @@ TensorView* createGroupedMmaOutput(
         mat2_domain[2]->cloneWithoutRFactor()};
   } else {
     NVF_THROW(
-        "Unexpected operand ranks. If two 3D tensors, you should use bmm/matmul instead of grouped_mm: ", mat1, " and ", mat2);
+        "Unexpected operand ranks. If two 3D tensors, you should use "
+        "bmm/matmul instead of grouped_mm: ",
+        mat1,
+        " and ",
+        mat2);
   }
 
   auto* out = IrBuilder::create<TensorView>(
@@ -2364,11 +2368,16 @@ TensorView* grouped_mm(
     return out;
   }
 
-  int64_t scale1_rank = std::ssize(TensorDomain::noReductions(scale1->getLogicalDomain()));
-  int64_t scale2_rank = std::ssize(TensorDomain::noReductions(scale2->getLogicalDomain()));
-  int64_t mat1_rank = std::ssize(TensorDomain::noReductions(mat1->getLogicalDomain()));
-  int64_t mat2_rank = std::ssize(TensorDomain::noReductions(mat2->getLogicalDomain()));
-  int64_t out_rank = std::ssize(TensorDomain::noReductions(out->getLogicalDomain()));
+  int64_t scale1_rank =
+      std::ssize(TensorDomain::noReductions(scale1->getLogicalDomain()));
+  int64_t scale2_rank =
+      std::ssize(TensorDomain::noReductions(scale2->getLogicalDomain()));
+  int64_t mat1_rank =
+      std::ssize(TensorDomain::noReductions(mat1->getLogicalDomain()));
+  int64_t mat2_rank =
+      std::ssize(TensorDomain::noReductions(mat2->getLogicalDomain()));
+  int64_t out_rank =
+      std::ssize(TensorDomain::noReductions(out->getLogicalDomain()));
 
   NVF_CHECK(
       scale1_rank == std::max(mat1_rank, out_rank),

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2318,17 +2318,17 @@ TensorView* create_grouped_mm_output(
 
   if (mat1->nDims() == 2 && mat2->nDims() == 2) {
     out_domain = {
-    offs_domain[0]->cloneWithoutRFactor(),
-    mat1_domain[0]->cloneWithoutRFactor(),
-    mat2_domain[1]->cloneWithoutRFactor()};
+        offs_domain[0]->cloneWithoutRFactor(),
+        mat1_domain[0]->cloneWithoutRFactor(),
+        mat2_domain[1]->cloneWithoutRFactor()};
   } else if (mat1->nDims() == 3 && mat2->nDims() == 2) {
     out_domain = {
-    mat1_domain[1]->cloneWithoutRFactor(),
-    mat2_domain[1]->cloneWithoutRFactor()};
+        mat1_domain[1]->cloneWithoutRFactor(),
+        mat2_domain[1]->cloneWithoutRFactor()};
   } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
     out_domain = {
-    mat1_domain[0]->cloneWithoutRFactor(),
-    mat2_domain[2]->cloneWithoutRFactor()};
+        mat1_domain[0]->cloneWithoutRFactor(),
+        mat2_domain[2]->cloneWithoutRFactor()};
   } else {
     NVF_ERROR(
         false, "Two 3D tensors should use bmm/matmul instead of grouped_mm");

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2396,22 +2396,26 @@ TensorView* grouped_mm(
       std::ssize(TensorDomain::noReductions(out->getLogicalDomain()));
 
   NVF_CHECK_EQ(
-      scale1_rank, std::max(mat1_rank, out_rank),
+      scale1_rank,
+      std::max(mat1_rank, out_rank),
       "mat1 rank: ",
       mat1_rank,
       ", out rank: ",
       out_rank);
-  NVF_CHECK(
-      scale2_rank == std::max(mat2_rank, out_rank),
-      "scale 2 rank is incorrect, mat2 rank: ",
-      mat2_rank,
-      ", out rank: ",
-      out_rank,
-      " but scale 2 rank: ",
-      scale2_rank);
+      ", scale1 rank: ",
+      scale1_rank);
+      NVF_CHECK_EQ(
+          scale2_rank,
+          std::max(mat2_rank, out_rank),
+          "mat2 rank: ",
+          mat2_rank,
+          ", out rank: ",
+          out_rank,
+          ", scale2 rank: ",
+          scale2_rank);
 
-  IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
-  return out;
+      IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
+      return out;
 }
 
 TopKResult topk(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2339,11 +2339,17 @@ TensorView* grouped_mm(
       mat1->getDataType().value());
 
   bool has_scale = scale1 != nullptr;
-  NVF_CHECK(has_scale && (scale2 != nullptr), "scale1 and scale2 needs to be non-null or both null");
+  NVF_CHECK(
+      has_scale && (scale2 != nullptr),
+      "scale1 and scale2 needs to be non-null or both null");
   if (has_scale) {
     // NOTE: backend has requirements for scale tensor's broadcast pattern.
-    NVF_CHECK(scale1->nDims() == mat1->nDims(), "scale1 needs to be the same rank as mat1");
-    NVF_CHECK(scale2->nDims() == mat2->nDims(), "scale2 needs to be the same rank as mat2");
+    NVF_CHECK(
+        scale1->nDims() == mat1->nDims(),
+        "scale1 needs to be the same rank as mat1");
+    NVF_CHECK(
+        scale2->nDims() == mat2->nDims(),
+        "scale2 needs to be the same rank as mat2");
     IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets, scale1, scale2);
   } else {
     IrBuilder::create<GroupedMmaOp>(out, mat1, mat2, offsets);

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2321,11 +2321,11 @@ TensorView* createGroupedMmaOutput(
         offs_domain[0]->cloneWithoutRFactor(),
         mat1_domain[0]->cloneWithoutRFactor(),
         mat2_domain[1]->cloneWithoutRFactor()};
-  } else if (mat1->nDims() == 3 && mat2->nDims() == 2) {
+  } else if (mat1_domain.size() == 3 && mat2_domain.size() == 2) {
     out_domain = {
         mat1_domain[1]->cloneWithoutRFactor(),
         mat2_domain[1]->cloneWithoutRFactor()};
-  } else if (mat1->nDims() == 2 && mat2->nDims() == 3) {
+  } else if (mat1_domain.size() == 2 && mat2_domain.size() == 3) {
     out_domain = {
         mat1_domain[0]->cloneWithoutRFactor(),
         mat2_domain[2]->cloneWithoutRFactor()};

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -733,6 +733,7 @@ NVF_API TensorView* argsort(
     bool descending = false,
     bool stable = false);
 
+// TODO: I should remove this and wrap an overload in python binding.
 //! Grouped matrix multiplication
 //!
 //! Performs matrix multiplication on grouped sets of matrices using offsets
@@ -742,7 +743,7 @@ NVF_API TensorView* argsort(
 //! \param mat2 Second set of matrices
 //! \param offsets Offsets tensor defining group boundaries
 //! \return Result of grouped matrix multiplication
-NVF_API TensorView* scaled_grouped_mm(
+NVF_API TensorView* grouped_mm(
     TensorView* mat1,
     TensorView* mat2,
     TensorView* offsets);

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -749,7 +749,8 @@ NVF_API TensorView* grouped_mm(
     TensorView* mat2,
     TensorView* offsets,
     TensorView* scale1 = nullptr,
-    TensorView* scale2 = nullptr);
+    TensorView* scale2 = nullptr,
+    std::optional<DataType> dtype = std::nullopt);
 
 //! TopK operation: find the k largest or smallest elements along a dimension
 //!

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -741,15 +741,29 @@ NVF_API TensorView* argsort(
 //! \param mat1 First set of matrices
 //! \param mat2 Second set of matrices
 //! \param offsets Offsets tensor defining group boundaries
+//! \return Result of grouped matrix multiplication
+NVF_API TensorView* scaled_grouped_mm(
+    TensorView* mat1,
+    TensorView* mat2,
+    TensorView* offsets);
+
+//! Grouped matrix multiplication
+//!
+//! Performs matrix multiplication on grouped sets of matrices using offsets
+//! to define variable-sized groups.
+//!
+//! \param mat1 First set of matrices
+//! \param mat2 Second set of matrices
+//! \param offsets Offsets tensor defining group boundaries
 //! \param scale1 Scale tensor for mat1
 //! \param scale2 Scale tensor for mat2
 //! \return Result of grouped matrix multiplication
-NVF_API TensorView* grouped_mm(
+NVF_API TensorView* scaled_grouped_mm(
     TensorView* mat1,
     TensorView* mat2,
     TensorView* offsets,
-    TensorView* scale1 = nullptr,
-    TensorView* scale2 = nullptr);
+    TensorView* scale1,
+    TensorView* scale2);
 
 //! TopK operation: find the k largest or smallest elements along a dimension
 //!

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -733,21 +733,6 @@ NVF_API TensorView* argsort(
     bool descending = false,
     bool stable = false);
 
-// TODO: I should remove this and wrap an overload in python binding.
-//! Grouped matrix multiplication
-//!
-//! Performs matrix multiplication on grouped sets of matrices using offsets
-//! to define variable-sized groups.
-//!
-//! \param mat1 First set of matrices
-//! \param mat2 Second set of matrices
-//! \param offsets Offsets tensor defining group boundaries
-//! \return Result of grouped matrix multiplication
-NVF_API TensorView* grouped_mm(
-    TensorView* mat1,
-    TensorView* mat2,
-    TensorView* offsets);
-
 //! Grouped matrix multiplication
 //!
 //! Performs matrix multiplication on grouped sets of matrices using offsets
@@ -759,12 +744,12 @@ NVF_API TensorView* grouped_mm(
 //! \param scale1 Scale tensor for mat1
 //! \param scale2 Scale tensor for mat2
 //! \return Result of grouped matrix multiplication
-NVF_API TensorView* scaled_grouped_mm(
+NVF_API TensorView* grouped_mm(
     TensorView* mat1,
     TensorView* mat2,
     TensorView* offsets,
-    TensorView* scale1,
-    TensorView* scale2);
+    TensorView* scale1 = nullptr,
+    TensorView* scale2 = nullptr);
 
 //! TopK operation: find the k largest or smallest elements along a dimension
 //!

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -741,11 +741,15 @@ NVF_API TensorView* argsort(
 //! \param mat1 First set of matrices
 //! \param mat2 Second set of matrices
 //! \param offsets Offsets tensor defining group boundaries
+//! \param scale1 Scale tensor for mat1
+//! \param scale2 Scale tensor for mat2
 //! \return Result of grouped matrix multiplication
 NVF_API TensorView* grouped_mm(
     TensorView* mat1,
     TensorView* mat2,
-    TensorView* offsets);
+    TensorView* offsets,
+    TensorView* scale1 = nullptr,
+    TensorView* scale2 = nullptr);
 
 //! TopK operation: find the k largest or smallest elements along a dimension
 //!

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -70,7 +70,7 @@ bool ExprEvalScheduler::canScheduleCompileTime(Fusion* fusion) {
               EmbeddingFwdOp,
               IndexPutAccumulateOp,
               ArgsortOp,
-              GroupedMMOp,
+              GroupedMmaOp,
               TopKOp>()) {
     return true;
   }

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -43,7 +43,7 @@ bool checkCanSchedule(Fusion* fusion, SchedulerType scheduler_type) {
           EmbeddingFwdOp,
           IndexPutAccumulateOp,
           ArgsortOp,
-          GroupedMMOp,
+          GroupedMmaOp,
           TopKOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
         scheduler_type, "Has unsupported ops");

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -132,7 +132,7 @@ union RecordData {
   Welford,
   Sort,
   TopK,
-  GroupedMma,
+  ScaledGroupedMma,
 }
 
 // The PolymorphicValueData union holds the attribute information for each PolymorphicValue.
@@ -366,8 +366,8 @@ table TopK {
   sorted: bool;
 }
 
-// Data for GroupedMma
-table GroupedMma {
+// Data for ScaledGroupedMmaOpRecord
+table ScaledGroupedMma {
   dtype: long;
 }
 

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -87,6 +87,7 @@ enum RecordType: int {
     ReductionSum,
     ReshapeOp,
     Scalar,
+    ScaledGroupedMmaOp,
     SdpaFwdOp,
     SdpaBwdOp,
     ShapeOp,

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -132,6 +132,7 @@ union RecordData {
   Welford,
   Sort,
   TopK,
+  GroupedMma,
 }
 
 // The PolymorphicValueData union holds the attribute information for each PolymorphicValue.
@@ -363,6 +364,11 @@ table TopK {
   dim: long;
   largest: bool;
   sorted: bool;
+}
+
+// Data for GroupedMma
+table GroupedMma {
+  dtype: long;
 }
 
 // =====================================================================================

--- a/csrc/serde/fusion_record.cpp
+++ b/csrc/serde/fusion_record.cpp
@@ -853,10 +853,11 @@ void RecordFunctorFactory::setupFunctionMaps() {
   NVFUSER_UNARY_TV_ALPHA_OP("triu", triu)
 
   NVFUSER_BINARY_TV_ONLY_OP("matmul", matmul)
-  NVFUSER_TERNARY_TV_ONLY_OP("grouped_mm",
-    [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
+  NVFUSER_TERNARY_TV_ONLY_OP(
+      "grouped_mm",
+      [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
         return grouped_mm(mat1, mat2, offsets);
-})
+      })
   NVFUSER_BINARY_TV_ONLY_OP("linear", linear)
   NVFUSER_TERNARY_TV_ONLY_OP("linear", linear)
 

--- a/csrc/serde/fusion_record.cpp
+++ b/csrc/serde/fusion_record.cpp
@@ -853,7 +853,10 @@ void RecordFunctorFactory::setupFunctionMaps() {
   NVFUSER_UNARY_TV_ALPHA_OP("triu", triu)
 
   NVFUSER_BINARY_TV_ONLY_OP("matmul", matmul)
-  NVFUSER_TERNARY_TV_ONLY_OP("grouped_mm", grouped_mm)
+  NVFUSER_TERNARY_TV_ONLY_OP("grouped_mm",
+    [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
+        return grouped_mm(mat1, mat2, offsets);
+})
   NVFUSER_BINARY_TV_ONLY_OP("linear", linear)
   NVFUSER_TERNARY_TV_ONLY_OP("linear", linear)
 

--- a/python/nvfuser/testing/utils.py
+++ b/python/nvfuser/testing/utils.py
@@ -88,6 +88,8 @@ map_dtype_to_str = {
     torch.int16: "int16",
     torch.int32: "int32",
     torch.int64: "int64",
+    torch.float8_e4m3fn: "float8_e4m3fn",
+    torch.float8_e5m2: "float8_e5m2",
     torch.bfloat16: "bfloat16",
     torch.float16: "float16",
     torch.float32: "float32",

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -1601,21 +1601,32 @@ struct ReductionOpRecord : RecordFunctor {
         result = result &&
             (*fusion_op_.template target<
 
-                 TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>() ==
+                 TensorView* (*)(TensorView*,
+                                 const std::vector<int64_t>&,
+                                 bool,
+                                 DataType)>() ==
              *child_ptr->fusion_op_.template target<
 
-                 TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>());
+                 TensorView* (*)(TensorView*,
+                                 const std::vector<int64_t>&,
+                                 bool,
+                                 DataType)>());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          debug()
-              << " Target  Ptr [self: 0x" << std::hex
-              << (size_t)*fusion_op_.template target<
+          debug() << " Target  Ptr [self: 0x" << std::hex
+                  << (size_t)*fusion_op_.template target<
 
-                     TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>()
-              << "] [other: 0x" << std::hex
-              << (size_t)*child_ptr->fusion_op_.template target<
+                         TensorView* (*)(TensorView*,
+                                         const std::vector<int64_t>&,
+                                         bool,
+                                         DataType)>()
+                  << "] [other: 0x" << std::hex
+                  << (size_t)*child_ptr->fusion_op_.template target<
 
-                     TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>()
-              << "]\n";
+                         TensorView* (*)(TensorView*,
+                                         const std::vector<int64_t>&,
+                                         bool,
+                                         DataType)>()
+                  << "]\n";
         }
         result = result && (keep_dim_ == child_ptr->keep_dim_);
         result = result && (dtype_ == child_ptr->dtype_);

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3282,7 +3282,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     auto scale1 = fd.getFusionState(args_.at(3).index)->template as<TensorView>();
     auto scale2 = fd.getFusionState(args_.at(4).index)->template as<TensorView>();
     auto output = scaled_grouped_mm(mat1, mat2, offsets, scale1, scale2);
-    fd.setFusionState(outputs.at(0).index, output);
+    fd.setFusionState(outputs().at(0).index, output);
   }
 };
 

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3319,7 +3319,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
   std::pair<serde::RecordData, flatbuffers::Offset<void>> recordData(
       flatbuffers::FlatBufferBuilder& builder) const final {
     return {
-        serde::RecordData::GroupedMma,
+        serde::RecordData::ScaledGroupedMma,
         serde::CreateVector(builder, nvfuser::toUnderlying(dtype_)).Union()};
   };
 

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3264,15 +3264,45 @@ struct TopKOpRecord : RecordFunctor {
 struct ScaledGroupedMmaOpRecord : RecordFunctor {
   ScaledGroupedMmaOpRecord(
       std::vector<State> _args,
-      std::vector<State> _outputs)
+      std::vector<State> _outputs,
+      std::optional<PrimDataType> dtype)
       : RecordFunctor(
             std::move(_args),
             std::move(_outputs),
             "ops.grouped_mm",
-            serde::RecordType::ScaledGroupedMmaOp) {}
+            serde::RecordType::ScaledGroupedMmaOp),
+        dtype_(
+            dtype.has_value()
+                ? dtype.value()
+                : PrimDataType::Half) {}
   ~ScaledGroupedMmaOpRecord() override = default;
   RecordFunctor* clone() final {
     return new ScaledGroupedMmaOpRecord(*this);
+  }
+
+  //! Child specific hash function in lower 32 bits.
+  //! | 31 ---------------------------------------  0 |
+  //! | Dtype                                         |
+  size_t hash() const final {
+    auto result = RecordFunctor::hash();
+    return result | (static_cast<size_t>(dtype_) & 0xffffffff);
+  }
+  
+  bool operator==(const RecordFunctor& other) const final {
+    auto result = false;
+    if (auto child_ptr = dynamic_cast<const ScaledGroupedMmaOpRecord*>(&other)) {
+      result = RecordFunctor::operator==(other);
+      result = result && (dtype_ == child_ptr->dtype_);
+    }
+    return result;
+  }
+
+  void print(std::ostream& os, bool close_function = true) const final {
+    RecordFunctor::print(os, false);
+    os << ", dtype=" << dtypeToPyString(dtype_);
+    if (close_function) {
+      os << ")";
+    }
   }
 
   void operator()(FusionState& fd) final {
@@ -3281,9 +3311,18 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     auto offsets = fd.getFusionState(args_.at(2).index)->template as<TensorView>();
     auto scale1 = fd.getFusionState(args_.at(3).index)->template as<TensorView>();
     auto scale2 = fd.getFusionState(args_.at(4).index)->template as<TensorView>();
-    auto output = grouped_mm(mat1, mat2, offsets, scale1, scale2);
+    auto output = grouped_mm(mat1, mat2, offsets, scale1, scale2, dtype_);
     fd.setFusionState(outputs().at(0).index, output);
   }
+
+  std::pair<serde::RecordData, flatbuffers::Offset<void>> recordData(
+    flatbuffers::FlatBufferBuilder& builder) const final {
+  return {
+      serde::RecordData::GroupedMma,
+      serde::CreateVector(builder, nvfuser::toUnderlying(dtype_)).Union()};
+  };
+
+  PrimDataType dtype_;
 };
 
 } // namespace nvfuser::python_frontend

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3268,7 +3268,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
       : RecordFunctor(
             std::move(_args),
             std::move(_outputs),
-            "ops.scaled_grouped_mm",
+            "ops.grouped_mm",
             serde::RecordType::ScaledGroupedMmaOp) {}
   ~ScaledGroupedMmaOpRecord() override = default;
   RecordFunctor* clone() final {
@@ -3281,7 +3281,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     auto offsets = fd.getFusionState(args_.at(2).index)->template as<TensorView>();
     auto scale1 = fd.getFusionState(args_.at(3).index)->template as<TensorView>();
     auto scale2 = fd.getFusionState(args_.at(4).index)->template as<TensorView>();
-    auto output = scaled_grouped_mm(mat1, mat2, offsets, scale1, scale2);
+    auto output = grouped_mm(mat1, mat2, offsets, scale1, scale2);
     fd.setFusionState(outputs().at(0).index, output);
   }
 };

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3275,13 +3275,6 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     return new ScaledGroupedMmaOpRecord(*this);
   }
 
-  bool operator==(const RecordFunctor& other) const final {
-    if (auto other_topk = dynamic_cast<const ScaledGroupedMmaOpRecord*>(&other)) {
-      return RecordFunctor::operator==(other);
-    }
-    return false;
-  }
-
   void operator()(FusionState& fd) final {
     auto mat1 = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
     auto mat2 = fd.getFusionState(args_.at(1).index)->template as<TensorView>();
@@ -3289,7 +3282,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     auto scale1 = fd.getFusionState(args_.at(3).index)->template as<TensorView>();
     auto scale2 = fd.getFusionState(args_.at(4).index)->template as<TensorView>();
     auto output = scaled_grouped_mm(mat1, mat2, offsets, scale1, scale2);
-    fd.setFusionState(output.index, output.indices);
+    fd.setFusionState(outputs.at(0).index, output);
   }
 };
 

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -1601,32 +1601,21 @@ struct ReductionOpRecord : RecordFunctor {
         result = result &&
             (*fusion_op_.template target<
 
-                 TensorView* (*)(TensorView*,
-                                 const std::vector<int64_t>&,
-                                 bool,
-                                 DataType)>() ==
+                 TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>() ==
              *child_ptr->fusion_op_.template target<
 
-                 TensorView* (*)(TensorView*,
-                                 const std::vector<int64_t>&,
-                                 bool,
-                                 DataType)>());
+                 TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>());
         if (isDebugDumpEnabled(DebugDumpOption::PythonFrontendDebug)) {
-          debug() << " Target  Ptr [self: 0x" << std::hex
-                  << (size_t)*fusion_op_.template target<
+          debug()
+              << " Target  Ptr [self: 0x" << std::hex
+              << (size_t)*fusion_op_.template target<
 
-                         TensorView* (*)(TensorView*,
-                                         const std::vector<int64_t>&,
-                                         bool,
-                                         DataType)>()
-                  << "] [other: 0x" << std::hex
-                  << (size_t)*child_ptr->fusion_op_.template target<
+                     TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>()
+              << "] [other: 0x" << std::hex
+              << (size_t)*child_ptr->fusion_op_.template target<
 
-                         TensorView* (*)(TensorView*,
-                                         const std::vector<int64_t>&,
-                                         bool,
-                                         DataType)>()
-                  << "]\n";
+                     TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>()
+              << "]\n";
         }
         result = result && (keep_dim_ == child_ptr->keep_dim_);
         result = result && (dtype_ == child_ptr->dtype_);
@@ -3271,10 +3260,7 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
             std::move(_outputs),
             "ops.grouped_mm",
             serde::RecordType::ScaledGroupedMmaOp),
-        dtype_(
-            dtype.has_value()
-                ? dtype.value()
-                : PrimDataType::Half) {}
+        dtype_(dtype.has_value() ? dtype.value() : PrimDataType::Half) {}
   ~ScaledGroupedMmaOpRecord() override = default;
   RecordFunctor* clone() final {
     return new ScaledGroupedMmaOpRecord(*this);
@@ -3287,10 +3273,11 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
     auto result = RecordFunctor::hash();
     return result | (static_cast<size_t>(dtype_) & 0xffffffff);
   }
-  
+
   bool operator==(const RecordFunctor& other) const final {
     auto result = false;
-    if (auto child_ptr = dynamic_cast<const ScaledGroupedMmaOpRecord*>(&other)) {
+    if (auto child_ptr =
+            dynamic_cast<const ScaledGroupedMmaOpRecord*>(&other)) {
       result = RecordFunctor::operator==(other);
       result = result && (dtype_ == child_ptr->dtype_);
     }
@@ -3308,18 +3295,21 @@ struct ScaledGroupedMmaOpRecord : RecordFunctor {
   void operator()(FusionState& fd) final {
     auto mat1 = fd.getFusionState(args_.at(0).index)->template as<TensorView>();
     auto mat2 = fd.getFusionState(args_.at(1).index)->template as<TensorView>();
-    auto offsets = fd.getFusionState(args_.at(2).index)->template as<TensorView>();
-    auto scale1 = fd.getFusionState(args_.at(3).index)->template as<TensorView>();
-    auto scale2 = fd.getFusionState(args_.at(4).index)->template as<TensorView>();
+    auto offsets =
+        fd.getFusionState(args_.at(2).index)->template as<TensorView>();
+    auto scale1 =
+        fd.getFusionState(args_.at(3).index)->template as<TensorView>();
+    auto scale2 =
+        fd.getFusionState(args_.at(4).index)->template as<TensorView>();
     auto output = grouped_mm(mat1, mat2, offsets, scale1, scale2, dtype_);
     fd.setFusionState(outputs().at(0).index, output);
   }
 
   std::pair<serde::RecordData, flatbuffers::Offset<void>> recordData(
-    flatbuffers::FlatBufferBuilder& builder) const final {
-  return {
-      serde::RecordData::GroupedMma,
-      serde::CreateVector(builder, nvfuser::toUnderlying(dtype_)).Union()};
+      flatbuffers::FlatBufferBuilder& builder) const final {
+    return {
+        serde::RecordData::GroupedMma,
+        serde::CreateVector(builder, nvfuser::toUnderlying(dtype_)).Union()};
   };
 
   PrimDataType dtype_;

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -2547,100 +2547,97 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_TERNARY_WITH_ALPHA_OP("addcmul", addcmul)
 #undef NVFUSER_PYTHON_BINDING_TERNARY_WITH_ALPHA_OP
 
-#define NVFUSER_PYTHON_BINDING_REDUCTION_OP(op_str, op_name, record_type)     \
-  nvf_ops.def(                                                                \
-      op_str,                                                                 \
-      [](FusionDefinition::Operators& self,                                   \
-         Tensor arg,                                                          \
-         PrimDataType dtype) -> Tensor {                                      \
-        FUSER_PERF_SCOPE("Operators." op_str);                                \
-        NVF_CHECK(                                                            \
-            self.validUse(), "Attempting to add to a completed definition!"); \
-        FusionDefinition* fd = self.fusion_definition;                        \
-        size_t ndims = 0;                                                     \
-        std::vector<int64_t> dims(arg.dims);                                  \
-        std::iota(dims.begin(), dims.end(), 0);                               \
-        Tensor output = fd->defineTensor(ndims);                              \
-        fd->defineRecord(new ReductionOpRecord(                               \
-            {fd->recordingState(arg())},                                      \
-            {fd->recordingState(output())},                                   \
-            ("ops." op_str),                                                  \
-            record_type,                                                      \
-            static_cast<TensorView* (*)(TensorView*,                          \
-                                        const std::vector<int64_t>&,          \
-                                        bool,                                 \
-                                        DataType)>(op_name),                  \
-            dims,                                                             \
-            false,                                                            \
-            dtype));                                                          \
-        return output;                                                        \
-      },                                                                      \
-      py::arg("arg"),                                                         \
-      py::arg("dtype") = DataType::Null,                                      \
-      py::return_value_policy::reference);                                    \
-  nvf_ops.def(                                                                \
-      op_str,                                                                 \
-      [](FusionDefinition::Operators& self,                                   \
-         Tensor arg,                                                          \
-         int dim,                                                             \
-         bool keepdim,                                                        \
-         PrimDataType dtype) -> Tensor {                                      \
-        FUSER_PERF_SCOPE("Operators." op_str);                                \
-        NVF_CHECK(                                                            \
-            self.validUse(), "Attempting to add to a completed definition!"); \
-        FusionDefinition* fd = self.fusion_definition;                        \
-        size_t ndims = keepdim ? arg.dims : (arg.dims - 1);                   \
-        Tensor output = fd->defineTensor(ndims);                              \
-        fd->defineRecord(new ReductionOpRecord(                               \
-            {fd->recordingState(arg())},                                      \
-            {fd->recordingState(output())},                                   \
-            ("ops." op_str),                                                  \
-            record_type,                                                      \
-            static_cast<TensorView* (*)(TensorView*,                          \
-                                        const std::vector<int64_t>&,          \
-                                        bool,                                 \
-                                        DataType)>(op_name),                  \
-            {dim},                                                            \
-            keepdim,                                                          \
-            dtype));                                                          \
-        return output;                                                        \
-      },                                                                      \
-      py::arg("arg"),                                                         \
-      py::arg("dim"),                                                         \
-      py::arg("keepdim") = false,                                             \
-      py::arg("dtype") = DataType::Null,                                      \
-      py::return_value_policy::reference);                                    \
-  nvf_ops.def(                                                                \
-      op_str,                                                                 \
-      [](FusionDefinition::Operators& self,                                   \
-         Tensor arg,                                                          \
-         const std::vector<int64_t>& dims,                                    \
-         bool keepdim,                                                        \
-         PrimDataType dtype) -> Tensor {                                      \
-        FUSER_PERF_SCOPE("Operators." op_str);                                \
-        NVF_CHECK(                                                            \
-            self.validUse(), "Attempting to add to a completed definition!"); \
-        FusionDefinition* fd = self.fusion_definition;                        \
-        size_t ndims = keepdim ? arg.dims : (arg.dims - dims.size());         \
-        Tensor output = fd->defineTensor(ndims);                              \
-        fd->defineRecord(new ReductionOpRecord(                               \
-            {fd->recordingState(arg())},                                      \
-            {fd->recordingState(output())},                                   \
-            ("ops." op_str),                                                  \
-            record_type,                                                      \
-            static_cast<TensorView* (*)(TensorView*,                          \
-                                        const std::vector<int64_t>&,          \
-                                        bool,                                 \
-                                        DataType)>(op_name),                  \
-            dims,                                                             \
-            keepdim,                                                          \
-            dtype));                                                          \
-        return output;                                                        \
-      },                                                                      \
-      py::arg("arg"),                                                         \
-      py::arg("dims"),                                                        \
-      py::arg("keepdim") = false,                                             \
-      py::arg("dtype") = DataType::Null,                                      \
+#define NVFUSER_PYTHON_BINDING_REDUCTION_OP(op_str, op_name, record_type)                   \
+  nvf_ops.def(                                                                              \
+      op_str,                                                                               \
+      [](FusionDefinition::Operators& self,                                                 \
+         Tensor arg,                                                                        \
+         PrimDataType dtype) -> Tensor {                                                    \
+        FUSER_PERF_SCOPE("Operators." op_str);                                              \
+        NVF_CHECK(                                                                          \
+            self.validUse(), "Attempting to add to a completed definition!");               \
+        FusionDefinition* fd = self.fusion_definition;                                      \
+        size_t ndims = 0;                                                                   \
+        std::vector<int64_t> dims(arg.dims);                                                \
+        std::iota(dims.begin(), dims.end(), 0);                                             \
+        Tensor output = fd->defineTensor(ndims);                                            \
+        fd->defineRecord(new ReductionOpRecord(                                             \
+            {fd->recordingState(arg())},                                                    \
+            {fd->recordingState(output())},                                                 \
+            ("ops." op_str),                                                                \
+            record_type,                                                                    \
+            static_cast<                                                                    \
+                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
+                op_name),                                                                   \
+            dims,                                                                           \
+            false,                                                                          \
+            dtype));                                                                        \
+        return output;                                                                      \
+      },                                                                                    \
+      py::arg("arg"),                                                                       \
+      py::arg("dtype") = DataType::Null,                                                    \
+      py::return_value_policy::reference);                                                  \
+  nvf_ops.def(                                                                              \
+      op_str,                                                                               \
+      [](FusionDefinition::Operators& self,                                                 \
+         Tensor arg,                                                                        \
+         int dim,                                                                           \
+         bool keepdim,                                                                      \
+         PrimDataType dtype) -> Tensor {                                                    \
+        FUSER_PERF_SCOPE("Operators." op_str);                                              \
+        NVF_CHECK(                                                                          \
+            self.validUse(), "Attempting to add to a completed definition!");               \
+        FusionDefinition* fd = self.fusion_definition;                                      \
+        size_t ndims = keepdim ? arg.dims : (arg.dims - 1);                                 \
+        Tensor output = fd->defineTensor(ndims);                                            \
+        fd->defineRecord(new ReductionOpRecord(                                             \
+            {fd->recordingState(arg())},                                                    \
+            {fd->recordingState(output())},                                                 \
+            ("ops." op_str),                                                                \
+            record_type,                                                                    \
+            static_cast<                                                                    \
+                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
+                op_name),                                                                   \
+            {dim},                                                                          \
+            keepdim,                                                                        \
+            dtype));                                                                        \
+        return output;                                                                      \
+      },                                                                                    \
+      py::arg("arg"),                                                                       \
+      py::arg("dim"),                                                                       \
+      py::arg("keepdim") = false,                                                           \
+      py::arg("dtype") = DataType::Null,                                                    \
+      py::return_value_policy::reference);                                                  \
+  nvf_ops.def(                                                                              \
+      op_str,                                                                               \
+      [](FusionDefinition::Operators& self,                                                 \
+         Tensor arg,                                                                        \
+         const std::vector<int64_t>& dims,                                                  \
+         bool keepdim,                                                                      \
+         PrimDataType dtype) -> Tensor {                                                    \
+        FUSER_PERF_SCOPE("Operators." op_str);                                              \
+        NVF_CHECK(                                                                          \
+            self.validUse(), "Attempting to add to a completed definition!");               \
+        FusionDefinition* fd = self.fusion_definition;                                      \
+        size_t ndims = keepdim ? arg.dims : (arg.dims - dims.size());                       \
+        Tensor output = fd->defineTensor(ndims);                                            \
+        fd->defineRecord(new ReductionOpRecord(                                             \
+            {fd->recordingState(arg())},                                                    \
+            {fd->recordingState(output())},                                                 \
+            ("ops." op_str),                                                                \
+            record_type,                                                                    \
+            static_cast<                                                                    \
+                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
+                op_name),                                                                   \
+            dims,                                                                           \
+            keepdim,                                                                        \
+            dtype));                                                                        \
+        return output;                                                                      \
+      },                                                                                    \
+      py::arg("arg"),                                                                       \
+      py::arg("dims"),                                                                      \
+      py::arg("keepdim") = false,                                                           \
+      py::arg("dtype") = DataType::Null,                                                    \
       py::return_value_policy::reference);
 
   NVFUSER_PYTHON_BINDING_REDUCTION_OP(
@@ -3683,9 +3680,11 @@ void initNvFuserPythonBindings(PyObject* module) {
                 serde::RecordType::Ternary_TV,
                 static_cast<
                     TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
-                    [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
-                        return grouped_mm(mat1, mat2, offsets);
-                })));
+                    [](TensorView* mat1,
+                       TensorView* mat2,
+                       TensorView* offsets) {
+                      return grouped_mm(mat1, mat2, offsets);
+                    })));
         return output;
       },
       R"(
@@ -3725,15 +3724,14 @@ void initNvFuserPythonBindings(PyObject* module) {
         size_t output_dims = mat1.dims == 2 && mat2.dims == 2 ? 3 : 2;
         Tensor output = fd->defineTensor(output_dims);
 
-        fd->defineRecord(
-            new ScaledGroupedMmaOpRecord(
-                {fd->recordingState(mat1()),
-                 fd->recordingState(mat2()),
-                 fd->recordingState(offsets()),
-                 fd->recordingState(scale1()),
-                 fd->recordingState(scale2())},
-                {fd->recordingState(output())},
-                 dtype));
+        fd->defineRecord(new ScaledGroupedMmaOpRecord(
+            {fd->recordingState(mat1()),
+             fd->recordingState(mat2()),
+             fd->recordingState(offsets()),
+             fd->recordingState(scale1()),
+             fd->recordingState(scale2())},
+            {fd->recordingState(output())},
+            dtype));
         return output;
       },
       R"(

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -2547,97 +2547,100 @@ void initNvFuserPythonBindings(PyObject* module) {
   NVFUSER_PYTHON_BINDING_TERNARY_WITH_ALPHA_OP("addcmul", addcmul)
 #undef NVFUSER_PYTHON_BINDING_TERNARY_WITH_ALPHA_OP
 
-#define NVFUSER_PYTHON_BINDING_REDUCTION_OP(op_str, op_name, record_type)                   \
-  nvf_ops.def(                                                                              \
-      op_str,                                                                               \
-      [](FusionDefinition::Operators& self,                                                 \
-         Tensor arg,                                                                        \
-         PrimDataType dtype) -> Tensor {                                                    \
-        FUSER_PERF_SCOPE("Operators." op_str);                                              \
-        NVF_CHECK(                                                                          \
-            self.validUse(), "Attempting to add to a completed definition!");               \
-        FusionDefinition* fd = self.fusion_definition;                                      \
-        size_t ndims = 0;                                                                   \
-        std::vector<int64_t> dims(arg.dims);                                                \
-        std::iota(dims.begin(), dims.end(), 0);                                             \
-        Tensor output = fd->defineTensor(ndims);                                            \
-        fd->defineRecord(new ReductionOpRecord(                                             \
-            {fd->recordingState(arg())},                                                    \
-            {fd->recordingState(output())},                                                 \
-            ("ops." op_str),                                                                \
-            record_type,                                                                    \
-            static_cast<                                                                    \
-                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
-                op_name),                                                                   \
-            dims,                                                                           \
-            false,                                                                          \
-            dtype));                                                                        \
-        return output;                                                                      \
-      },                                                                                    \
-      py::arg("arg"),                                                                       \
-      py::arg("dtype") = DataType::Null,                                                    \
-      py::return_value_policy::reference);                                                  \
-  nvf_ops.def(                                                                              \
-      op_str,                                                                               \
-      [](FusionDefinition::Operators& self,                                                 \
-         Tensor arg,                                                                        \
-         int dim,                                                                           \
-         bool keepdim,                                                                      \
-         PrimDataType dtype) -> Tensor {                                                    \
-        FUSER_PERF_SCOPE("Operators." op_str);                                              \
-        NVF_CHECK(                                                                          \
-            self.validUse(), "Attempting to add to a completed definition!");               \
-        FusionDefinition* fd = self.fusion_definition;                                      \
-        size_t ndims = keepdim ? arg.dims : (arg.dims - 1);                                 \
-        Tensor output = fd->defineTensor(ndims);                                            \
-        fd->defineRecord(new ReductionOpRecord(                                             \
-            {fd->recordingState(arg())},                                                    \
-            {fd->recordingState(output())},                                                 \
-            ("ops." op_str),                                                                \
-            record_type,                                                                    \
-            static_cast<                                                                    \
-                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
-                op_name),                                                                   \
-            {dim},                                                                          \
-            keepdim,                                                                        \
-            dtype));                                                                        \
-        return output;                                                                      \
-      },                                                                                    \
-      py::arg("arg"),                                                                       \
-      py::arg("dim"),                                                                       \
-      py::arg("keepdim") = false,                                                           \
-      py::arg("dtype") = DataType::Null,                                                    \
-      py::return_value_policy::reference);                                                  \
-  nvf_ops.def(                                                                              \
-      op_str,                                                                               \
-      [](FusionDefinition::Operators& self,                                                 \
-         Tensor arg,                                                                        \
-         const std::vector<int64_t>& dims,                                                  \
-         bool keepdim,                                                                      \
-         PrimDataType dtype) -> Tensor {                                                    \
-        FUSER_PERF_SCOPE("Operators." op_str);                                              \
-        NVF_CHECK(                                                                          \
-            self.validUse(), "Attempting to add to a completed definition!");               \
-        FusionDefinition* fd = self.fusion_definition;                                      \
-        size_t ndims = keepdim ? arg.dims : (arg.dims - dims.size());                       \
-        Tensor output = fd->defineTensor(ndims);                                            \
-        fd->defineRecord(new ReductionOpRecord(                                             \
-            {fd->recordingState(arg())},                                                    \
-            {fd->recordingState(output())},                                                 \
-            ("ops." op_str),                                                                \
-            record_type,                                                                    \
-            static_cast<                                                                    \
-                TensorView* (*)(TensorView*, const std::vector<int64_t>&, bool, DataType)>( \
-                op_name),                                                                   \
-            dims,                                                                           \
-            keepdim,                                                                        \
-            dtype));                                                                        \
-        return output;                                                                      \
-      },                                                                                    \
-      py::arg("arg"),                                                                       \
-      py::arg("dims"),                                                                      \
-      py::arg("keepdim") = false,                                                           \
-      py::arg("dtype") = DataType::Null,                                                    \
+#define NVFUSER_PYTHON_BINDING_REDUCTION_OP(op_str, op_name, record_type)     \
+  nvf_ops.def(                                                                \
+      op_str,                                                                 \
+      [](FusionDefinition::Operators& self,                                   \
+         Tensor arg,                                                          \
+         PrimDataType dtype) -> Tensor {                                      \
+        FUSER_PERF_SCOPE("Operators." op_str);                                \
+        NVF_CHECK(                                                            \
+            self.validUse(), "Attempting to add to a completed definition!"); \
+        FusionDefinition* fd = self.fusion_definition;                        \
+        size_t ndims = 0;                                                     \
+        std::vector<int64_t> dims(arg.dims);                                  \
+        std::iota(dims.begin(), dims.end(), 0);                               \
+        Tensor output = fd->defineTensor(ndims);                              \
+        fd->defineRecord(new ReductionOpRecord(                               \
+            {fd->recordingState(arg())},                                      \
+            {fd->recordingState(output())},                                   \
+            ("ops." op_str),                                                  \
+            record_type,                                                      \
+            static_cast<TensorView* (*)(TensorView*,                          \
+                                        const std::vector<int64_t>&,          \
+                                        bool,                                 \
+                                        DataType)>(op_name),                  \
+            dims,                                                             \
+            false,                                                            \
+            dtype));                                                          \
+        return output;                                                        \
+      },                                                                      \
+      py::arg("arg"),                                                         \
+      py::arg("dtype") = DataType::Null,                                      \
+      py::return_value_policy::reference);                                    \
+  nvf_ops.def(                                                                \
+      op_str,                                                                 \
+      [](FusionDefinition::Operators& self,                                   \
+         Tensor arg,                                                          \
+         int dim,                                                             \
+         bool keepdim,                                                        \
+         PrimDataType dtype) -> Tensor {                                      \
+        FUSER_PERF_SCOPE("Operators." op_str);                                \
+        NVF_CHECK(                                                            \
+            self.validUse(), "Attempting to add to a completed definition!"); \
+        FusionDefinition* fd = self.fusion_definition;                        \
+        size_t ndims = keepdim ? arg.dims : (arg.dims - 1);                   \
+        Tensor output = fd->defineTensor(ndims);                              \
+        fd->defineRecord(new ReductionOpRecord(                               \
+            {fd->recordingState(arg())},                                      \
+            {fd->recordingState(output())},                                   \
+            ("ops." op_str),                                                  \
+            record_type,                                                      \
+            static_cast<TensorView* (*)(TensorView*,                          \
+                                        const std::vector<int64_t>&,          \
+                                        bool,                                 \
+                                        DataType)>(op_name),                  \
+            {dim},                                                            \
+            keepdim,                                                          \
+            dtype));                                                          \
+        return output;                                                        \
+      },                                                                      \
+      py::arg("arg"),                                                         \
+      py::arg("dim"),                                                         \
+      py::arg("keepdim") = false,                                             \
+      py::arg("dtype") = DataType::Null,                                      \
+      py::return_value_policy::reference);                                    \
+  nvf_ops.def(                                                                \
+      op_str,                                                                 \
+      [](FusionDefinition::Operators& self,                                   \
+         Tensor arg,                                                          \
+         const std::vector<int64_t>& dims,                                    \
+         bool keepdim,                                                        \
+         PrimDataType dtype) -> Tensor {                                      \
+        FUSER_PERF_SCOPE("Operators." op_str);                                \
+        NVF_CHECK(                                                            \
+            self.validUse(), "Attempting to add to a completed definition!"); \
+        FusionDefinition* fd = self.fusion_definition;                        \
+        size_t ndims = keepdim ? arg.dims : (arg.dims - dims.size());         \
+        Tensor output = fd->defineTensor(ndims);                              \
+        fd->defineRecord(new ReductionOpRecord(                               \
+            {fd->recordingState(arg())},                                      \
+            {fd->recordingState(output())},                                   \
+            ("ops." op_str),                                                  \
+            record_type,                                                      \
+            static_cast<TensorView* (*)(TensorView*,                          \
+                                        const std::vector<int64_t>&,          \
+                                        bool,                                 \
+                                        DataType)>(op_name),                  \
+            dims,                                                             \
+            keepdim,                                                          \
+            dtype));                                                          \
+        return output;                                                        \
+      },                                                                      \
+      py::arg("arg"),                                                         \
+      py::arg("dims"),                                                        \
+      py::arg("keepdim") = false,                                             \
+      py::arg("dtype") = DataType::Null,                                      \
       py::return_value_policy::reference);
 
   NVFUSER_PYTHON_BINDING_REDUCTION_OP(

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -3725,7 +3725,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         Tensor output = fd->defineTensor(output_dims);
 
         fd->defineRecord(
-            new ScaledGroupedMmaOpRecord<TensorView*, TensorView*, TensorView*, TensorView*>(
+            new ScaledGroupedMmaOpRecord(
                 {fd->recordingState(mat1()),
                  fd->recordingState(mat2()),
                  fd->recordingState(offsets()),

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -3670,8 +3670,8 @@ void initNvFuserPythonBindings(PyObject* module) {
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
 
-        // Calculate output dimensions based on mat1 structure
-        size_t output_dims = mat1.dims;
+        // Calculate output dimensions based on mat1 & mat2 rank
+        size_t output_dims = mat1.dims == 2 && mat2.dims == 2 ? 3 : 2;
         Tensor output = fd->defineTensor(output_dims);
 
         fd->defineRecord(
@@ -3705,6 +3705,56 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("mat1"),
       py::arg("mat2"),
       py::arg("offsets"),
+      py::return_value_policy::reference);
+
+  nvf_ops.def(
+      "scaled_grouped_mm",
+      [](FusionDefinition::Operators& self,
+         Tensor mat1,
+         Tensor mat2,
+         Tensor offsets,
+         Tensor scale1,
+         Tensor scale2) -> Tensor {
+        FUSER_PERF_SCOPE("Operators.scaled_grouped_mm");
+        NVF_CHECK(
+            self.validUse(), "Attempting to add to a completed definition!");
+        FusionDefinition* fd = self.fusion_definition;
+
+        // Calculate output dimensions based on mat1 & mat2 rank
+        size_t output_dims = mat1.dims == 2 && mat2.dims == 2 ? 3 : 2;
+        Tensor output = fd->defineTensor(output_dims);
+
+        fd->defineRecord(
+            new ScaledGroupedMmaOpRecord<TensorView*, TensorView*, TensorView*, TensorView*>(
+                {fd->recordingState(mat1()),
+                 fd->recordingState(mat2()),
+                 fd->recordingState(offsets()),
+                 fd->recordingState(scale1()),
+                 fd->recordingState(scale2())},
+                {fd->recordingState(output())}));
+        return output;
+      },
+      R"(
+      Scaled Grouped matrix multiplication.
+
+      Performs matrix multiplication on grouped sets of matrices using offsets
+      to define variable-sized groups.
+
+      Args:
+          mat1 (Tensor): First set of matrices
+          mat2 (Tensor): Second set of matrices
+          offsets (Tensor): Offsets tensor defining group boundaries
+          scale1 (Tensor): Scale tensor for mat1
+          scale2 (Tensor): Scale tensor for mat2
+
+      Returns:
+          Tensor: Result of grouped matrix multiplication
+      )",
+      py::arg("mat1"),
+      py::arg("mat2"),
+      py::arg("offsets"),
+      py::arg("scale1"),
+      py::arg("scale2"),
       py::return_value_policy::reference);
 
   nvf_ops.def(

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1160,8 +1160,11 @@ class FusionTranslator : public OptInConstDispatch {
             {fd_->recordingState(output())},
             ("ops.grouped_mm"),
             serde::RecordType::Ternary_TV,
-            static_cast<TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
-                grouped_mm)));
+static_cast<
+    TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
+    [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
+        return grouped_mm(mat1, mat2, offsets);
+})));
   }
 
   // Map TopKOp to python frontend

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1149,7 +1149,7 @@ class FusionTranslator : public OptInConstDispatch {
   // Map GroupedMmaOp to python frontend
   void handle(const GroupedMmaOp* gmm_op) final {
     TensorView* out_tv = gmm_op->output(0)->as<TensorView>();
-    Tensor output = fd_->defineTensor(out_tv->nDims());
+    Tensor output = fd_->defineTensor(TensorDomain::noReductions(out_tv->getLogicalDomain()).size());
     map_val_to_fd_index_.emplace(out_tv, output());
 
     fd_->defineRecord(

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1161,7 +1161,9 @@ class FusionTranslator : public OptInConstDispatch {
             ("ops.grouped_mm"),
             serde::RecordType::Ternary_TV,
             static_cast<TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
-                [](TensorView* matrix1, TensorView* matrix2, TensorView* offsets) {
+                [](TensorView* matrix1,
+                   TensorView* matrix2,
+                   TensorView* offsets) {
                   return grouped_mm(matrix1, matrix2, offsets);
                 })));
   }

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1146,8 +1146,8 @@ class FusionTranslator : public OptInConstDispatch {
         argsortop->isStable()));
   }
 
-  // Map GroupedMMOp to python frontend
-  void handle(const GroupedMMOp* gmm_op) final {
+  // Map GroupedMmaOp to python frontend
+  void handle(const GroupedMmaOp* gmm_op) final {
     TensorView* out_tv = gmm_op->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1149,7 +1149,8 @@ class FusionTranslator : public OptInConstDispatch {
   // Map GroupedMmaOp to python frontend
   void handle(const GroupedMmaOp* gmm_op) final {
     TensorView* out_tv = gmm_op->output(0)->as<TensorView>();
-    Tensor output = fd_->defineTensor(TensorDomain::noReductions(out_tv->getLogicalDomain()).size());
+    Tensor output = fd_->defineTensor(
+        TensorDomain::noReductions(out_tv->getLogicalDomain()).size());
     map_val_to_fd_index_.emplace(out_tv, output());
 
     fd_->defineRecord(

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1154,15 +1154,15 @@ class FusionTranslator : public OptInConstDispatch {
 
     fd_->defineRecord(
         new OpRecord<TensorView*, TensorView*, TensorView*, TensorView*>(
-            {fd_->recordingState(map_val_to_fd_index_.at(gmm_op->mat1())),
-             fd_->recordingState(map_val_to_fd_index_.at(gmm_op->mat2())),
+            {fd_->recordingState(map_val_to_fd_index_.at(gmm_op->matrix1())),
+             fd_->recordingState(map_val_to_fd_index_.at(gmm_op->matrix2())),
              fd_->recordingState(map_val_to_fd_index_.at(gmm_op->offsets()))},
             {fd_->recordingState(output())},
             ("ops.grouped_mm"),
             serde::RecordType::Ternary_TV,
             static_cast<TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
-                [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
-                  return grouped_mm(mat1, mat2, offsets);
+                [](TensorView* matrix1, TensorView* matrix2, TensorView* offsets) {
+                  return grouped_mm(matrix1, matrix2, offsets);
                 })));
   }
 

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -1160,11 +1160,10 @@ class FusionTranslator : public OptInConstDispatch {
             {fd_->recordingState(output())},
             ("ops.grouped_mm"),
             serde::RecordType::Ternary_TV,
-static_cast<
-    TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
-    [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
-        return grouped_mm(mat1, mat2, offsets);
-})));
+            static_cast<TensorView* (*)(TensorView*, TensorView*, TensorView*)>(
+                [](TensorView* mat1, TensorView* mat2, TensorView* offsets) {
+                  return grouped_mm(mat1, mat2, offsets);
+                })));
   }
 
   // Map TopKOp to python frontend

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1845,7 +1845,14 @@ def grouped_mm_input_generator(
 
     def make_index(extent, num_groups):
         group_size = extent // num_groups
-        return torch.arange(group_size, group_size * g + 1, group_size, device="cuda", dtype=torch.int32, requires_grad=False)
+        return torch.arange(
+            group_size,
+            group_size * g + 1,
+            group_size,
+            device="cuda",
+            dtype=torch.int32,
+            requires_grad=False,
+        )
 
     # FIXME: enable test cases when switched to cublas fallback
     # TODO: expand the test when kernel restrictions are lifted
@@ -1873,6 +1880,7 @@ def grouped_mm_input_generator(
         mat2 = make_arg((k, n))
         offsets = make_index(n, g)
         yield SampleInput(mat1, mat2, offsets)
+
 
 def scaled_grouped_mm_input_generator(
     op: OpInfo, dtype: torch.dtype, requires_grad: bool = False, **kwargs
@@ -1907,7 +1915,14 @@ def scaled_grouped_mm_input_generator(
 
     def make_index(extent, num_groups):
         group_size = extent // num_groups
-        return torch.arange(group_size, group_size * g + 1, group_size, device="cuda", dtype=torch.int32, requires_grad=False)
+        return torch.arange(
+            group_size,
+            group_size * g + 1,
+            group_size,
+            device="cuda",
+            dtype=torch.int32,
+            requires_grad=False,
+        )
 
     # TODO: expand the test when fallback kernel restrictions are lifted
     #       currently only bf16 output is supported.

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1854,7 +1854,6 @@ def grouped_mm_input_generator(
             requires_grad=False,
         )
 
-    # FIXME: enable test cases when switched to cublas fallback
     # TODO: expand the test when kernel restrictions are lifted
     # Test various group sizes and matrix dimensions
     configs = (

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1852,7 +1852,7 @@ def grouped_mm_input_generator(
     # Test various group sizes and matrix dimensions
     configs = (
         (4, 128, 256, 64),
-        (3, 256, 48, 96),
+        (2, 32, 32, 32),
     )
 
     for config in configs:
@@ -1916,7 +1916,7 @@ def scaled_grouped_mm_input_generator(
     # configs: list(g, m, k, n, output_dtype)
     configs = (
         (4, 128, 256, 64, torch.bfloat16),
-        (3, 256, 48, 96, torch.bfloat16),
+        (2, 32, 32, 32, torch.bfloat16),
     )
 
     # TODO: Enable mxfp8 test when backend supports it.

--- a/tests/python/opinfo_input_generators.py
+++ b/tests/python/opinfo_input_generators.py
@@ -1851,7 +1851,8 @@ def grouped_mm_input_generator(
     # TODO: expand the test when kernel restrictions are lifted
     # Test various group sizes and matrix dimensions
     configs = (
-        (3, 128, 48, 64),
+        (4, 128, 256, 64),
+        (3, 256, 48, 96),
     )
 
     for config in configs:
@@ -1914,7 +1915,8 @@ def scaled_grouped_mm_input_generator(
     # Test various group sizes and matrix dimensions
     # configs: list(g, m, k, n, output_dtype)
     configs = (
-        (3, 128, 48, 64, torch.bfloat16),
+        (4, 128, 256, 64, torch.bfloat16),
+        (3, 256, 48, 96, torch.bfloat16),
     )
 
     # TODO: Enable mxfp8 test when backend supports it.

--- a/tests/python/opinfos.py
+++ b/tests/python/opinfos.py
@@ -1307,6 +1307,7 @@ grouped_mm_opinfo = OpInfo(
     reference=torch._grouped_mm,
 )
 
+
 def scaled_grouped_mm_wrapper(mat1, mat2, offsets, scale1, scale2, dtype):
     # mat1 needs to be in column major while mat2 needs to be in row major.
     row_major_mat2 = mat2.transpose(-1, -2).contiguous().transpose(-1, -2)
@@ -1318,7 +1319,17 @@ def scaled_grouped_mm_wrapper(mat1, mat2, offsets, scale1, scale2, dtype):
         # squeeze out the k dimension
         reshaped_scale1 = scale1.squeeze(-1)
         reshaped_scale2 = scale2.squeeze(-2)
-    return torch._scaled_grouped_mm(mat1, row_major_mat2, reshaped_scale1, reshaped_scale2, offsets, None, None, dtype)
+    return torch._scaled_grouped_mm(
+        mat1,
+        row_major_mat2,
+        reshaped_scale1,
+        reshaped_scale2,
+        offsets,
+        None,
+        None,
+        dtype,
+    )
+
 
 scaled_grouped_mm_opinfo = OpInfo(
     lambda fd: fd.ops.grouped_mm,

--- a/tests/python/opinfos.py
+++ b/tests/python/opinfos.py
@@ -5,6 +5,7 @@
 
 import math
 import torch
+from packaging.version import LooseVersion
 from opinfo_core import OpInfo, ReferenceType, Domain
 from opinfo_fusion_definitions import (
     api_test_fd_fn,
@@ -1298,60 +1299,61 @@ matmul_opinfo = OpInfo(
 )
 matmul_ops.append(matmul_opinfo)
 
-grouped_mm_opinfo = OpInfo(
-    lambda fd: fd.ops.grouped_mm,
-    "grouped_mm",
-    # only bf16 is supported
-    dtypes=(torch.bfloat16,),
-    sample_input_generator=grouped_mm_input_generator,
-    reference=torch._grouped_mm,
-)
+# torch._grouped_mm and torch._scaled_grouped_mm is not available prior to PyTorch 2.8.0
+if LooseVersion(torch.__version__) >= LooseVersion("2.8.0"):
 
-
-def scaled_grouped_mm_wrapper(mat1, mat2, offsets, scale1, scale2, dtype):
-    # mat1 needs to be in column major while mat2 needs to be in row major.
-    row_major_mat2 = mat2.transpose(-1, -2).contiguous().transpose(-1, -2)
-    if mat1.ndim == 2 and mat2.ndim == 2:
-        # case 1, mat1 and mat2 are both 2D, aten fallback expects collapsed 1D scale with group dimension on the slower side.
-        reshaped_scale1 = scale1.reshape(-1)
-        reshaped_scale2 = scale2.reshape(-1)
-    else:
-        # squeeze out the k dimension
-        reshaped_scale1 = scale1.squeeze(-1)
-        reshaped_scale2 = scale2.squeeze(-2)
-    return torch._scaled_grouped_mm(
-        mat1,
-        row_major_mat2,
-        reshaped_scale1,
-        reshaped_scale2,
-        offsets,
-        None,
-        None,
-        dtype,
+    grouped_mm_opinfo = OpInfo(
+        lambda fd: fd.ops.grouped_mm,
+        "grouped_mm",
+        # only bf16 is supported
+        dtypes=(torch.bfloat16,),
+        sample_input_generator=grouped_mm_input_generator,
+        reference=torch._grouped_mm,
     )
 
+    def scaled_grouped_mm_wrapper(mat1, mat2, offsets, scale1, scale2, dtype):
+        # mat1 needs to be in column major while mat2 needs to be in row major.
+        row_major_mat2 = mat2.transpose(-1, -2).contiguous().transpose(-1, -2)
+        if mat1.ndim == 2 and mat2.ndim == 2:
+            # case 1, mat1 and mat2 are both 2D, aten fallback expects collapsed 1D scale with group dimension on the slower side.
+            reshaped_scale1 = scale1.reshape(-1)
+            reshaped_scale2 = scale2.reshape(-1)
+        else:
+            # squeeze out the k dimension
+            reshaped_scale1 = scale1.squeeze(-1)
+            reshaped_scale2 = scale2.squeeze(-2)
+        return torch._scaled_grouped_mm(
+            mat1,
+            row_major_mat2,
+            reshaped_scale1,
+            reshaped_scale2,
+            offsets,
+            None,
+            None,
+            dtype,
+        )
 
-scaled_grouped_mm_opinfo = OpInfo(
-    lambda fd: fd.ops.grouped_mm,
-    "scaled_grouped_mm",
-    # only float8 is supported
-    dtypes=(torch.float8_e4m3fn,),
-    sample_input_generator=scaled_grouped_mm_input_generator,
-    reference=scaled_grouped_mm_wrapper,
-    symbolic_parameter_list=(
-        ArgumentType.Symbolic,
-        ArgumentType.Symbolic,
-        ArgumentType.Symbolic,
-        ArgumentType.Symbolic,
-        ArgumentType.Symbolic,
-        ArgumentType.Constant,
-    ),
-)
+    scaled_grouped_mm_opinfo = OpInfo(
+        lambda fd: fd.ops.grouped_mm,
+        "scaled_grouped_mm",
+        # only float8 is supported
+        dtypes=(torch.float8_e4m3fn,),
+        sample_input_generator=scaled_grouped_mm_input_generator,
+        reference=scaled_grouped_mm_wrapper,
+        symbolic_parameter_list=(
+            ArgumentType.Symbolic,
+            ArgumentType.Symbolic,
+            ArgumentType.Symbolic,
+            ArgumentType.Symbolic,
+            ArgumentType.Symbolic,
+            ArgumentType.Constant,
+        ),
+    )
 
-# only hopper is supported with torch._grouped_mm at this point.
-if torch.cuda.get_device_properties(torch.cuda.current_device()).major == 9:
-    matmul_ops.append(grouped_mm_opinfo)
-    matmul_ops.append(scaled_grouped_mm_opinfo)
+    # only hopper is supported with torch._grouped_mm at this point.
+    if torch.cuda.get_device_properties(torch.cuda.current_device()).major == 9:
+        matmul_ops.append(grouped_mm_opinfo)
+        matmul_ops.append(scaled_grouped_mm_opinfo)
 
 linear_ops = []
 

--- a/tests/python/opinfos.py
+++ b/tests/python/opinfos.py
@@ -5,7 +5,7 @@
 
 import math
 import torch
-from packaging.version import LooseVersion
+from looseversion import LooseVersion
 from opinfo_core import OpInfo, ReferenceType, Domain
 from opinfo_fusion_definitions import (
     api_test_fd_fn,

--- a/tests/python/opinfos.py
+++ b/tests/python/opinfos.py
@@ -1314,10 +1314,18 @@ def scaled_grouped_mm_wrapper(mat1, mat2, offsets, scale1, scale2, dtype):
 scaled_grouped_mm_opinfo = OpInfo(
     lambda fd: fd.ops.grouped_mm,
     "scaled_grouped_mm",
-    # only bf16 is supported
-    dtypes=(torch.bfloat16,),
+    # only float8 is supported
+    dtypes=(torch.float8_e4m3fn,),
     sample_input_generator=scaled_grouped_mm_input_generator,
     reference=scaled_grouped_mm_wrapper,
+    symbolic_parameter_list=(
+        ArgumentType.Symbolic,
+        ArgumentType.Symbolic,
+        ArgumentType.Symbolic,
+        ArgumentType.Symbolic,
+        ArgumentType.Symbolic,
+        ArgumentType.Constant,
+    ),
 )
 
 # only hopper is supported with torch._grouped_mm at this point.

--- a/tests/python/opinfos.py
+++ b/tests/python/opinfos.py
@@ -1301,7 +1301,6 @@ matmul_ops.append(matmul_opinfo)
 
 # torch._grouped_mm and torch._scaled_grouped_mm is not available prior to PyTorch 2.8.0
 if LooseVersion(torch.__version__) >= LooseVersion("2.8.0"):
-
     grouped_mm_opinfo = OpInfo(
         lambda fd: fd.ops.grouped_mm,
         "grouped_mm",


### PR DESCRIPTION
Adding grouped matmul in nvfuser:

1. Adding fusion node added `GroupedMMOp`;
    output = GroupedMMOp (matrix1, matrix2, offsets, scale1 [optional], scale2 [optional], output_dtype);
2. Plumbed through python, c++ api -> `fd.ops.grouped_mm` / `grouped_mm`;
3. Current fallback execution goes through `torch._grouped_mm` and `torch._scaled_grouped_mm` accordingly;

A couple note:
1. Semantics about `scaled_grouped_mm` is tricky. I have a note as code comment.
```
NOTE -- [ Grouped Matrix Multiplication semantics ]

This operation performs a grouped matrix multiplication.

Parameters:
- out: output tensor
- matrix1: first input tensor matrix
- matrix2: second input tensor matrix
- offsets: 1D offsets tensor, specifying the ending index of each group
- scale1: scale tensor for matrix1 (optional)
- scale2: scale tensor for matrix2 (optional)

The offsets tensor is a vector tensor of length `num_groups` that specifies
the ending index of each group in the matrix1 and matrix2 tensors.

Given the number of groups as G, the operation conceptually runs G matmuls.
There are three configurations of grouping, reflected by ranks of input
matrices:

Note 0: f(0) = 0 : offset[0]
        f(i) = offset(i-1) : offset(i), when i >= 1;
        f(i) is a slice with length equal to offsets[i] - offsets[i-1]
Note 1: scales don't need to follow broadcast rules against corresponding
        matrices on the k-dimension. Hardware uses blocked scale factors.
        so the corresponding scale factor on k-dimension is shared by fixed
        number of consecutive elements.
        e.g. Given k as the size of k-dimension on input matrices, and the
        scale factor has size k' on k-dimension.
        For mxfp8, k' = k // 32. Each scale factor is shared by 32
        consecutive elements.
Note 2: output could have a reduction axis rk if k is not broadcast on
inputs.

    Case 1: grouped k-dimension:
      inputs: mat1[ m, k ] @ mat2[ k, n ] , offsets[ g ]
              scale1[ g, m, k' ], scale2[ g, k', n]
      requires: offsets[g-1] == k
      output: out[ g, m, n, [rk]]

      math:
      for i in range(g):
        out[ i, 0:m, 0:n ] = (mat1[ 0:m, f(i) ] * scale1[ i, 0:m, 0:k' ])
                            @(mat2[ f(i), 0:n ] * scale2[ i, 0:k', 0:n ])

    Case 2: grouped m-dimension:
      inputs: mat1[ m, k ] @ mat2[ g, k, n ] , offsets[ g ]
              scale1[ m, k' ], scale2[ g, k', n ]
      requires: offsets[g-1] == m
      output: out[ m, n, [rk]]

      math:
      for i in range(g):
        out[ f(i), 0:n ] = (mat1[ f(i), 0:k ] * scale1[ f(i), 0:k' ])
                          @(mat2[ i, 0:k, 0:n ] * scale2[ i, 0:k', 0:n ])

    Case 3: grouped n-dimension:
      inputs: mat1[ g, m, k ] @ mat2[ k, n ] , offsets[ g ]
              scale1[ g, m, k' ], scale2[ k', n ]
      requires: offsets[g-1] == n
      output: out[ m, n, [rk]]

      math:
      for i in range(g):
        out[ 0:m, f(i) ] = (mat1[ i, 0:m, 0:k ] * scale1[ i, 0:m, 0:k' ])
                          @(mat2[ 0:k, f(i) ] * scale2[ 0:k', f(i) ])
```


2. Decided to have one API to support both the vanilla gouped_mm and scaled_grouped_mm. Ended up using two different FusionRecord node for python side cache.

3. Current fallback doesn't support mxfp8 scaling. It only matters for codegen, since the blocked scaling thing doesn't affect shape inference during concretization. So we don't need to address it until we start working on codegen support.

Follow up PR:
I'll change the fallback implementation to allow mxfp8 support. We are still evaluating which backend to use.