### PR TITLE
Use subclass method for scheduling in `profile_matmul.py`

### DIFF
--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -641,6 +641,7 @@ void defineHeuristicParamBindings(py::module& nvfuser) {
       .PARAM(MatmulParams, async_gmem_load_operands)
       .PARAM(MatmulParams, grid_traversal_factor)
       .PARAM(MatmulParams, use_smem_epilogue)
+      .PARAM(MatmulParams, use_ldst_matrix)
       .PARAM(MatmulParams, promote_prologue_smem_reuse)
       .PARAM(MatmulParams, splitk_factor)
       .PARAM(MatmulParams, tiling_strategy)


### PR DESCRIPTION
At some point `doc/dev/python_scheduling/profile_matmul.py` seems to have stopped actually applying the custom schedule. This PR switches to subclassing `FusionDefinition` and implementing the `schedule` and `definition` methods there instead, which seems to work.