### PR TITLE
Add common file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,12 @@ foo.bin
 .DS_Store
 
 test_log*
+
+# Skip files created commonly during development
+.lintrunner.private.toml
+compile_commands.json
+
+# Skip nsight files that are created during perf debugging
+*.sqlite
+*.nsys-rep
+*.ncu-rep


### PR DESCRIPTION
This small change is just meant to keep `git status` less noisy and possibly prevent adding unnecessary files to our repo.