### PR TITLE
Add embedding_indexing benchmark and Llama 4 Maverick configuration

### DIFF
--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -25,6 +25,7 @@ EMBEDDING_CONFIGS = [
 ]
 
 SEQ_LENGTHS = [
+    1,  # Decode phase
     1024,
     2048,
     3072,

--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import Callable
+
 import pytest
 
 import torch
@@ -13,7 +15,7 @@ from .core import (
     DEFAULT_EXECUTORS,
 )
 from .global_params import FLOAT_DTYPES
-from .torch_ops import embedding
+from .torch_ops import embedding, embedding_indexing
 
 
 # (vocab, hidden) configurations seen in models.
@@ -39,17 +41,24 @@ SEQ_LENGTHS = [
     32768,
 ]
 
+FNS = [
+    pytest.param(embedding, id="embedding"),
+    pytest.param(embedding_indexing, id="embedding_indexing"),
+]
+
 # To run this benchmark and group results by embedding size and sequence length, use:
 # pytest --benchmark-group-by=group,param:vocab_hidden,param:seq_length,param:dtype test_embedding.py  --benchmark-eager --benchmark-thunder --benchmark-torchcompile
 @pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
 @pytest.mark.parametrize("seq_length", SEQ_LENGTHS)
 @pytest.mark.parametrize("vocab_hidden", EMBEDDING_CONFIGS)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("fn", FNS)
 def test_embedding_fwd_baseline_benchmark(
     benchmark,
     seq_length: int,
     vocab_hidden: tuple,
     dtype: torch.dtype,
+    fn: Callable,
     executor: str,
 ):
     kwargs = {}
@@ -61,7 +70,7 @@ def test_embedding_fwd_baseline_benchmark(
     indices = torch.randint(0, vocab_hidden[0], (seq_length,), device="cuda")
     embedding_table = torch.randn(vocab_hidden, device="cuda", dtype=dtype)
 
-    benchmark_fn = with_executor(executor, embedding, **kwargs)
+    benchmark_fn = with_executor(executor, fn, **kwargs)
     run_benchmark(
         benchmark,
         benchmark_fn,

--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -21,6 +21,7 @@ EMBEDDING_CONFIGS = [
     (152064, 3584),  # hf_qwen2
     (32064, 3072),  # hf_phi3
     (131072, 5120),  # hf_mistral_nemo
+    (202048, 5120),  # https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E
 ]
 
 SEQ_LENGTHS = [
@@ -36,7 +37,6 @@ SEQ_LENGTHS = [
     28672,
     32768,
 ]
-
 
 @pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
 @pytest.mark.parametrize("seq_length", SEQ_LENGTHS)

--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -39,6 +39,8 @@ SEQ_LENGTHS = [
     32768,
 ]
 
+# To run this benchmark and group results by embedding size and sequence length, use:
+# pytest --benchmark-group-by=group,param:vocab_hidden,param:seq_length,param:dtype test_embedding.py  --benchmark-eager --benchmark-thunder --benchmark-torchcompile
 @pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
 @pytest.mark.parametrize("seq_length", SEQ_LENGTHS)
 @pytest.mark.parametrize("vocab_hidden", EMBEDDING_CONFIGS)

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -88,6 +88,11 @@ def embedding(inputs: list):
     return F.embedding(indices, embedding_table)
 
 
+def embedding_indexing(inputs: list):
+    indices, embedding_table = inputs
+    return embedding_table[indices]
+
+
 # deepseek v3 moe scatter
 # commit e815299
 # https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py#L599-L607


### PR DESCRIPTION
This pull request introduces a new benchmark for `embedding_indexing(indices, weight): weight[indices]` to compare its performance against the standard `torch.nn.functional.embedding` operation.

This will allow for direct comparison of the two embedding implementations under various configurations of sequence length, vocabulary size, and hidden dimension size.

Changes:
* Added Llama 4 Maverick embedding configuration
* Added 1 token input sequence length for benchmarking the decode phase in inference
* Added embedding_indexing to the list of functions to be benchmarked in test_embedding.py.
* Parameterized the forward pass benchmark to run for both embedding and embedding_indexing.