### PR TITLE
Fix condition for smem limit in kernel executor

### DIFF
--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -911,7 +911,7 @@ void KernelExecutor::validateDynamicSmemSize(int64_t dynamic_smem_size) {
         expected_dynamic_smem_size);
   }
   NVF_ERROR(
-      getStaticSmemSize() + dynamic_smem_size < device_smem_limit_,
+      getStaticSmemSize() + dynamic_smem_size <= device_smem_limit_,
       "The total shared memory allocation is larger than available memory.",
       " Dynamic size: ",
       dynamic_smem_size,

--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -203,6 +203,9 @@ class KernelExecutor : public ExecutorAbstract {
     return compiled_kernel_;
   }
 
+  //! Get the static shared memory size of the current compiled kernel
+  int64_t getStaticSmemSize();
+
  private:
   LaunchParams computeLaunchParams(
       const LaunchParams& launch_constraints,
@@ -272,9 +275,6 @@ class KernelExecutor : public ExecutorAbstract {
 
   //! Get the current dynamic shared memory size
   int64_t getAvailableDynamicSmemSize();
-
-  //! Get the static shared memory size of the current compiled kernel
-  int64_t getStaticSmemSize();
 
   //! Check if the shared memory size can be expandable to accommodate
   //! the given dynamic size. The total shared memory size consumed

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -9093,17 +9093,21 @@ TEST_F(NVFuserTest, DeviceSharedMemoryLimit) {
 TEST_F(NVFuserTest, UseAllSharedMemory) {
   const auto properties = at::cuda::getDeviceProperties(
       c10::Device(c10::DeviceType::CUDA, 0).index());
-  const int64_t available_dyn_smem_bytes =
-      (int64_t)properties->sharedMemPerBlockOptin;
 
-  const PrimDataType dtype = DataType::Float;
+  // This kernel requires some static smem for some reason. We validate that
+  // here as well.
+  constexpr int64_t expected_static_smem = 16L;
+  const int64_t available_dyn_smem_bytes =
+      (int64_t)properties->sharedMemPerBlockOptin - expected_static_smem;
+
+  const PrimDataType dtype = DataType::Char;
   EXPECT_EQ(available_dyn_smem_bytes % dataTypeSizeByte(dtype), 0);
   const int64_t len = available_dyn_smem_bytes / dataTypeSizeByte(dtype);
 
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  auto tv0 = makeConcreteTensor({len});
+  auto tv0 = makeConcreteTensor({len}, dtype);
   fusion.addInput(tv0);
 
   auto tv1 = set(tv0);
@@ -9112,8 +9116,8 @@ TEST_F(NVFuserTest, UseAllSharedMemory) {
   auto tv1_smem = tv1->cacheBefore();
   tv1_smem->setMemoryType(MemoryType::Shared);
 
-  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
-  at::Tensor t0 = at::randn({len}, options);
+  auto options = at::TensorOptions().dtype(at::kChar).device(at::kCUDA, 0);
+  at::Tensor t0 = at::randint(0, 128, {len}, options);
 
   KernelExecutor ke;
   ke.compile(&fusion, {t0});
@@ -9123,6 +9127,7 @@ TEST_F(NVFuserTest, UseAllSharedMemory) {
   // check that we used the full device
   int64_t actual_smem = ke.lastLaunchParams().smem();
   EXPECT_EQ(actual_smem, available_dyn_smem_bytes);
+  EXPECT_EQ(ke.getStaticSmemSize(), expected_static_smem);
 }
 
 // Test file size should be up to 10K LoC. Create a new file for more tests.


### PR DESCRIPTION
Previously we checked that the required static+dynamic smem of our kernels are < the device limit. This causes problems on some unlucky matmul problem sizes were we'd like to use the entire range of shared memory. This PR changes that condition to <=.

I also added a test that tries to exercise this and noticed that the kernel required 16 bytes of static smem surprisingly. 