### PR TITLE
Some adjustments on Ampere matmul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -854,7 +854,7 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/tests/cpp/test_translate_mma.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_matmul.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_matmul_aten_evaluation.cpp
-    ${NVFUSER_ROOT}/tests/cpp/test_matmul_sass.cpp
+    # ${NVFUSER_ROOT}/tests/cpp/test_matmul_sass.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_matmul_scheduler.cpp
     ${NVFUSER_ROOT}/tests/cpp/test_mma.cpp
   )

--- a/csrc/scheduler/matmul_ampere-.cpp
+++ b/csrc/scheduler/matmul_ampere-.cpp
@@ -448,12 +448,6 @@ AbstractTensor swizzleSharedMemory(TensorView* shared_mem_tv) {
 
 namespace schedule_matmul {
 void AmpereMinus::validate() const {
-  const auto device_prop = at::cuda::getCurrentDeviceProperties();
-  const int cc = device_prop->major * 10 + device_prop->minor;
-  NVF_ERROR(
-      cc >= 75 && cc < 90,
-      "This matmul scheduler is restricted to Ampere and Turing.");
-
   NVF_CHECK(
       params_->tiling_strategy == MatmulParams::TilingStrategy::OneTilePerCTA,
       "Ampere & Turing matmul scheduler does not support scheduling persistent "


### PR DESCRIPTION
- SASS tests are skipped in whole. The disassembled cubin string format has no compatibility guarantee, so these tests might fail.
- Allow running ampere matmuls on all devices: Ampere's `mma` instruction is available on all devices, not just Ampere. `mma` on Hopper/Blackwell is not as fast as `wgmma` or `tcgen05.mma`, but is functionally available and can deliver Ampere-level performance. Ampere tests are still skipped on Hooper & Blackwell, to save CI time.