### PR TITLE
Add fused Embedding and RMSNorm benchmarks

### DIFF
--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -15,7 +15,7 @@ from .core import (
     DEFAULT_EXECUTORS,
 )
 from .global_params import FLOAT_DTYPES
-from .torch_ops import embedding, embedding_indexing
+from .torch_ops import embedding, embedding_indexing, rmsnorm, rmsnorm_rsqrt
 
 
 # (vocab, hidden) configurations seen in models.
@@ -42,6 +42,11 @@ SEQ_LENGTHS = [
 FNS = [
     pytest.param(embedding, id="embedding"),
     pytest.param(embedding_indexing, id="embedding_indexing"),
+]
+
+RMS_NORM_FNS = [
+    pytest.param(rmsnorm, id="rmsnorm"),
+    pytest.param(rmsnorm_rsqrt, id="rmsnorm_rsqrt"),
 ]
 
 
@@ -105,4 +110,41 @@ def test_embedding_bwd_baseline_benchmark(
         benchmark,
         unary_bwd_torch,
         [outputs, grads, *fwd_inputs],
+    )
+
+# Almost all transformer models use rmsnorm after the embedding layer and nvFuser should be able to fuse this.
+# To run this benchmark and group results by embedding size and sequence length, use:
+# pytest --benchmark-group-by=group,param:vocab_hidden,param:seq_length,param:dtype test_embedding.py  -k "test_embedding_rmsnorm_inference" --benchmark-eager --benchmark-thunder --benchmark-torchcompile
+@pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
+@pytest.mark.parametrize("seq_length", SEQ_LENGTHS)
+@pytest.mark.parametrize("vocab_hidden", EMBEDDING_CONFIGS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("embedding_fn", FNS)
+@pytest.mark.parametrize("rmsnorm_fn", RMS_NORM_FNS)
+def test_embedding_rmsnorm_inference(
+    benchmark,
+    seq_length: int,
+    vocab_hidden: tuple,
+    dtype: torch.dtype,
+    embedding_fn: Callable,
+    rmsnorm_fn: Callable,
+    executor: str,
+):
+    kwargs = {}
+    if executor == "torchcompile":
+        clear_dynamo_cache()
+
+    indices = torch.randint(0, vocab_hidden[0], (seq_length,), device="cuda")
+    embedding_table = torch.randn(vocab_hidden, device="cuda", dtype=dtype)
+    rmsnorm_weights = torch.randn(vocab_hidden[1], device="cuda", dtype=dtype)
+
+    def fn(inputs: list):
+        indices, embedding_table, rmsnorm_weights = inputs
+        return rmsnorm_fn([embedding_fn([indices, embedding_table]), rmsnorm_weights])
+
+    benchmark_fn = with_executor(executor, fn, **kwargs)
+    run_benchmark(
+        benchmark,
+        benchmark_fn,
+        [indices, embedding_table, rmsnorm_weights],
     )

--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -140,7 +140,7 @@ def test_embedding_rmsnorm_inference(
 
     def fn(inputs: list):
         indices, embedding_table, rmsnorm_weights = inputs
-        return rmsnorm_fn([embedding_fn([indices, embedding_table]), rmsnorm_weights])
+        return rmsnorm_fn([embedding_fn([indices, embedding_table]).float(), rmsnorm_weights]).to(dtype)
 
     benchmark_fn = with_executor(executor, fn, **kwargs)
     run_benchmark(

--- a/benchmarks/python/test_embedding.py
+++ b/benchmarks/python/test_embedding.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
+from typing import Callable
+
 import pytest
 
 import torch
@@ -13,7 +15,7 @@ from .core import (
     DEFAULT_EXECUTORS,
 )
 from .global_params import FLOAT_DTYPES
-from .torch_ops import embedding
+from .torch_ops import embedding, embedding_indexing
 
 
 # (vocab, hidden) configurations seen in models.
@@ -35,6 +37,11 @@ SEQ_LENGTHS = [
     24576,
     28672,
     32768,
+]
+
+FNS = [
+    pytest.param(embedding, id="embedding"),
+    pytest.param(embedding_indexing, id="embedding_indexing"),
 ]
 
 

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -68,6 +68,14 @@ def rmsnorm(inputs: list):
     return output
 
 
+def rmsnorm_rsqrt(inputs: list):
+    inp, weights = inputs
+    squared_mean = (inp**2).mean(1, keepdim=True)
+    rms_eps = torch.rsqrt(squared_mean + 1e-5)
+    output = weights * inp * rms_eps
+    return output
+
+
 def scale_bias_relu(inputs: list):
     inp, scale, bias = inputs
     return F.relu(inp * scale + bias)

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -88,6 +88,11 @@ def embedding(inputs: list):
     return F.embedding(indices, embedding_table)
 
 
+def embedding_indexing(inputs: list):
+    indices, embedding_table = inputs
+    return embedding_table[indices]
+
+
 # deepseek v3 moe scatter
 # commit e815299
 # https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py#L599-L607


### PR DESCRIPTION
This pull request introduces new benchmarks to evaluate the performance of fused Embedding and RMSNorm operations. RMSNorm is commonly applied after the Embedding layer in many transformer models, so this benchmark provides a realistic scenario for an important fusion pattern.

The new benchmark, test_embedding_rmsnorm_inference, is designed to test various combinations of embedding (indexing or `torch.nn.functional.embedding` and RMSNorm implementations (with rsqrt or sqrt). It is parameterized to run across different executors (eager, thunder, torchcompile), sequence lengths, embedding configurations, and data types. This will allow for a comprehensive analysis of performance gains from fusing these operations.

In the decoding phase, embedding is a latency-bound operation; fusing it with RMS norm should help convert it to a memory-bound operation.