### PR TITLE
Move `MultiDeviceFinalizePass` to the end

### DIFF
--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -85,13 +85,18 @@ namespace nvfuser::preseg_passes {
   OptimizationPass<PropagateShardingsPass>::runPass(fusion);
   OptimizationPass<InsertReshardingsPass>::runPass(fusion);
   OptimizationPass<ReorderShardedAxisPass>::runPass(fusion);
-  OptimizationPass<FinalizeMultideviceDomainsPass>::runPass(fusion);
 
   OptimizationPass<RemoveBcastSqueeze>::runPass(fusion);
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);
   OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(fusion);
   OptimizationPass<MoveRepeatForwardPass>::runPass(fusion);
   OptimizationPass<MoveGatherPass>::runPass(fusion);
+
+  // This pass should be the last presegmentation pass.
+  // It transforms the allocation domains of tvs with device mesh to
+  // inherit DID splits. Before this pass, the allocation domains are
+  // permutations of the logical domains.
+  OptimizationPass<FinalizeMultideviceDomainsPass>::runPass(fusion);
 }
 
 } // namespace nvfuser::preseg_passes


### PR DESCRIPTION
Before this pass, allocation domain should be a permutation of logical domain. This aims at simplifying the allocation domain analysis during presegmentation by not handling split allocation domains.
Note, that, this is not currently true due to existing tests that will be gradually modified.