### PR TITLE
[RFC] Add Cutlass FP8 Grouped Gemm to `nvfuser_direct` python bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           source tools/setup-env.sh
           wait
           cd python
-          python setup.py build --cpp=23
+          python setup.py build --no-cutlass --cpp=23
 
   dynamic-type-meson:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(NVFUSER_PYTHON_DIR "${NVFUSER_ROOT}/python")
 set(NVFUSER_PYTHON_BINDINGS "${NVFUSER_ROOT}/python/python_frontend")
 set(NVFUSER_PYTHON_COMMON "${NVFUSER_ROOT}/python/python_common")
 set(NVFUSER_PYTHON_DIRECT_BINDINGS "${NVFUSER_ROOT}/python/python_direct")
+set(NVFUSER_CUTLASS "${NVFUSER_ROOT}/cutlass")
 set(NVFUSER_THIRD_PARTY_DIR "${NVFUSER_ROOT}/third_party")
 
 option(NVFUSER_STANDALONE_BUILD_WITH_UCC "" OFF)
@@ -467,6 +468,74 @@ install(DIRECTORY "${NVFUSER_THIRD_PARTY_DIR}/flatbuffers/include/flatbuffers/"
 install(DIRECTORY "${NVFUSER_ROOT}/lib/dynamic_type/src/dynamic_type"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvfuser")
 
+set(CUTLASS_STATUS "N/A")
+if(BUILD_CUTLASS)
+  enable_language(CUDA)
+
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8)
+    message(WARNING "Skip building CUTLASS because of incompatible CUDA ${CMAKE_CUDA_COMPILER_VERSION}")
+    set(CUTLASS_STATUS "DISABLED")
+  else()
+    add_compile_definitions(NVFUSER_ENABLE_CUTLASS)
+    set(CUTLASS_STATUS "ENABLED")
+
+    find_package(CUDAToolkit REQUIRED)
+    include(FetchContent)
+
+    # cutlass
+    FetchContent_Declare(
+      repo-cutlass
+      GIT_REPOSITORY https://github.com/NVIDIA/cutlass
+      GIT_TAG        f115c3f85467d5d9619119d1dbeb9c03c3d73864
+      GIT_SHALLOW    OFF
+    )
+    FetchContent_Populate(repo-cutlass)
+
+    include(ProcessorCount)
+    ProcessorCount(NPROC)
+
+    set(NVF_CUTLASS_CUDA_FLAGS
+      "-DCUTE_USE_PACKED_TUPLE=1"
+      "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1"
+      "-DCUTLASS_VERSIONS_GENERATED"
+      "-DCUTLASS_TEST_LEVEL=0"
+      "-DCUTLASS_TEST_ENABLE_CACHED_RESULTS=1"
+      "-DCUTLASS_DEBUG_TRACE_LEVEL=0"
+      "--expt-relaxed-constexpr"
+      "--expt-extended-lambda"
+      "--threads=${NPROC}"
+      # Suppress warnings
+      "-Xcompiler=-Wconversion"
+      "-Xcompiler=-fno-strict-aliasing"
+    )
+
+    set(NVFUSER_CUTLASS_SRCS)
+    list(APPEND NVFUSER_CUTLASS_SRCS
+        ${NVFUSER_CUTLASS}/fp8_blockwise_moe_kernel.cu
+        ${NVFUSER_CUTLASS}/cutlass_utils.cpp
+        )
+    add_library(nvf_cutlass SHARED ${NVFUSER_CUTLASS_SRCS})
+    set_target_properties(nvf_cutlass PROPERTIES
+        CUDA_STANDARD ${NVFUSER_CUDA_STANDARD}
+        CXX_STANDARD ${NVFUSER_CPP_STANDARD}
+        POSITION_INDEPENDENT_CODE Yes
+    )
+    target_include_directories(nvf_cutlass PUBLIC ${NVFUSER_CUTLASS})
+    target_include_directories(nvf_cutlass PUBLIC ${NVFUSER_SRCS_DIR})
+    target_include_directories(nvf_cutlass PUBLIC ${repo-cutlass_SOURCE_DIR}/include)
+    target_include_directories(nvf_cutlass PUBLIC ${repo-cutlass_SOURCE_DIR}/tools/util/include)
+    target_compile_options(nvf_cutlass PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${NVF_CUTLASS_CUDA_FLAGS}>)
+    if(NOT MSVC)
+      set(NVF_LIB_SUFFIX ".so")
+    else()
+      set(NVF_LIB_SUFFIX ".pyd")
+    endif()
+    set_target_properties(nvf_cutlass PROPERTIES CUDA_ARCHITECTURES "100a")
+    target_link_libraries(nvf_cutlass PRIVATE "${TORCH_LIBRARIES}" c10)
+    install(TARGETS nvf_cutlass DESTINATION lib)
+  endif()
+endif()
+
 if(BUILD_PYTHON)
   # -----------------------------
   # build nvfuser python library
@@ -483,6 +552,7 @@ if(BUILD_PYTHON)
   add_library(nvf_py_internal OBJECT ${NVFUSER_PYTHON_SRCS})
   target_include_directories(nvf_py_internal PUBLIC ${NVFUSER_PYTHON_DIR})
   target_include_directories(nvf_py_internal PUBLIC ${NVFUSER_PYTHON_COMMON})
+  target_include_directories(nvf_py_internal PUBLIC ${NVFUSER_CUTLASS})
   target_include_directories(nvf_py_internal SYSTEM INTERFACE
     ${CMAKE_SOURCE_DIR}/third_party/flatbuffers/include
   )
@@ -573,6 +643,7 @@ if(BUILD_PYTHON)
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/enum.cpp
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/ir.cpp
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/ops.cpp
+    ${NVFUSER_PYTHON_DIRECT_BINDINGS}/cutlass.cpp
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/runtime.cpp
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/direct_utils.cpp
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/python_translate.cpp
@@ -620,7 +691,7 @@ if(BUILD_PYTHON)
     CXX_STANDARD_REQUIRED ON
     CXX_VISIBILITY_PRESET hidden
     INSTALL_RPATH
-    "$ORIGIN/lib:$ORIGIN/../nvidia/cuda_runtime/lib:$ORIGIN/../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../torch/lib"
+    "$ORIGIN/lib:$ORIGIN/../nvfuser_common/lib:$ORIGIN/../nvidia/cuda_runtime/lib:$ORIGIN/../nvidia/cuda_nvrtc/lib:$ORIGIN/../../nvidia/cuda_cupti/lib:$ORIGIN/../torch/lib"
     POSITION_INDEPENDENT_CODE Yes
     SUFFIX ${NVF_LIB_SUFFIX}
     VISIBILITY_INLINES_HIDDEN Yes
@@ -628,11 +699,20 @@ if(BUILD_PYTHON)
 
   target_include_directories(nvf_py_direct_internal PUBLIC ${NVFUSER_PYTHON_DIRECT_BINDINGS})
   target_include_directories(nvf_py_direct_internal PUBLIC ${NVFUSER_PYTHON_COMMON})
-  target_link_libraries(nvf_py_direct_internal PRIVATE
-    codegen_internal
-    "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
-    pybind11::pybind11 pybind11::headers
-  )
+  if (BUILD_CUTLASS AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
+    target_link_libraries(nvf_py_direct_internal PRIVATE
+      codegen_internal
+      nvf_cutlass
+      "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+      pybind11::pybind11 pybind11::headers
+    )
+  else()
+    target_link_libraries(nvf_py_direct_internal PRIVATE
+      codegen_internal
+      "${TORCH_INSTALL_PREFIX}/lib/libtorch_python.so"
+      pybind11::pybind11 pybind11::headers
+    )
+  endif()
 
   target_link_libraries(nvfuser_direct PRIVATE
     nvf_py_direct_internal
@@ -1085,6 +1165,7 @@ file(CREATE_LINK "${CMAKE_BINARY_DIR}" "${NVFUSER_ROOT}/bin" SYMBOLIC)
 
 message(STATUS "")
 message(STATUS "******** Nvfuser configuration summary ********")
+message(STATUS "  BUILD_CUTLASS: ${CUTLASS_STATUS}")
 message(STATUS "  UCC_FOUND: ${UCC_FOUND}")
 message(STATUS "  NVFUSER_STANDALONE_BUILD_WITH_UCC  : ${NVFUSER_STANDALONE_BUILD_WITH_UCC}")
 message(STATUS "  NVFUSER_BUILD_WITH_ASAN            : ${NVFUSER_BUILD_WITH_ASAN}")

--- a/cutlass/cutlass_utils.cpp
+++ b/cutlass/cutlass_utils.cpp
@@ -1,0 +1,24 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <cutlass_utils.h>
+
+namespace nvfuser::cutlass_kernels {
+
+int getSMVersion() {
+  int device{-1};
+  CHECK_CUDA_SUCCESS(cudaGetDevice(&device));
+  int sm_major = 0;
+  int sm_minor = 0;
+  CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(
+      &sm_major, cudaDevAttrComputeCapabilityMajor, device));
+  CHECK_CUDA_SUCCESS(cudaDeviceGetAttribute(
+      &sm_minor, cudaDevAttrComputeCapabilityMinor, device));
+  return sm_major * 10 + sm_minor;
+}
+
+} // namespace nvfuser::cutlass_kernels

--- a/cutlass/cutlass_utils.h
+++ b/cutlass/cutlass_utils.h
@@ -1,0 +1,44 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <cuda_runtime.h>
+#include <sstream>
+#include <stdexcept>
+
+namespace nvfuser::cutlass_kernels {
+
+struct cuda_error : public std::runtime_error {
+  /**
+   * @brief Constructs a `cuda_error` object with the given `message`.
+   *
+   * @param message The error char array used to construct `cuda_error`
+   */
+  cuda_error(const char* message) : std::runtime_error(message) {}
+  /**
+   * @brief Constructs a `cuda_error` object with the given `message` string.
+   *
+   * @param message The `std::string` used to construct `cuda_error`
+   */
+  cuda_error(std::string const& message) : cuda_error{message.c_str()} {}
+};
+
+#define CHECK_CUDA_SUCCESS(cmd)                                         \
+  do {                                                                  \
+    cudaError_t e = cmd;                                                \
+    if (e != cudaSuccess) {                                             \
+      std::stringstream _message;                                       \
+      auto s = cudaGetErrorString(e);                                   \
+      _message << std::string(s) + "\n" << __FILE__ << ':' << __LINE__; \
+      throw cuda_error(_message.str());                                 \
+    }                                                                   \
+  } while (0)
+
+int getSMVersion();
+
+} // namespace nvfuser::cutlass_kernels

--- a/cutlass/fp8_blockwise_moe_kernel.cu
+++ b/cutlass/fp8_blockwise_moe_kernel.cu
@@ -1,0 +1,691 @@
+#include <cutlass_utils.h>
+#include <nvf_cutlass.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cutlass/arch/arch.h>
+#include <torch/torch.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/thread/activation.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/kernel/tile_scheduler_params.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/distribution.h"
+#include "cutlass/util/host_tensor.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "cutlass/util/tensor_view_io.h"
+
+#include <exceptions.h>
+
+namespace nvfuser::cutlass_kernels {
+
+using namespace cute;
+
+template <
+    typename ElementAB,
+    typename ElementC,
+    typename ElementAccumulator,
+    typename LayoutSFA,
+    typename LayoutSFB,
+    typename ScaleConfig>
+__global__ void get_group_gemm_starts(
+    int32_t* expert_offsets,
+    ElementAB** a_offsets,
+    ElementAB** b_offsets,
+    ElementC** out_offsets,
+    ElementAccumulator** a_scales_offsets,
+    ElementAccumulator** b_scales_offsets,
+    ElementAB* a_base_as_int,
+    ElementAB* b_base_as_int,
+    ElementC* out_base_as_int,
+    ElementAccumulator* a_scales_base_as_int,
+    ElementAccumulator* b_scales_base_as_int,
+    LayoutSFA* layout_sfa_base_as_int,
+    LayoutSFB* layout_sfb_base_as_int,
+    int* problem_sizes,
+    int* problem_sizes_transpose,
+    bool transpose = false) {
+  int expert_id = threadIdx.x;
+
+  if (expert_id >= gridDim.x * blockDim.x) {
+    return;
+  }
+
+  int m = problem_sizes[expert_id * 3];
+  int n = problem_sizes[expert_id * 3 + 1];
+  int k = problem_sizes[expert_id * 3 + 2];
+  if (transpose) {
+    problem_sizes_transpose[expert_id * 3] = n;
+    problem_sizes_transpose[expert_id * 3 + 1] = m;
+    problem_sizes_transpose[expert_id * 3 + 2] = k;
+  }
+
+  int32_t expert_offset = expert_offsets[expert_id];
+  int a_stride = 0;
+  int b_stride = 0;
+  int a_scale_stride = 0;
+  int b_scale_stride = 0;
+  if (!transpose) {
+    a_stride = expert_offset * k;
+    b_stride = expert_id * k * n;
+    a_scale_stride = expert_offset * k / 128;
+    b_scale_stride = expert_id * k * n / 128 / 128;
+  } else {
+    a_stride = expert_id * k * n;
+    b_stride = expert_offset * k;
+    a_scale_stride = expert_id * k * n / 128 / 128;
+    b_scale_stride = expert_offset * k / 128;
+  }
+  a_offsets[expert_id] = a_base_as_int + a_stride;
+  b_offsets[expert_id] = b_base_as_int + b_stride;
+  out_offsets[expert_id] = out_base_as_int + expert_offset * n;
+  a_scales_offsets[expert_id] = a_scales_base_as_int + a_scale_stride;
+  b_scales_offsets[expert_id] = b_scales_base_as_int + b_scale_stride;
+
+  LayoutSFA* layout_sfa_ptr = layout_sfa_base_as_int + expert_id;
+  LayoutSFB* layout_sfb_ptr = layout_sfb_base_as_int + expert_id;
+
+  if (!transpose) {
+    *layout_sfa_ptr =
+        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(m, n, k, 1));
+    *layout_sfb_ptr =
+        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(m, n, k, 1));
+  } else {
+    *layout_sfa_ptr =
+        ScaleConfig::tile_atom_to_shape_SFA(cute::make_shape(n, m, k, 1));
+    *layout_sfb_ptr =
+        ScaleConfig::tile_atom_to_shape_SFB(cute::make_shape(n, m, k, 1));
+  }
+}
+
+#define __CALL_GET_STARTS_KERNEL(                                  \
+    TENSOR_C_TYPE, C_TYPE, LayoutSFA, LayoutSFB, ScaleConfig)      \
+  else if (out_tensors.dtype() == TENSOR_C_TYPE) {                 \
+    get_group_gemm_starts<                                         \
+        cutlass::float_e4m3_t,                                     \
+        C_TYPE,                                                    \
+        float,                                                     \
+        LayoutSFA,                                                 \
+        LayoutSFB,                                                 \
+        ScaleConfig><<<1, num_experts, 0, stream>>>(               \
+        static_cast<int32_t*>(expert_offsets.data_ptr()),          \
+        static_cast<cutlass::float_e4m3_t**>(a_ptrs.data_ptr()),   \
+        static_cast<cutlass::float_e4m3_t**>(b_ptrs.data_ptr()),   \
+        static_cast<C_TYPE**>(out_ptrs.data_ptr()),                \
+        static_cast<float**>(a_scales_ptrs.data_ptr()),            \
+        static_cast<float**>(b_scales_ptrs.data_ptr()),            \
+        static_cast<cutlass::float_e4m3_t*>(a_tensors.data_ptr()), \
+        static_cast<cutlass::float_e4m3_t*>(b_tensors.data_ptr()), \
+        static_cast<C_TYPE*>(out_tensors.data_ptr()),              \
+        static_cast<float*>(a_scales.data_ptr()),                  \
+        static_cast<float*>(b_scales.data_ptr()),                  \
+        reinterpret_cast<LayoutSFA*>(layout_sfa.data_ptr()),       \
+        reinterpret_cast<LayoutSFB*>(layout_sfb.data_ptr()),       \
+        static_cast<int*>(problem_sizes.data_ptr()),               \
+        static_cast<int*>(problem_sizes_transpose.data_ptr()),     \
+        transpose);                                                \
+  }
+
+template <typename LayoutSFA, typename LayoutSFB, typename ScaleConfig>
+void run_get_group_gemm_starts(
+    torch::Tensor const& expert_offsets,
+    torch::Tensor& a_ptrs,
+    torch::Tensor& b_ptrs,
+    torch::Tensor& out_ptrs,
+    torch::Tensor& a_scales_ptrs,
+    torch::Tensor& b_scales_ptrs,
+    torch::Tensor const& a_tensors,
+    torch::Tensor const& b_tensors,
+    torch::Tensor& out_tensors,
+    torch::Tensor const& a_scales,
+    torch::Tensor const& b_scales,
+    torch::Tensor const& layout_sfa,
+    torch::Tensor const& layout_sfb,
+    torch::Tensor const& problem_sizes,
+    torch::Tensor& problem_sizes_transpose,
+    bool transpose = false) {
+  NVF_CHECK(a_tensors.dtype() == torch::kFloat8_e4m3fn);
+  NVF_CHECK(b_tensors.dtype() == torch::kFloat8_e4m3fn);
+  NVF_CHECK(a_scales.dtype() == torch::kFloat32);
+  NVF_CHECK(b_scales.dtype() == torch::kFloat32);
+  NVF_CHECK(out_tensors.size(1) % 128 == 0 or out_tensors.size(0) % 128 == 0);
+  NVF_CHECK(a_tensors.size(1) % 128 == 0 or a_tensors.size(0) % 128 == 0);
+
+  int num_experts = (int)expert_offsets.size(0);
+  auto stream = at::cuda::getCurrentCUDAStream(a_tensors.device().index());
+
+  if (false) {
+  }
+  __CALL_GET_STARTS_KERNEL(
+      torch::kBFloat16, cutlass::bfloat16_t, LayoutSFA, LayoutSFB, ScaleConfig)
+  __CALL_GET_STARTS_KERNEL(
+      torch::kFloat16, half, LayoutSFA, LayoutSFB, ScaleConfig)
+  else {
+    NVF_CHECK(false, "Invalid output type (must be float16 or bfloat16)");
+  }
+}
+
+using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;
+template <typename OutType, typename ScheduleConfig, typename LayoutD>
+void launch_sm100_fp8_blockwise_scaled_group_mm(
+    torch::Tensor& out_ptrs,
+    const torch::Tensor& a_ptrs,
+    const torch::Tensor& b_ptrs,
+    const torch::Tensor& a_scales_ptrs,
+    const torch::Tensor& b_scales_ptrs,
+    const torch::Tensor& stride_a,
+    const torch::Tensor& stride_b,
+    const torch::Tensor& stride_c,
+    const torch::Tensor& layout_sfa,
+    const torch::Tensor& layout_sfb,
+    const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets,
+    const torch::Tensor& workspace) {
+  using ProblemShape = cutlass::gemm::GroupProblemShape<Shape<int, int, int>>;
+  using ElementA = cutlass::float_e4m3_t;
+  using ElementB = cutlass::float_e4m3_t;
+  using ElementC = OutType;
+  using ElementD = ElementC;
+  using ElementAccumulator = float;
+  // Layout definitions
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = LayoutD;
+
+  // Alignment constraints
+  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
+  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  // Architecture definitions
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassTensorOp;
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          typename ScheduleConfig::MmaTileShape,
+          typename ScheduleConfig::ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          void,
+          LayoutC*,
+          AlignmentC,
+          ElementD,
+          LayoutC*,
+          AlignmentC,
+          typename ScheduleConfig::EpilogueSchedule>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementA,
+          cute::tuple<LayoutA*, typename ScheduleConfig::LayoutSFA*>,
+          AlignmentA,
+          ElementB,
+          cute::tuple<LayoutB*, typename ScheduleConfig::LayoutSFB*>,
+          AlignmentB,
+          ElementAccumulator,
+          typename ScheduleConfig::MmaTileShape,
+          typename ScheduleConfig::ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          typename ScheduleConfig::KernelSchedule>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::
+      GemmUniversal<ProblemShape, CollectiveMainloop, CollectiveEpilogue, void>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using UnderlyingProblemShape = ProblemShape::UnderlyingProblemShape;
+  using StrideA = typename Gemm::GemmKernel::InternalStrideA;
+  using StrideB = typename Gemm::GemmKernel::InternalStrideB;
+  using StrideC = typename Gemm::GemmKernel::InternalStrideC;
+  using StrideD = typename Gemm::GemmKernel::InternalStrideD;
+
+  int num_experts = (int)expert_offsets.size(0);
+  // Create an instance of the GEMM
+  Gemm gemm_op;
+
+  typename GemmKernel::MainloopArguments mainloop_args{
+      static_cast<const ElementA**>(a_ptrs.data_ptr()),
+      static_cast<StrideA*>(stride_a.data_ptr()),
+      static_cast<const ElementB**>(b_ptrs.data_ptr()),
+      static_cast<StrideB*>(stride_b.data_ptr()),
+      static_cast<const ElementAccumulator**>(a_scales_ptrs.data_ptr()),
+      reinterpret_cast<typename ScheduleConfig::LayoutSFA*>(
+          layout_sfa.data_ptr()),
+      static_cast<const ElementAccumulator**>(b_scales_ptrs.data_ptr()),
+      reinterpret_cast<typename ScheduleConfig::LayoutSFB*>(
+          layout_sfb.data_ptr())};
+
+  cutlass::KernelHardwareInfo hw_info;
+
+  hw_info.device_id = 0;
+  // For SM100 Blackwell, the number of SM is 148.
+  const auto dev_prop = at::cuda::getCurrentDeviceProperties();
+  hw_info.sm_count = dev_prop->multiProcessorCount;
+  // Currently, we are only able to do broadcast on either all or none a_scales
+  // and on either all or none b_scales
+  typename GemmKernel::EpilogueArguments epilogue_args{
+      {},
+      nullptr,
+      static_cast<StrideC*>(stride_c.data_ptr()),
+      static_cast<ElementD**>(out_ptrs.data_ptr()),
+      static_cast<StrideC*>(stride_c.data_ptr())};
+
+  UnderlyingProblemShape* problem_sizes_as_shapes =
+      static_cast<UnderlyingProblemShape*>(problem_sizes.data_ptr());
+  typename GemmKernel::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGrouped,
+      {num_experts, problem_sizes_as_shapes, nullptr},
+      mainloop_args,
+      epilogue_args,
+      hw_info};
+
+  at::cuda::CUDAGuard device_guard{(int8_t)a_ptrs.get_device()};
+  const cudaStream_t stream =
+      at::cuda::getCurrentCUDAStream(a_ptrs.get_device());
+
+  auto can_implement_status = gemm_op.can_implement(args);
+  NVF_CHECK(
+      can_implement_status == cutlass::Status::kSuccess,
+      "Failed to implement GEMM");
+
+  // Run the GEMM
+  auto status = gemm_op.initialize(args, workspace.data_ptr(), stream);
+
+  NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
+
+  status = gemm_op.run(stream);
+  NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
+}
+
+template <typename OutType>
+void sm100_fp8_blockwise_group_mm_dispatch_shape(
+    torch::Tensor& output,
+    torch::Tensor& a_ptrs,
+    torch::Tensor& b_ptrs,
+    torch::Tensor& out_ptrs,
+    torch::Tensor& a_scales_ptrs,
+    torch::Tensor& b_scales_ptrs,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Tensor& stride_a,
+    const torch::Tensor& stride_b,
+    const torch::Tensor& stride_c,
+    const torch::Tensor& layout_sfa,
+    const torch::Tensor& layout_sfb,
+    const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets,
+    const torch::Tensor& workspace) {
+  // Check the first matrix size to decide on the configuration
+  // Assuming all matrices in the group have similar size characteristics
+  // bool use_small_config = a[0].size(0) <= 128;
+  struct MmaConfig1 {
+    using ElementA = cutlass::float_e4m3_t;
+    using MmaTileShape = Shape<_128, _32, _128>;
+    using ClusterShape =
+        Shape<_1, _1, _1>; // Layout type for SFB matrix operand
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise1SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        128,
+        1,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+  struct MmaConfig2 {
+    using ElementA = cutlass::float_e4m3_t;
+    using MmaTileShape = Shape<_128, _128, _128>;
+    using ClusterShape =
+        Shape<_1, _1, _1>; // Layout type for SFB matrix operand
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise1SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        1,
+        128,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+  struct MMAConfig3 {
+    using ElementA = cutlass::float_e4m3_t;
+    using MmaTileShape = Shape<_64, _128, _128>;
+    using ClusterShape =
+        Shape<_1, _1, _1>; // Layout type for SFB matrix operand
+    using KernelSchedule =
+        cutlass::gemm::KernelPtrArrayTmaWarpSpecializedBlockwise1SmSm100;
+    using EpilogueSchedule = cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm;
+    using ScaleConfig = cutlass::detail::Sm100BlockwiseScaleConfig<
+        1,
+        128,
+        128,
+        cute::UMMA::Major::K,
+        cute::UMMA::Major::K>;
+    using LayoutSFA = decltype(ScaleConfig::deduce_layoutSFA());
+    using LayoutSFB = decltype(ScaleConfig::deduce_layoutSFB());
+  };
+  int num_experts = (int)expert_offsets.size(0);
+  torch::TensorOptions options_int =
+      torch::TensorOptions().dtype(torch::kInt64).device(a.device());
+  torch::Tensor problem_sizes_transpose =
+      torch::empty(num_experts * 3, options_int);
+  torch::Tensor output_t = output.t();
+  torch::Tensor a_t = a.t();
+  torch::Tensor b_t = b.transpose(1, 2);
+  torch::Tensor scales_a_t = scales_a.t();
+  torch::Tensor scales_b_t = scales_b.transpose(1, 2);
+
+  if (a.size(0) <= 512 && a.size(1) >= 2048) {
+    run_get_group_gemm_starts<
+        MmaConfig1::LayoutSFA,
+        MmaConfig1::LayoutSFB,
+        MmaConfig1::ScaleConfig>(
+        expert_offsets,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        b_t,
+        a_t,
+        output_t,
+        scales_b_t,
+        scales_a_t,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        problem_sizes_transpose,
+        true);
+    launch_sm100_fp8_blockwise_scaled_group_mm<
+        OutType,
+        MmaConfig1,
+        cutlass::layout::ColumnMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes_transpose,
+        expert_offsets,
+        workspace);
+    output = output_t.t();
+  } else if (a.size(0) > 512 && a.size(1) >= 2048) {
+    run_get_group_gemm_starts<
+        MmaConfig2::LayoutSFA,
+        MmaConfig2::LayoutSFB,
+        MmaConfig2::ScaleConfig>(
+        expert_offsets,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        a,
+        b,
+        output,
+        scales_a,
+        scales_b,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        problem_sizes_transpose);
+    launch_sm100_fp8_blockwise_scaled_group_mm<
+        OutType,
+        MmaConfig2,
+        cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        expert_offsets,
+        workspace);
+  } else {
+    run_get_group_gemm_starts<
+        MMAConfig3::LayoutSFA,
+        MMAConfig3::LayoutSFB,
+        MMAConfig3::ScaleConfig>(
+        expert_offsets,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        a,
+        b,
+        output,
+        scales_a,
+        scales_b,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        problem_sizes_transpose);
+    launch_sm100_fp8_blockwise_scaled_group_mm<
+        OutType,
+        MMAConfig3,
+        cutlass::layout::RowMajor>(
+        out_ptrs,
+        a_ptrs,
+        b_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        stride_a,
+        stride_b,
+        stride_c,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        expert_offsets,
+        workspace);
+  }
+}
+
+/**
+ * @brief Performs blockwise grouped matrix multiplication on FP8 quantized
+ * inputs, with per-block scaling.
+ *
+ * This function dispatches to hardware-specific implementations (e.g., SM100
+ * FP8) to compute: C_i = scale_a[i] * A_i * scale_b[i] * B_i for each expert
+ * group `i`, using input `problem_sizes` and `expert_offsets` to describe the
+ * individual matrix dimensions and their offsets.
+ *
+ * Input tensors A and B must be quantized to 8-bit formats and dequantized
+ * before multiplication. The output tensor is written with bfloat16 or half
+ * precision.
+ *
+ * @param output         Output tensor (must be of type bfloat16 or half).
+ * @param a              Input tensor A (must be kFloat8_e4m3fn).
+ * @param b              Input tensor B (must be kFloat8_e4m3fn).
+ * @param scales_a       Scaling factors for tensor A, float32 per expert group.
+ * @param scales_b       Scaling factors for tensor B, float32 per expert group.
+ * @param stride_a       Stride information for tensor A (int32).
+ * @param stride_b       Stride information for tensor B (int32).
+ * @param stride_c       Stride information for output tensor C (int32).
+ * @param layout_sfa     Layout descriptor for A (int32), e.g.,
+ * row-major/column-major.
+ * @param layout_sfb     Layout descriptor for B (int32).
+ * @param problem_sizes  2D int32 tensor of shape (num_experts, 3), specifying
+ * (M, N, K) for each grouped matrix multiplication problem.
+ * @param expert_offsets 1D int32 tensor of size (num_experts), used to index
+ * into the grouped input tensors for dispatch.
+ *  @note Performance Optimization:
+ *       If the batch size (a.size(0)) is smaller than 512, the implementation
+ *       will internally transpose input matrices to align with the optimal
+ * memory access pattern for better GPU efficiency. This transformation is done
+ * within the kernel.
+ */
+void fp8_blockwise_scaled_grouped_mm(
+    torch::Tensor& output,
+    torch::Tensor& a_ptrs,
+    torch::Tensor& b_ptrs,
+    torch::Tensor& out_ptrs,
+    torch::Tensor& a_scales_ptrs,
+    torch::Tensor& b_scales_ptrs,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Tensor& stride_a,
+    const torch::Tensor& stride_b,
+    const torch::Tensor& stride_c,
+    const torch::Tensor& layout_sfa,
+    const torch::Tensor& layout_sfb,
+    const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets,
+    const torch::Tensor& workspace) {
+  NVF_CHECK(problem_sizes.dim() == 2, "problem_sizes must be 2D tensor");
+  NVF_CHECK(
+      problem_sizes.size(1) == 3,
+      "problem_sizes must have shape (num_experts, 3)");
+  NVF_CHECK(
+      problem_sizes.size(0) == expert_offsets.size(0),
+      "Number of experts in problem_sizes must match expert_offsets");
+  NVF_CHECK(
+      problem_sizes.dtype() == torch::kInt32, "problem_sizes must be int32");
+  NVF_CHECK(
+      a.scalar_type() == torch::kFloat8_e4m3fn, "a must be kFloat8_e4m3fn");
+  NVF_CHECK(
+      b.scalar_type() == torch::kFloat8_e4m3fn, "b must be kFloat8_e4m3fn");
+  NVF_CHECK(
+      output.scalar_type() == torch::kBFloat16 ||
+          output.scalar_type() == torch::kHalf,
+      "output must be bfloat16 or half");
+  NVF_CHECK(
+      scales_a.scalar_type() == torch::kFloat32, "scales_a must be float32");
+  NVF_CHECK(
+      scales_b.scalar_type() == torch::kFloat32, "scales_b must be float32");
+  NVF_CHECK(stride_a.scalar_type() == torch::kInt64, "stride_a must be int64");
+  NVF_CHECK(stride_b.scalar_type() == torch::kInt64, "stride_b must be int64");
+  NVF_CHECK(stride_c.scalar_type() == torch::kInt64, "stride_c must be int64");
+  NVF_CHECK(
+      layout_sfa.scalar_type() == torch::kInt32, "layout_sfa must be int32");
+  NVF_CHECK(
+      layout_sfb.scalar_type() == torch::kInt32, "layout_sfb must be int32");
+  NVF_CHECK(
+      expert_offsets.scalar_type() == torch::kInt32,
+      "expert_offsets must be int32");
+
+  NVF_CHECK(output.dim() == 2, "output must be 2D tensor");
+  NVF_CHECK(a.dim() == 2, "a must be 2D tensor");
+  NVF_CHECK(b.dim() == 3, "b must be 3D tensor");
+  NVF_CHECK(scales_a.dim() == 2, "scales_a must be 2D tensor");
+  NVF_CHECK(scales_b.dim() == 3, "scales_b must be 3D tensor");
+  NVF_CHECK(stride_a.dim() == 1, "stride_a must be 1D tensor");
+  NVF_CHECK(stride_b.dim() == 1, "stride_b must be 1D tensor");
+  NVF_CHECK(stride_c.dim() == 1, "stride_c must be 1D tensor");
+  NVF_CHECK(layout_sfa.dim() == 2, "layout_sfa must be 1D tensor");
+  NVF_CHECK(layout_sfb.dim() == 2, "layout_sfb must be 1D tensor");
+  NVF_CHECK(a_ptrs.dim() == 1, "a_ptrs must be 1D tensor");
+  NVF_CHECK(b_ptrs.dim() == 1, "b_ptrs must be 1D tensor");
+  NVF_CHECK(out_ptrs.dim() == 1, "out_ptrs must be 1D tensor");
+  NVF_CHECK(a_scales_ptrs.dim() == 1, "a_scales_ptrs must be 1D tensor");
+  NVF_CHECK(b_scales_ptrs.dim() == 1, "b_scales_ptrs must be 1D tensor");
+  NVF_CHECK(problem_sizes.dim() == 2, "problem_sizes must be 2D tensor");
+  NVF_CHECK(
+      problem_sizes.size(1) == 3,
+      "problem_sizes must have shape (num_experts, 3)");
+  NVF_CHECK(
+      problem_sizes.size(0) == expert_offsets.size(0),
+      "Number of experts in problem_sizes must match expert_offsets");
+  NVF_CHECK(
+      problem_sizes.dtype() == torch::kInt32, "problem_sizes must be int32");
+  NVF_CHECK(expert_offsets.dim() == 1, "expert_offsets must be 1D tensor");
+  NVF_CHECK(workspace.dim() == 1, "workspace must be 1D tensor");
+
+  bool can_implement = false;
+  auto sm_version = getSMVersion();
+
+#if defined(CUTLASS_ARCH_MMA_SM100A_SUPPORTED) || \
+    defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+#if defined CUDA_VERSION && CUDA_VERSION >= 12080
+  if (sm_version == 100) {
+    if (output.scalar_type() == torch::kBFloat16) {
+      sm100_fp8_blockwise_group_mm_dispatch_shape<cutlass::bfloat16_t>(
+          output,
+          a_ptrs,
+          b_ptrs,
+          out_ptrs,
+          a_scales_ptrs,
+          b_scales_ptrs,
+          a,
+          b,
+          scales_a,
+          scales_b,
+          stride_a,
+          stride_b,
+          stride_c,
+          layout_sfa,
+          layout_sfb,
+          problem_sizes,
+          expert_offsets,
+          workspace);
+    } else {
+      sm100_fp8_blockwise_group_mm_dispatch_shape<cutlass::half_t>(
+          output,
+          a_ptrs,
+          b_ptrs,
+          out_ptrs,
+          a_scales_ptrs,
+          b_scales_ptrs,
+          a,
+          b,
+          scales_a,
+          scales_b,
+          stride_a,
+          stride_b,
+          stride_c,
+          layout_sfa,
+          layout_sfb,
+          problem_sizes,
+          expert_offsets,
+          workspace);
+    }
+    can_implement = true;
+  }
+#endif
+#endif
+
+  NVF_CHECK(
+      can_implement,
+      "fp8_blockwise_scaled_grouped_mm is not implemented for current compute "
+      "capability: ",
+      sm_version);
+}
+
+} // namespace nvfuser::cutlass_kernels

--- a/cutlass/nvf_cutlass.h
+++ b/cutlass/nvf_cutlass.h
@@ -1,0 +1,34 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <torch/torch.h>
+
+namespace nvfuser::cutlass_kernels {
+
+void fp8_blockwise_scaled_grouped_mm(
+    torch::Tensor& output,
+    torch::Tensor& a_ptrs,
+    torch::Tensor& b_ptrs,
+    torch::Tensor& out_ptrs,
+    torch::Tensor& a_scales_ptrs,
+    torch::Tensor& b_scales_ptrs,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Tensor& stride_a,
+    const torch::Tensor& stride_b,
+    const torch::Tensor& stride_c,
+    const torch::Tensor& layout_sfa,
+    const torch::Tensor& layout_sfb,
+    const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets,
+    const torch::Tensor& workspace);
+
+} // namespace nvfuser::cutlass_kernels

--- a/python/python_direct/bindings.cpp
+++ b/python/python_direct/bindings.cpp
@@ -17,6 +17,9 @@ void initNvFuserPythonBindings(PyObject* module) {
   bindRuntime(nvfuser);
   bindOperations(nvfuser);
   nvfuser.def("translate_fusion", &translateFusion);
+#ifdef NVFUSER_ENABLE_CUTLASS
+  bindCutlass(nvfuser);
+#endif
 }
 
 } // namespace nvfuser::python

--- a/python/python_direct/bindings.h
+++ b/python/python_direct/bindings.h
@@ -30,4 +30,7 @@ void bindOperations(py::module& nvfuser);
 // Translate a CPP Fusion to a bindings python function
 std::string translateFusion(Fusion* f);
 
+// Add bindings for Cutlass GEMM Operations
+void bindCutlass(py::module& nvfuser);
+
 } // namespace nvfuser::python

--- a/python/python_direct/cutlass.cpp
+++ b/python/python_direct/cutlass.cpp
@@ -1,0 +1,39 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#ifdef NVFUSER_ENABLE_CUTLASS
+
+#include <bindings.h>
+#include <nvf_cutlass.h>
+
+namespace nvfuser::python {
+
+namespace {
+
+void bindGroupedGemm(py::module_& cutlass) {
+  const char* docstring =
+      R"(fp8_blockwise_scaled_grouped_mm(Tensor output, Tensor a_ptrs, Tensor b_ptrs, Tensor out_ptrs, "
+         "Tensor a_scales_ptrs, Tensor b_scales_ptrs, Tensor a, Tensor b, Tensor scales_a, Tensor scales_b, "
+         "Tensor stride_a, Tensor stride_b, Tensor stride_c, Tensor layout_sfa, Tensor layout_sfb, "
+         "Tensor problem_sizes, Tensor expert_offsets, Tensor workspace))";
+  cutlass.def(
+      "fp8_blockwise_scaled_grouped_mm",
+      &cutlass_kernels::fp8_blockwise_scaled_grouped_mm,
+      docstring);
+}
+
+} // namespace
+
+void bindCutlass(py::module& nvfuser) {
+  py::module_ nvf_cutlass = nvfuser.def_submodule(
+      "nvf_cutlass", "This submodule contains all cutlass gemms for NvFuser.");
+  bindGroupedGemm(nvf_cutlass);
+}
+
+} // namespace nvfuser::python
+
+#endif

--- a/tests/python_direct/test_cutlass.py
+++ b/tests/python_direct/test_cutlass.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# Owner(s): ["module: nvfuser"]
+
+import pytest
+import random
+import torch
+from nvfuser_direct import nvf_cutlass
+
+
+def cdiv(a: int, b: int) -> int:
+    return -(a // -b)
+
+
+def scale_shape(shape, group_shape):
+    return tuple(cdiv(shape[i], group_shape[i]) for i in range(len(group_shape)))
+
+
+def to_fp8(tensor: torch.Tensor) -> torch.Tensor:
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    return torch.round(tensor.clamp(min=finfo.min, max=finfo.max)).to(
+        dtype=torch.float8_e4m3fn
+    )
+
+
+def baseline_scaled_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: type[torch.dtype],
+) -> torch.Tensor:
+    def group_broadcast(t, shape):
+        for i, s in enumerate(shape):
+            if t.shape[i] != s and t.shape[i] != 1:
+                assert s % t.shape[i] == 0
+                t = (
+                    t.unsqueeze(i + 1)
+                    .expand(*t.shape[: i + 1], s // t.shape[i], *t.shape[i + 1 :])
+                    .flatten(i, i + 1)
+                )
+        return t
+
+    scale_a = group_broadcast(scale_a, a.shape)
+    scale_b = group_broadcast(scale_b, b.shape)
+
+    return torch.mm(
+        (scale_a * a.to(dtype=torch.float32)), (scale_b * b.to(dtype=torch.float32))
+    ).to(out_dtype)
+
+
+@pytest.mark.parametrize("num_experts", [8, 16])
+@pytest.mark.parametrize("out_dtype", [torch.half, torch.bfloat16])
+def test_fp8_blockwise_scaled_grouped_mm(num_experts, out_dtype):
+    device = "cuda"
+    alignment = 16
+    n_g = alignment * random.randint(1, 5) * 128
+    k_g = alignment * random.randint(1, 5) * 128
+
+    scale_a_group_shape = (1, 128)
+    scale_b_group_shape = (128, 128)
+
+    expert_offsets = torch.zeros((num_experts + 1), device=device, dtype=torch.int32)
+    problem_sizes = torch.zeros((num_experts, 3), device=device, dtype=torch.int32)
+    layout_sfa = torch.zeros((num_experts, 5), device=device, dtype=torch.int32)
+    layout_sfb = torch.zeros((num_experts, 5), device=device, dtype=torch.int32)
+
+    a_tensors = []
+    b_tensors = []
+    a_scales_tensors = []
+    b_scales_tensors = []
+    baseline_tensors = []
+
+    for g in range(num_experts):
+        m_g = alignment * random.randint(1, 64)
+        expert_offsets[g + 1] = expert_offsets[g] + m_g
+        problem_sizes[g][:] = torch.tensor([m_g, n_g, k_g], device=device)
+
+        a_g = to_fp8(torch.randn((m_g, k_g), device=device))
+        b_g = to_fp8(torch.randn((n_g, k_g), device=device).t())
+        a_tensors.append(a_g)
+        b_tensors.append(b_g)
+
+        scale_a_shape = scale_shape(a_g.shape, scale_a_group_shape)
+        scale_b_shape = scale_shape(b_g.shape, scale_b_group_shape)
+
+        a_scales_tensors.append(torch.randn(scale_a_shape, device=device) * 0.001)
+        b_scales_tensors.append(torch.randn(scale_b_shape, device=device) * 0.001)
+
+        baseline = baseline_scaled_mm(
+            a_g, b_g, a_scales_tensors[-1], b_scales_tensors[-1], out_dtype
+        )
+        baseline_tensors.append(baseline)
+
+    a_stack = torch.empty(
+        (expert_offsets[-1], k_g), device=device, dtype=torch.float8_e4m3fn
+    )
+    b_stack = torch.empty(
+        (num_experts, n_g, k_g), device=device, dtype=torch.float8_e4m3fn
+    )
+
+    for g in range(num_experts):
+        a_stack[expert_offsets[g] : expert_offsets[g + 1]] = a_tensors[g]
+        b_stack[g] = b_tensors[g].t()
+    b_stack = b_stack.transpose(1, 2)
+
+    a_scale_stack = torch.empty(
+        (expert_offsets[-1], k_g // 128), device=device, dtype=torch.float32
+    )
+    b_scale_stack = torch.empty(
+        (num_experts, n_g // 128, k_g // 128), device=device, dtype=torch.float32
+    )
+
+    for g in range(num_experts):
+        a_scale_stack[expert_offsets[g] : expert_offsets[g + 1]] = a_scales_tensors[g]
+        b_scale_stack[g] = b_scales_tensors[g].t()
+    b_scale_stack = b_scale_stack.transpose(1, 2)
+
+    c_out = torch.empty((expert_offsets[-1], n_g), device=device, dtype=out_dtype)
+    a_strides = torch.full(
+        (num_experts,), a_stack.stride(0), device=device, dtype=torch.int64
+    )
+    c_strides = torch.full(
+        (num_experts,), c_out.stride(0), device=device, dtype=torch.int64
+    )
+
+    a_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
+    b_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
+    out_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
+    a_scales_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
+    b_scales_ptrs = torch.empty((num_experts,), device=device, dtype=torch.int64)
+    workspace = torch.empty((1024 * 1024 * 1024), device=device, dtype=torch.uint8)
+
+    nvf_cutlass.fp8_blockwise_scaled_grouped_mm(
+        c_out,
+        a_ptrs,
+        b_ptrs,
+        out_ptrs,
+        a_scales_ptrs,
+        b_scales_ptrs,
+        a_stack,
+        b_stack,
+        a_scale_stack,
+        b_scale_stack,
+        a_strides,
+        a_strides,
+        c_strides,
+        layout_sfa,
+        layout_sfb,
+        problem_sizes,
+        expert_offsets[:-1],
+        workspace,
+    )
+
+    for g in range(num_experts):
+        baseline = baseline_tensors[g]
+        actual = c_out[expert_offsets[g] : expert_offsets[g + 1]]
+        torch.testing.assert_close(actual, baseline, rtol=1e-2, atol=5e-4)
+        print(f"num_experts={num_experts}, out_dtype={out_dtype}: OK")


### PR DESCRIPTION
This draft PR pulls the changes from `Add FP8 Blockscale MoE CUTLASS kernel for Blackwell #5281` into nvfuser's python bindings.

Tests in `tests/python_direct/test_cutlass.py` pass on gb200 node.