### PR TITLE
Introduce NVFUSER_LOWER_VALIDATE macro

### DIFF
--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -684,7 +684,7 @@ class HandleExpr {
           SimplifyingIrBuilder::modExpr(
               from[0]->front()->as<IterDomain>()->extent(), split->factor()),
           split->fusion()->zeroVal());
-      GpuLower::current()->validate(
+      NVFUSER_LOWER_VALIDATE(
           is_divisible,
           "Invalid view in TMA: the extent of ",
           from[0]->toString(),

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -461,4 +461,9 @@ class GpuLower : public NonCopyable {
   IdModelOptions id_model_options_;
 };
 
+#define NVFUSER_LOWER_VALIDATE(cond, ...) \
+  GpuLower::current()->validate(          \
+      cond,                               \
+      "Validation at " STRINGIZE(__FILE__) ":" STRINGIZE(__LINE__) " ", __VA_ARGS__);
+
 } // namespace nvfuser


### PR DESCRIPTION
This is the same interface as using `GpuLower::current()->validate` directly, but it adds the original validation location to the error message, which can be useful when the validation fails at runtime.