### PR TITLE
Support non-aten `DataType`s as input/ouput `TensorView`

### DIFF
--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -360,8 +360,7 @@ void PrecomputedValues::bindTensorMetaData(
   const auto adjust_last_dim = getLastDimAdjustment(tv->dtype());
   if (!logical_sizes.empty()) {
     auto& last_dim = logical_sizes.back();
-    last_dim *= adjust_last_dim.numerator;
-    last_dim /= adjust_last_dim.denominator;
+    last_dim = adjust_last_dim.fromATenToNVF(last_dim);
   } else {
     NVF_ERROR(
         adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,

--- a/csrc/evaluator_common.cpp
+++ b/csrc/evaluator_common.cpp
@@ -362,6 +362,10 @@ void PrecomputedValues::bindTensorMetaData(
     auto& last_dim = logical_sizes.back();
     last_dim *= adjust_last_dim.numerator;
     last_dim /= adjust_last_dim.denominator;
+  } else {
+    NVF_ERROR(
+        adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
+        "DataType not supported");
   }
 
   for (const auto dim : arange(static_cast<int64_t>(logical_domain.size()))) {

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -80,7 +80,7 @@ void validateValWithConcreteValue(
         ", to be bound to a tensor of dtype ",
         value->dtype(),
         ", but got a tensor of dtype ",
-        actual_dtype);
+        t.scalar_type());
     // Intermediate tensorviews marked as CPU scalars will be created as meta
     // tensors during compilation. For example, for fusions containing SDPA fwd
     // and bwd, some outputs of the fwd op (philox seed, philox offset) are CPU

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -72,8 +72,10 @@ void validateValWithConcreteValue(
         ", but got a tensor of rank ",
         t.dim());
     NVF_CHECK(
-        (value->dtype() == DataType::Index && (t.scalar_type() == torch::kInt64 || t.scalar_type() == torch::kInt32)) ||
-        (t.scalar_type() == data_type_to_aten(value->dtype())),
+        (value->dtype() == DataType::Index &&
+         (t.scalar_type() == torch::kInt64 ||
+          t.scalar_type() == torch::kInt32)) ||
+            (t.scalar_type() == data_type_to_aten(value->dtype())),
         "Expected ",
         getInputPosString(tv),
         tv->toString(),

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -156,6 +156,10 @@ void ExpressionEvaluator::bindTensorDomain(
     auto& last_dim = logical_sizes.back();
     last_dim *= adjust_last_dim.numerator;
     last_dim /= adjust_last_dim.denominator;
+  } else {
+    NVF_ERROR(
+        adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
+        "DataType not supported");
   }
 
   for (auto i : arange(t.dim())) {

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -154,8 +154,7 @@ void ExpressionEvaluator::bindTensorDomain(
   const auto adjust_last_dim = getLastDimAdjustment(tv->dtype());
   if (!logical_sizes.empty()) {
     auto& last_dim = logical_sizes.back();
-    last_dim *= adjust_last_dim.numerator;
-    last_dim /= adjust_last_dim.denominator;
+    last_dim = adjust_last_dim.fromATenToNVF(last_dim);
   } else {
     NVF_ERROR(
         adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -71,11 +71,9 @@ void validateValWithConcreteValue(
         expect_dim,
         ", but got a tensor of rank ",
         t.dim());
-    auto actual_dtype = aten_to_data_type(t.scalar_type());
     NVF_CHECK(
-        (value->dtype() == DataType::Index && isIntegralType(actual_dtype)) ||
-        (value->dtype() == DataType::Float4_e2m1 && actual_dtype == DataType::Byte) ||
-            (value->dtype() == actual_dtype),
+        (value->dtype() == DataType::Index && (t.scalar_type() == torch::kInt64 || t.scalar_type() == torch::kInt32)) ||
+        (t.scalar_type() == data_type_to_aten(value->dtype())),
         "Expected ",
         getInputPosString(tv),
         tv->toString(),

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -317,7 +317,7 @@ std::vector<GlobalBufferInfo> getBufferInfos(
     info.tv = out->as<TensorView>();
     info.shape_info = inferTensorShapes(info.tv, expr_eval);
     auto dtype =
-      (info.tv->dtype() == DataType::Index ? index_dtype : info.tv->dtype());
+        (info.tv->dtype() == DataType::Index ? index_dtype : info.tv->dtype());
     info.type = data_type_to_aten(dtype);
 
     output_buffer_infos.emplace_back(info);

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -184,6 +184,10 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
     auto& last_dim = concrete_sizes.back();
     last_dim *= adjust_last_dim.denominator;
     last_dim /= adjust_last_dim.numerator;
+  } else {
+    NVF_ERROR(
+        adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
+        "DataType not supported");
   }
 
   auto strides = getContiguousStrides(concrete_sizes, expand_flags);

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -182,8 +182,7 @@ std::pair<std::vector<int64_t>, std::vector<int64_t>> inferShape(
   const auto adjust_last_dim = getLastDimAdjustment(tv->dtype());
   if (!concrete_sizes.empty()) {
     auto& last_dim = concrete_sizes.back();
-    last_dim *= adjust_last_dim.denominator;
-    last_dim /= adjust_last_dim.numerator;
+    last_dim = adjust_last_dim.fromNVFToATen(last_dim);
   } else {
     NVF_ERROR(
         adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -317,7 +317,7 @@ std::vector<GlobalBufferInfo> getBufferInfos(
     info.tv = out->as<TensorView>();
     info.shape_info = inferTensorShapes(info.tv, expr_eval);
     auto dtype =
-        (info.tv->dtype() == DataType::Index ? index_dtype : info.tv->dtype() == DataType::Float4_e2m1 ? DataType::Byte : info.tv->dtype());
+      (info.tv->dtype() == DataType::Index ? index_dtype : info.tv->dtype());
     info.type = data_type_to_aten(dtype);
 
     output_buffer_infos.emplace_back(info);

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -855,6 +855,7 @@ void KernelExecutor::computeArgs(
               ? buffer_info.shape_info.logical_strides
               : buffer_info.shape_info.allocation_strides,
           idx_type,
+          getLastDimAdjustment(buffer_info.tv->dtype()),
           buffer_info.shape_info.unsharded_logical_sizes);
       entry.arg_ptrs[arg_idx] = entry.args[arg_idx].data();
     } else {

--- a/csrc/runtime/executor_kernel_arg.cpp
+++ b/csrc/runtime/executor_kernel_arg.cpp
@@ -341,7 +341,8 @@ std::vector<std::byte> tensorToBytes(
     // Adjust the last dimension of the logical domain to support DataType
     // that is not supported by PyTorch. See the comment of getLastDimAdjustment
     // in type.h for more details.
-    int64_t& last_size = *reinterpret_cast<int64_t*>(bytes.data() + bytes.size() - sizeof(int64_t));
+    int64_t& last_size = *reinterpret_cast<int64_t*>(
+        bytes.data() + bytes.size() - sizeof(int64_t));
     last_size *= adjust_last_dim.numerator;
     last_size /= adjust_last_dim.denominator;
 

--- a/csrc/runtime/executor_kernel_arg.cpp
+++ b/csrc/runtime/executor_kernel_arg.cpp
@@ -344,8 +344,7 @@ std::vector<std::byte> tensorToBytes(
     if (!size_to_use.empty()) {
       int64_t& last_size = *reinterpret_cast<int64_t*>(
           bytes.data() + bytes.size() - sizeof(int64_t));
-      last_size *= adjust_last_dim.numerator;
-      last_size /= adjust_last_dim.denominator;
+      last_size = adjust_last_dim.fromATenToNVF(last_size);
     } else {
       NVF_ERROR(
           adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
@@ -369,8 +368,7 @@ std::vector<std::byte> tensorToBytes(
     // in type.h for more details.
     if (!logical_size32.empty()) {
       int32_t& last_size = logical_size32.back();
-      last_size *= adjust_last_dim.numerator;
-      last_size /= adjust_last_dim.denominator;
+      last_size = (int32_t)adjust_last_dim.fromATenToNVF(last_size);
     } else {
       NVF_ERROR(
           adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,

--- a/csrc/runtime/executor_kernel_arg.cpp
+++ b/csrc/runtime/executor_kernel_arg.cpp
@@ -341,10 +341,16 @@ std::vector<std::byte> tensorToBytes(
     // Adjust the last dimension of the logical domain to support DataType
     // that is not supported by PyTorch. See the comment of getLastDimAdjustment
     // in type.h for more details.
-    int64_t& last_size = *reinterpret_cast<int64_t*>(
-        bytes.data() + bytes.size() - sizeof(int64_t));
-    last_size *= adjust_last_dim.numerator;
-    last_size /= adjust_last_dim.denominator;
+    if (!size_to_use.empty()) {
+      int64_t& last_size = *reinterpret_cast<int64_t*>(
+          bytes.data() + bytes.size() - sizeof(int64_t));
+      last_size *= adjust_last_dim.numerator;
+      last_size /= adjust_last_dim.denominator;
+    }  else {
+      NVF_ERROR(
+          adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
+          "DataType not supported");
+    }
 
     bytes.insert(
         bytes.end(),
@@ -361,9 +367,15 @@ std::vector<std::byte> tensorToBytes(
     // Adjust the last dimension of the logical domain to support DataType
     // that is not supported by PyTorch. See the comment of getLastDimAdjustment
     // in type.h for more details.
-    int32_t& last_size = logical_size32.back();
-    last_size *= adjust_last_dim.numerator;
-    last_size /= adjust_last_dim.denominator;
+    if (!logical_size32.empty()) {
+      int32_t& last_size = logical_size32.back();
+      last_size *= adjust_last_dim.numerator;
+      last_size /= adjust_last_dim.denominator;
+    } else {
+      NVF_ERROR(
+          adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
+          "DataType not supported");
+    }
 
     bytes.insert(
         bytes.end(),

--- a/csrc/runtime/executor_kernel_arg.cpp
+++ b/csrc/runtime/executor_kernel_arg.cpp
@@ -346,7 +346,7 @@ std::vector<std::byte> tensorToBytes(
           bytes.data() + bytes.size() - sizeof(int64_t));
       last_size *= adjust_last_dim.numerator;
       last_size /= adjust_last_dim.denominator;
-    }  else {
+    } else {
       NVF_ERROR(
           adjust_last_dim.denominator == 1 && adjust_last_dim.numerator == 1,
           "DataType not supported");

--- a/csrc/runtime/executor_kernel_arg.h
+++ b/csrc/runtime/executor_kernel_arg.h
@@ -233,6 +233,7 @@ std::vector<std::byte> tensorToBytes(
     const std::vector<int64_t>& logical_sizes,
     const std::vector<int64_t>& allocation_strides,
     PrimDataType idx_type,
+    AdjustLastDim adjust_last_dim = {1, 1},
     const std::vector<int64_t>& unsharded_logical_sizes = {});
 
 int64_t computeBytes(const KernelArgumentHolder& args);

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1321,29 +1321,28 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
       default:
         break;
     }
+  }
+  // NVFuser's DataType is much wider than PyTorch's ScalarType. If
+  // there is no direct mapping, we use some data type as a proxy.
+  // If there is a data type with the same size, we use that
+  const int64_t size_bit = dataTypeSizeBit(data_type);
+  if (size_bit == 8) {
+    return at::ScalarType::Byte;
+  } else if (size_bit == 16) {
+    return at::ScalarType::UInt16;
+  } else if (size_bit == 32) {
+    return at::ScalarType::UInt32;
+  } else if (size_bit == 64) {
+    return at::ScalarType::UInt64;
+  } else if (size_bit == 128) {
+    return at::ScalarType::ComplexDouble;
   } else {
-    // NVFuser's DataType is much wider than PyTorch's ScalarType. If
-    // there is no direct mapping, we use some data type as a proxy.
-    // If there is a data type with the same size, we use that
-    const int64_t size_bit = dataTypeSizeBit(data_type);
-    if (size_bit == 8) {
-      return at::ScalarType::Byte;
-    } else if (size_bit == 16) {
-      return at::ScalarType::UInt16;
-    } else if (size_bit == 32) {
-      return at::ScalarType::UInt32;
-    } else if (size_bit == 64) {
-      return at::ScalarType::UInt64;
-    } else if (size_bit == 128) {
-      return at::ScalarType::ComplexDouble;
-    } else {
-      // If there is no data type with the same size, we use byte.
-      // For this case, we adjust the size of the last dimension.
-      // For example, if we have a TensorView with shape [10, 4],
-      // and dtype is 3 bytes, then the corresponding ScalarType is Byte,
-      // and the shape of the corresponding at::Tensor is [10, 12].
-      return at::ScalarType::Byte;
-    }
+    // If there is no data type with the same size, we use byte.
+    // For this case, we adjust the size of the last dimension.
+    // For example, if we have a TensorView with shape [10, 4],
+    // and dtype is 3 bytes, then the corresponding ScalarType is Byte,
+    // and the shape of the corresponding at::Tensor is [10, 12].
+    return at::ScalarType::Byte;
   }
 }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1346,6 +1346,9 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
 }
 
 AdjustLastDim getLastDimAdjustment(const DataType& dtype) {
+  if (dtype == DataType::Index) {
+    return AdjustLastDim{1, 1};
+  }
   const int64_t scalar_type_bit =
       (int64_t)c10::elementSize(data_type_to_aten(dtype)) * 8;
   const int64_t dtype_bit = dataTypeSizeBit(dtype);

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1346,7 +1346,8 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
 }
 
 AdjustLastDim getLastDimAdjustment(const DataType& dtype) {
-  const int64_t scalar_type_bit = (int64_t)c10::elementSize(data_type_to_aten(dtype)) * 8;
+  const int64_t scalar_type_bit =
+      (int64_t)c10::elementSize(data_type_to_aten(dtype)) * 8;
   const int64_t dtype_bit = dataTypeSizeBit(dtype);
   // Example: dtype_bit = 6, scalar_type_bit = 8
   // Then we need to adjust the last dimension by 4/3, that is,

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -23,7 +23,7 @@ StructType NotImplementedStruct::type() const {
 }
 
 StructType globalTensorMetaData(
-    const PrimDataType& dtype,
+    const DataType& dtype,
     size_t dim,
     size_t alloc_dim) {
   std::stringstream ss;
@@ -80,8 +80,7 @@ DataType metaDataTypeOf(const Val* v) {
   size_t dim = TensorDomain::noReductions(tv->getLogicalDomain()).size();
   size_t alloc_dim =
       TensorDomain::noReductions(tv->getMaybeAllocationDomain()).size();
-  return globalTensorMetaData(
-      std::get<PrimDataType>(tv->dtype().type), dim, alloc_dim);
+  return globalTensorMetaData(tv->dtype().type, dim, alloc_dim);
 }
 
 PrimDataType indexModeToDtype(KernelIndexMode index_mode) {

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1318,6 +1318,8 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
         return at::ScalarType::ComplexFloat;
       case DataType::ComplexDouble:
         return at::ScalarType::ComplexDouble;
+      default:
+        break;
     }
   } else {
     // NVFuser's DataType is much wider than PyTorch's ScalarType. If
@@ -1346,7 +1348,7 @@ at::ScalarType data_type_to_aten(const DataType& data_type) {
 }
 
 AdjustLastDim getLastDimAdjustment(const DataType& dtype) {
-  const auto scalar_type_bit = c10::elementSize(data_type_to_aten(dtype)) * 8;
+  const int64_t scalar_type_bit = (int64_t)c10::elementSize(data_type_to_aten(dtype)) * 8;
   const int64_t dtype_bit = dataTypeSizeBit(dtype);
   // Example: dtype_bit = 6, scalar_type_bit = 8
   // Then we need to adjust the last dimension by 4/3, that is,

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -991,14 +991,14 @@ inline DataType promoteType(const std::vector<DataType>& types) {
 NVF_API DataType aten_to_data_type(const at::ScalarType& scalar_type);
 NVF_API at::ScalarType data_type_to_aten(const DataType& data_type);
 
-
 // NVFuser's DataType is much wider than PyTorch's ScalarType, and we do support
 // input/output TensorViews with these data types not supported by PyTorch.
 // For these cases, we use a PyTorch ScalarType as a proxy. If there exists
 // a scalar type with the same size, we use that. Otherwise, we use Byte and
 // and adjust the size of the last dimension. For example, if we have a
 // TensorView with shape [10, 4], and dtype is 3 bytes, then the corresponding
-// ScalarType is Byte, and the shape of the corresponding at::Tensor is [10, 12].
+// ScalarType is Byte, and the shape of the corresponding at::Tensor is [10,
+// 12].
 struct AdjustLastDim {
   int64_t numerator;
   int64_t denominator;

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -991,6 +991,22 @@ inline DataType promoteType(const std::vector<DataType>& types) {
 NVF_API DataType aten_to_data_type(const at::ScalarType& scalar_type);
 NVF_API at::ScalarType data_type_to_aten(const DataType& data_type);
 
+
+// NVFuser's DataType is much wider than PyTorch's ScalarType, and we do support
+// input/output TensorViews with these data types not supported by PyTorch.
+// For these cases, we use a PyTorch ScalarType as a proxy. If there exists
+// a scalar type with the same size, we use that. Otherwise, we use Byte and
+// and adjust the size of the last dimension. For example, if we have a
+// TensorView with shape [10, 4], and dtype is 3 bytes, then the corresponding
+// ScalarType is Byte, and the shape of the corresponding at::Tensor is [10, 12].
+struct AdjustLastDim {
+  int64_t numerator;
+  int64_t denominator;
+};
+// at_size * numerator / denominator is the size of the last dimension of the
+// corresponding TensorView.
+AdjustLastDim getLastDimAdjustment(const DataType& dtype);
+
 NVF_API std::ostream& operator<<(std::ostream&, const ValType);
 std::ostream& operator<<(std::ostream&, const PredicateType);
 NVF_API std::ostream& operator<<(std::ostream&, const DataType);

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -241,11 +241,11 @@ inline StructType StructHandle::type() const {
 }
 
 StructType globalTensorMetaData(
-    const PrimDataType& dtype,
+    const DataType& dtype,
     size_t dim,
     size_t alloc_dim);
 
-inline StructType globalTensorMetaData(const PrimDataType& dtype, size_t dim) {
+inline StructType globalTensorMetaData(const DataType& dtype, size_t dim) {
   return globalTensorMetaData(dtype, dim, dim);
 }
 

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -1002,6 +1002,26 @@ NVF_API at::ScalarType data_type_to_aten(const DataType& data_type);
 struct AdjustLastDim {
   int64_t numerator;
   int64_t denominator;
+  inline int64_t fromATenToNVF(int64_t aten_size) const {
+    int64_t dividend = aten_size * numerator;
+    int64_t remainder = dividend % denominator;
+    if (remainder != 0) {
+      NVF_ERROR(
+          "Last dimension of the logical domain is not divisible by the adjustment factor. ",
+          "Last dimension: ", aten_size, " Adjustment factor: ", denominator);
+    }
+    return dividend / denominator;
+  }
+  inline int64_t fromNVFToATen(int64_t nvf_size) const {
+    int64_t dividend = nvf_size * denominator;
+    int64_t remainder = dividend % numerator;
+    if (remainder != 0) {
+      NVF_ERROR(
+          "Last dimension of the logical domain is not divisible by the adjustment factor. ",
+          "Last dimension: ", nvf_size, " Adjustment factor: ", numerator);
+    }
+    return dividend / numerator;
+  }
 };
 // at_size * numerator / denominator is the size of the last dimension of the
 // corresponding TensorView.

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -1007,8 +1007,12 @@ struct AdjustLastDim {
     int64_t remainder = dividend % denominator;
     if (remainder != 0) {
       NVF_ERROR(
-          "Last dimension of the logical domain is not divisible by the adjustment factor. ",
-          "Last dimension: ", aten_size, " Adjustment factor: ", denominator);
+          "Last dimension of the logical domain is not divisible by the "
+          "adjustment factor. ",
+          "Last dimension: ",
+          aten_size,
+          " Adjustment factor: ",
+          denominator);
     }
     return dividend / denominator;
   }
@@ -1017,8 +1021,12 @@ struct AdjustLastDim {
     int64_t remainder = dividend % numerator;
     if (remainder != 0) {
       NVF_ERROR(
-          "Last dimension of the logical domain is not divisible by the adjustment factor. ",
-          "Last dimension: ", nvf_size, " Adjustment factor: ", numerator);
+          "Last dimension of the logical domain is not divisible by the "
+          "adjustment factor. ",
+          "Last dimension: ",
+          nvf_size,
+          " Adjustment factor: ",
+          numerator);
     }
     return dividend / numerator;
   }

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2781,7 +2781,7 @@ TEST_P(AdvancedDtypeTest, CopyKernelPointer) {
   inlineMost();
 
   auto options = at::TensorOptions().dtype(torch::kUInt64).device(at::kCUDA, 0);
-  at::Tensor input = at::randint(0, 1LL << 63, {1024}, options);
+  at::Tensor input = at::randint(0, 1LL << 62, {1024}, options);
 
   KernelExecutor ke;
   ke.compile(&fusion, {input});

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2771,7 +2771,8 @@ TEST_P(AdvancedDtypeTest, CopyKernelPointer) {
 
   DataType dtype = PointerType{std::make_shared<DataType>(DataType::Float)};
 
-  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype) : makeContigConcreteTensor({2048}, dtype);
+  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype)
+                                      : makeContigConcreteTensor({2048}, dtype);
   fusion.addInput(tv0);
   TensorView* tv1 = set(tv0);
   fusion.addOutput(tv1);
@@ -2796,7 +2797,8 @@ TEST_P(AdvancedDtypeTest, CopyKernel3ByteArray) {
 
   DataType dtype = ArrayType{std::make_shared<DataType>(DataType::Byte), 3};
 
-  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype) : makeContigConcreteTensor({300}, dtype);
+  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype)
+                                      : makeContigConcreteTensor({300}, dtype);
   fusion.addInput(tv0);
   TensorView* tv1 = set(tv0);
   fusion.addOutput(tv1);

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2823,7 +2823,7 @@ std::string advancedDtypeTestName(const testing::TestParamInfo<bool>& info) {
 INSTANTIATE_TEST_SUITE_P(
     ,
     AdvancedDtypeTest,
-    testing::Combine(testing::Values(false, true)),
+    testing::Values(false, true),
     advancedDtypeTestName);
 
 TEST_F(NVFuserTest, BitCeilEval) {

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2772,7 +2772,7 @@ TEST_P(AdvancedDtypeTest, CopyKernelPointer) {
   DataType dtype = PointerType{std::make_shared<DataType>(DataType::Float)};
 
   TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype)
-                                      : makeContigConcreteTensor({2048}, dtype);
+                                      : makeContigConcreteTensor({1024}, dtype);
   fusion.addInput(tv0);
   TensorView* tv1 = set(tv0);
   fusion.addOutput(tv1);

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2198,7 +2198,7 @@ void test_op(
       std::make_index_sequence<size>{});
 }
 
-TEST_F(NVFuserTest, FusionUnaryOps_CUDA) {
+TEST_F(NVFuserTest, UnaryOps) {
   using OpTuple =
       std::tuple<at::Tensor (*)(const at::Tensor&), UnaryOpType, std::string>;
 
@@ -2355,7 +2355,7 @@ TEST_F(NVFuserTest, FusionUnaryOps_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionBinaryOps_CUDA) {
+TEST_F(NVFuserTest, BinaryOps) {
   using AtenFuncSig = at::Tensor (*)(const at::Tensor&, const at::Tensor&);
   using OpTuple = std::tuple<AtenFuncSig, BinaryOpType, std::string>;
 
@@ -2528,7 +2528,7 @@ TEST_F(NVFuserTest, FusionBinaryOps_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionTernaryOps_CUDA) {
+TEST_F(NVFuserTest, TernaryOps) {
   std::vector<DataType> dtypes = {
       DataType::Double,
       DataType::Float,
@@ -2613,7 +2613,7 @@ TEST_F(NVFuserTest, FusionTernaryOps_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionCompoundOps_CUDA) {
+TEST_F(NVFuserTest, CompoundOps) {
   std::vector<DataType> dtypes = {
       DataType::Double,
       DataType::Float,
@@ -2665,7 +2665,7 @@ TEST_F(NVFuserTest, FusionCompoundOps_CUDA) {
   }
 }
 
-TEST_F(NVFuserTest, FusionFp8CastOps_CUDA) {
+TEST_F(NVFuserTest, Fp8CastOps) {
   std::vector<DataType> fp8_variants(
       {DataType::Float8_e4m3fn, DataType::Float8_e5m2});
   std::vector<DataType> cast_targets(
@@ -2756,6 +2756,75 @@ TEST_F(NVFuserTest, BitCeilKernel) {
 
   EXPECT_TRUE(cg_output.equal(expect_cpu.cuda()));
 }
+
+class AdvancedDtypeTest : public NVFuserFixtureParamTest<bool> {
+ protected:
+  bool use_dynamic_shape;
+  void SetUp() {
+    use_dynamic_shape = GetParam();
+  }
+};
+
+TEST_P(AdvancedDtypeTest, CopyKernelPointer) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  DataType dtype = PointerType{std::make_shared<DataType>(DataType::Float)};
+
+  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype) : makeContigConcreteTensor({2048}, dtype);
+  fusion.addInput(tv0);
+  TensorView* tv1 = set(tv0);
+  fusion.addOutput(tv1);
+
+  tv1->axis(0)->parallelize(ParallelType::TIDx);
+
+  inlineMost();
+
+  auto options = at::TensorOptions().dtype(torch::kUInt64).device(at::kCUDA, 0);
+  at::Tensor input = at::randint(0, 1LL << 63, {1024}, options);
+
+  KernelExecutor ke;
+  ke.compile(&fusion, {input});
+  auto outputs = ke.run({input});
+
+  EXPECT_TRUE(outputs[0].as<at::Tensor>().equal(input));
+}
+
+TEST_P(AdvancedDtypeTest, CopyKernel3ByteArray) {
+  Fusion fusion;
+  FusionGuard fg(&fusion);
+
+  DataType dtype = ArrayType{std::make_shared<DataType>(DataType::Byte), 3};
+
+  TensorView* tv0 = use_dynamic_shape ? makeContigTensor(1, dtype) : makeContigConcreteTensor({300}, dtype);
+  fusion.addInput(tv0);
+  TensorView* tv1 = set(tv0);
+  fusion.addOutput(tv1);
+
+  tv1->axis(0)->parallelize(ParallelType::TIDx);
+
+  inlineMost();
+
+  auto options = at::TensorOptions().dtype(torch::kUInt8).device(at::kCUDA, 0);
+  at::Tensor input = at::randint(0, 256, {900}, options);
+
+  KernelExecutor ke;
+  ke.compile(&fusion, {input});
+  auto outputs = ke.run({input});
+
+  EXPECT_TRUE(outputs[0].as<at::Tensor>().equal(input));
+}
+
+std::string advancedDtypeTestName(const testing::TestParamInfo<bool>& info) {
+  const auto& dynamic_shape = info.param;
+  return "DynamicShape" + std::to_string(dynamic_shape);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    AdvancedDtypeTest,
+    testing::Combine(testing::Values(false, true)),
+    advancedDtypeTestName);
 
 TEST_F(NVFuserTest, BitCeilEval) {
   Fusion fusion;


### PR DESCRIPTION
See code comment:

```C++
// NVFuser's DataType is much wider than PyTorch's ScalarType, and we do support
// input/output TensorViews with these data types not supported by PyTorch.
// For these cases, we use a PyTorch ScalarType as a proxy. If there exists
// a scalar type with the same size, we use that. Otherwise, we use Byte and
// and adjust the size of the last dimension. For example, if we have a
// TensorView with shape [10, 4], and dtype is 3 bytes, then the corresponding
// ScalarType is Byte, and the shape of the corresponding at::Tensor is [10, 12].
```