### PR TITLE
Validate vectorization using bit instead of byte

### DIFF
--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -598,7 +598,7 @@ class VectorizeValidator : public OptInDispatch {
         vector_word_size;
 
     // Except for TMem, allow half2, float2, float4 and same sized vtypes.
-    std::vector<int64_t> allowed_vector_sizes_bit = {16, 32, 64, 128};
+    std::vector<int64_t> allowed_vector_sizes_bit = {8, 16, 32, 64, 128};
     // TMem can vectorize up to 4096 bits.
     bool is_tmem = false;
     if (auto ldst = dynamic_cast<LoadStoreOp*>(tv_def); ldst != nullptr &&

--- a/tests/cpp/test_tmem.cpp
+++ b/tests/cpp/test_tmem.cpp
@@ -206,8 +206,8 @@ TEST_F(TMemTest, dtypes) {
       if (vec_bytes % 4 != 0) {
         EXPECT_THAT(
             [&]() { ke.compile(&fusion); },
-            ::testing::ThrowsMessage<nvfuser::nvfError>(
-                ::testing::HasSubstr("Vectorize size is not a multiple of 4 bytes")));
+            ::testing::ThrowsMessage<nvfuser::nvfError>(::testing::HasSubstr(
+                "Vectorize size is not a multiple of 4 bytes")));
         continue;
       }
 

--- a/tests/cpp/test_tmem.cpp
+++ b/tests/cpp/test_tmem.cpp
@@ -206,7 +206,7 @@ TEST_F(TMemTest, dtypes) {
       if (vec_bytes % 4 != 0) {
         std::string message = vec_bytes == 1
             ? "Tried to vectorize a dim resulting in a word size of 1 however, "
-              "vector sizes only upto and including 512 bytes are supported."
+              "vector sizes only upto and including 4096 bits are supported."
             : "Vectorize size is not a multiple of 4 bytes";
         EXPECT_THAT(
             [&]() { ke.compile(&fusion); },

--- a/tests/cpp/test_tmem.cpp
+++ b/tests/cpp/test_tmem.cpp
@@ -204,14 +204,10 @@ TEST_F(TMemTest, dtypes) {
       KernelExecutor ke;
 
       if (vec_bytes % 4 != 0) {
-        std::string message = vec_bytes == 1
-            ? "Tried to vectorize a dim resulting in a word size of 1 however, "
-              "vector sizes only upto and including 4096 bits are supported."
-            : "Vectorize size is not a multiple of 4 bytes";
         EXPECT_THAT(
             [&]() { ke.compile(&fusion); },
             ::testing::ThrowsMessage<nvfuser::nvfError>(
-                ::testing::HasSubstr(message)));
+                ::testing::HasSubstr("Vectorize size is not a multiple of 4 bytes")));
         continue;
       }
 


### PR DESCRIPTION
`dataTypeSizeByte(fp4)` always fail. But we do want to support fp4 as long as we are vectorizing it to at least 1 byte.