### PR TITLE
Add a test to exercise a mix of meta Exprs and kernels.

### DIFF
--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -674,8 +674,8 @@ void HostIrEvaluator::handle(LinearOp* linear) {
 
 void HostIrEvaluator::handle(LoadStoreOp* load_store_op) {
   NVF_ERROR(
-      load_store_op->opType() == LoadStoreOpType::Set,
-      "LoadStoreOp must be a Set");
+      load_store_op->opType() == LoadStoreOpType::Set ||
+      load_store_op->opType() == LoadStoreOpType::SegmenterSet);
   NVF_ERROR(
       load_store_op->out()->isA<TensorView>(), "out must be a TensorView");
   auto* out_tv = load_store_op->out()->as<TensorView>();


### PR DESCRIPTION
This is for @naoyam to understand #4230. 

```
[ RUN      ] HostIrIntegrationTest.ExprEvalAndKernel

%HostIrContainer { (T0_g_float[iS0{i0}, iS1{i2}]) -> (T3_g_float[rS6{i2}, iS7{i0}]) :
  T1_l_float[iS3{i2}, iS2{i0}]
     = Set.Permute( T0_g_float[iS0{i0}, iS1{i2}], cache_op=Streaming )
  Deallocate {
    T0_g_float[iS0{i0}, iS1{i2}]
  }
  T2_g_float[iS4{i2}, iS5{i0}]
     = SegmenterSet( T1_l_float[iS3{i2}, iS2{i0}] )
  Deallocate {
    T1_l_float[iS3{i2}, iS2{i0}]
  }
  T3_g_float[rS6{i2}, iS7{i0}] = ALLOCATE(buffer=T3_g_float[rS6{i2}, iS7{i0}], mem_type=global, size=i0, zero_init=false, resets_to_zero=false)
  LaunchKernel(
    Group ID: 0,
    Inputs: {T2_g_float[iS4{i2}, iS5{i0}]},
    Outputs: {T3_g_float[rS6{i2}, iS7{i0}]},
  )
  Deallocate {
    T2_g_float[iS4{i2}, iS5{i0}]
  }
} // %HostIrContainer

[       OK ] HostIrIntegrationTest.ExprEvalAndKernel (231 ms)
```