### PR TITLE
Remove broadcast from index put accumulate

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -138,7 +138,7 @@ class IndexPutAccumulateOp : public Expr {
   // logical ID groups of IndexPutAccumulateOp
   // args:
   //     acc   [ ID_indexed_g0, ID_g0 ]
-  //     index [ ID_indexing_g1, ID_broadcast ]
+  //     index [ ID_indexing_g1 ]
   //     value [ ID_indexing_g1, ID_g0 ]
   // output:
   //     out   [ ID_indexed_g0, ID_g0 ]
@@ -181,7 +181,7 @@ class IndexPutAccumulateOp : public Expr {
   IterDomain* getIndexingIDOfValue() const;
 
   // return ID_indexing_g1 from index, for IndexPutAccumulate, there's only one
-  // indexing ID, while the remaining ID is broadcast
+  // indexing ID at this moment
   IterDomain* getIndexingID() const;
 };
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -217,8 +217,7 @@ std::vector<PolymorphicValue> IndexPutAccumulateOp::evaluate(
     const std::vector<PolymorphicValue>& inputs) const {
   return {at::index_put(
       /*self=*/inputs.at(0).as<at::Tensor>(),
-      // NOTE: aten API doesn't allow the broadcast dimension
-      /*indices=*/{inputs.at(1).as<at::Tensor>().squeeze(-1)},
+      /*indices=*/{inputs.at(1).as<at::Tensor>()},
       /*values=*/inputs.at(2).as<at::Tensor>(),
       /*accumulate=*/true)};
 }

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -108,11 +108,6 @@ TensorView* indexPutAccumulate(
   NVF_CHECK(
       dtype != DataType::Null, "Invalid datatype provided for new value.");
 
-  // broadcast index_tv if applicable
-  if (index_tv->nDims() == 1) {
-    index_tv = unsqueeze(index_tv, -1);
-  }
-
   std::vector<IterDomain*> acc_domain =
       TensorDomain::noReductions(acc_tv->getLogicalDomain());
   std::vector<IterDomain*> index_domain =
@@ -121,14 +116,13 @@ TensorView* indexPutAccumulate(
       TensorDomain::noReductions(value_tv->getLogicalDomain());
 
   NVF_CHECK(acc_domain.size() == 2);
-  NVF_CHECK(index_domain.size() == 2);
-  NVF_CHECK(index_domain.at(1)->isBroadcast());
+  NVF_CHECK(index_domain.size() == 1);
   NVF_CHECK(value_domain.size() == 2);
   // IndexPutAccumulateOp semantics
   //
   // Producers:
   //     accumulate [ vocab, hidden ]
-  //     broadcast_index [ seq, broadcast ]
+  //     index [ seq ]
   //     value [ seq, hidden ]
   // Consumers:
   //     output [ vocab, hidden ]

--- a/tests/cpp/test_index_put.cpp
+++ b/tests/cpp/test_index_put.cpp
@@ -62,7 +62,7 @@ TEST_P(IndexPut, AccumulateOpWithBroadcastIDs) {
   auto [vocab, hidden, seq] = GetParam();
 
   std::vector<int64_t> shape1({seq, hidden});
-  std::vector<int64_t> shape2({seq, 1});
+  std::vector<int64_t> shape2({seq});
 
   auto tv_value = makeSymbolicTensor(shape1);
   fusion.addInput(tv_value);
@@ -96,14 +96,14 @@ TEST_P(IndexPut, AccumulateOpWithBroadcastIDs) {
   // see [ Note -- IndexPutAccumulateOp semantics ]
   // args:
   //     buf      [ ID_indexed_g0, ID_g0 ]
-  //     tv_index [ ID_indexing_g1, ID_broadcast ]
+  //     tv_index [ ID_indexing_g1 ]
   //     tv_value [ ID_indexing_g1, ID_g0 ]
   // output:
   //     out      [ ID_indexed_g0, ID_g0 ]
   map_logical({true, true}, buf, out);
   // depends on the size of ID_g0, it would map to ID_broadcast when hidden is
   // size-1 dimension
-  map_logical({false, hidden == 1}, tv_index, out);
+  map_logical({false}, tv_index, out);
   map_logical({false, true}, tv_value, out);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);


### PR DESCRIPTION
Need `indexPutAccumulate` for 1D tensors for MOE index shuffling. #4660 extends the op by removing the rank assumption. This PR first removes the automatic broadcasting.