### PR TITLE
Simplify multidevice tests

### DIFF
--- a/tests/python/multidevice/test_communication.py
+++ b/tests/python/multidevice/test_communication.py
@@ -28,10 +28,6 @@ def test_allgather(multidevice_test):
 
             self.sched.split(self.inp, 0, d, False)
             self.sched.parallelize(self.inp, 0, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.inp)
-
-            self.sched.split(self.out, 0, d, False)
-            self.sched.set_allocation_as_loop(self.out)
 
     unsharded = torch.randn(d * 4)
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
@@ -51,15 +47,13 @@ def test_allreduce(multidevice_test):
             self.inp = self.define_tensor(
                 (-1, -1, -1), contiguity=True, dtype=DataType.Float
             )
-            self.out = self.ops.sum(self.inp, [1])
-            self.add_output(self.out)
+            out = self.ops.sum(self.inp, [1])
+            self.add_output(out)
 
         def multidevice_schedule(self):
-            for tv in [self.inp, self.out]:
-                self.sched._set_device_mesh(tv, mesh)
-                self.sched.split(tv, 1, d, False)
-                self.sched.parallelize(tv, 1, nvfuser.ParallelType.mesh_x)
-                self.sched.set_allocation_as_loop(tv)
+            self.sched._set_device_mesh(self.inp, mesh)
+            self.sched.split(self.inp, 1, d, False)
+            self.sched.parallelize(self.inp, 1, nvfuser.ParallelType.mesh_x)
 
     m = 2
     k = d * 3
@@ -93,7 +87,6 @@ def test_reduce_scatter(multidevice_test):
 
             self.sched.split(self.out, -1, d, False)
             self.sched.parallelize(self.out, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.out)
 
     unsharded = torch.randn(d, d * 4)
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)
@@ -129,13 +122,10 @@ def test_reduce_scatter_noncontiguous(multidevice_test):
             #
             # Unlike test_reduce_scatter, this leads to extra data copy because
             # the scattered axis is not outermost in allocation.
-            # ProcessGroupNCCL::reduce_scatter was able to handle
-            # non-contiguous scattering in a functional but suboptimal way.
             self.sched.parallelize(self.inp, 0, nvfuser.ParallelType.mesh_x)
 
             self.sched.split(self.out, -1, d, False)
             self.sched.parallelize(self.out, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.out)
 
     unsharded = torch.randn(d, 3, d * 4)
     sharded = multidevice_test.shard_tensor(unsharded, 0, mesh)


### PR DESCRIPTION
Removes `set_allocation_as_loop` and output sharding annotations when possible.
For #4739 