### PR TITLE
Misc updates on fp4

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -233,7 +233,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
       case DataType::Index:
         return getLiteralSuffix(kernel_->indexType());
       case DataType::Float4_e2m1fn_x2:
-        NVF_THROW("Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion definition");
+        NVF_THROW(
+            "Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion "
+            "definition");
       default:
         return "";
     }

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -232,6 +232,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         return "ULL";
       case DataType::Index:
         return getLiteralSuffix(kernel_->indexType());
+      case DataType::Float4_e2m1fn_x2:
+        NVF_THROW("Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion definition");
       default:
         return "";
     }

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -14,6 +14,9 @@
 namespace nvfuser {
 
 void MinimumDeviceVersion::dispatch(Val* val) {
+  if (lower_utils::isCopyOnly(val)) {
+    return;
+  }
   if (val->dtype() == DataType::BFloat16) {
     ensureVersion(
         {8, 0},
@@ -40,7 +43,8 @@ void MinimumDeviceVersion::dispatch(Val* val) {
         "CUDA version");
 #endif // (CUDA_VERSION >= 12010)
   }
-  if (val->dtype() == DataType::Float8_e8m0fnu || val->dtype() == DataType::Float4_e2m1fn) {
+  if (val->dtype() == DataType::Float8_e8m0fnu ||
+      val->dtype() == DataType::Float4_e2m1fn) {
 #if (CUDA_VERSION >= 12070)
     ensureVersion(
         {10, 0},
@@ -53,7 +57,9 @@ void MinimumDeviceVersion::dispatch(Val* val) {
 #endif // (CUDA_VERSION >= 12070)
   }
   if (val->dtype() == DataType::Float4_e2m1fn_x2) {
-    NVF_THROW("Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion definition");
+    NVF_THROW(
+        "Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion "
+        "definition");
   }
   IterVisitor::dispatch(val);
 }

--- a/csrc/device_lower/analysis/device_version.cpp
+++ b/csrc/device_lower/analysis/device_version.cpp
@@ -40,7 +40,7 @@ void MinimumDeviceVersion::dispatch(Val* val) {
         "CUDA version");
 #endif // (CUDA_VERSION >= 12010)
   }
-  if (val->dtype() == DataType::Float8_e8m0fnu) {
+  if (val->dtype() == DataType::Float8_e8m0fnu || val->dtype() == DataType::Float4_e2m1fn) {
 #if (CUDA_VERSION >= 12070)
     ensureVersion(
         {10, 0},
@@ -51,6 +51,9 @@ void MinimumDeviceVersion::dispatch(Val* val) {
         "Fusion contains Float8_e8m0fnu values which was not supported in "
         "given CUDA version");
 #endif // (CUDA_VERSION >= 12070)
+  }
+  if (val->dtype() == DataType::Float4_e2m1fn_x2) {
+    NVF_THROW("Float4_e2m1fn_x2 should be converted to Float4_e2m1fn in fusion definition");
   }
   IterVisitor::dispatch(val);
 }

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -2137,6 +2137,24 @@ bool isWarpSpecializedLoop(ForLoop* loop) {
           .getCircularBufferOptionsFor(loop->iter_domain())
           .type);
 }
+
+bool isCopyOnly(Expr* expr) {
+  return expr
+      ->isOneOf<LoadStoreOp, BroadcastOp, SqueezeOp, SliceOp, PadOp, ViewOp>();
+}
+
+bool isCopyOnly(Val* val) {
+  if (val->definition() != nullptr && !isCopyOnly(val->definition())) {
+    return false;
+  }
+  for (auto use : val->uses()) {
+    if (!isCopyOnly(use)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -378,6 +378,19 @@ bool allMmaInputsGuardedByMBarrier(const MmaOp* mma);
 // Check if the given ForLoop is a warp specialized loop by checking
 // the circular buffer type of the loop domain.
 bool isWarpSpecializedLoop(ForLoop* loop);
-} // namespace lower_utils
 
+// Check if the given Expr is only a data copy, and no math is done on it.
+// For example, set, broadcast, squeeze, slice, pad, reshape, etc.
+// When an Expr is copy only, regardless of the architecture, it is always
+// supported. For example, it is totally OK to broadcast a fp8 tensor of shape
+// [1024] to a fp8 tensor of shape [1024, 1] on NVIDIA GeForce 8800 GTX, the
+// first device that supports CUDA, because it just involves byte copying, which
+// is supported on all architectures.
+bool isCopyOnly(Expr* expr);
+
+// Check if the given Val is only copied from/to other Val, and no math is done
+// on it.
+bool isCopyOnly(Val* val);
+
+} // namespace lower_utils
 } // namespace nvfuser

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -241,6 +241,11 @@ class NVF_API Val : public Statement {
           " for value ",
           PolymorphicValue_functions::toString(value_));
     }
+    NVF_ERROR(
+        !isPackedType(dtype_),
+        "Packed type ",
+        dtype_,
+        " must be unpacked when defining fusion");
   }
   explicit Val(IrBuilderPasskey passkey, DataType dtype)
       : Val(passkey, ValType::Others, std::move(dtype)) {}

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -598,14 +598,14 @@ Val* getMaximumValue(DataType v) {
       return IrBuilder::create<Val>(
           static_cast<double>(std::numeric_limits<c10::Float8_e8m0fnu>::max()));
       break;
-    case (DataType::Int):
+    case DataType::Int:
       return IrBuilder::create<Val>(std::numeric_limits<int64_t>::max());
       break;
-    case (DataType::Int32):
+    case DataType::Int32:
       return IrBuilder::create<Val>(
           (int64_t)std::numeric_limits<int32_t>::max());
       break;
-    case (DataType::Bool):
+    case DataType::Bool:
       return IrBuilder::create<Val>(true);
       break;
     default:

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -241,7 +241,7 @@ void fillTensorWithNan(at::Tensor& t) {
     case at::ScalarType::Float8_e4m3fn:
     case at::ScalarType::Float8_e5m2:
     case at::ScalarType::Float8_e8m0fnu:
-    // case at::ScalarType::Float4_e2m1fn_x2:
+      // case at::ScalarType::Float4_e2m1fn_x2:
       t.fill_(std::nan(""));
       break;
     case at::ScalarType::ComplexHalf:

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -241,6 +241,7 @@ void fillTensorWithNan(at::Tensor& t) {
     case at::ScalarType::Float8_e4m3fn:
     case at::ScalarType::Float8_e5m2:
     case at::ScalarType::Float8_e8m0fnu:
+    // case at::ScalarType::Float4_e2m1fn_x2:
       t.fill_(std::nan(""));
       break;
     case at::ScalarType::ComplexHalf:

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -12,6 +12,7 @@
 #include <visibility.h>
 
 #include <c10/core/ScalarType.h>
+// #include <c10/util/Float4_e2m1fn_x2.h>
 
 #include <polymorphic_value.h>
 
@@ -77,7 +78,8 @@ enum class PrimDataType {
   Float8_e4m3fn,
   Float8_e5m2,
   Float8_e8m0fnu,
-  Float4_e2m1,
+  Float4_e2m1fn,
+  Float4_e2m1fn_x2,
   // Integral types
   Char,
   Short,
@@ -188,7 +190,9 @@ struct DataType {
   static constexpr PrimDataType Double = PrimDataType::Double;
   static constexpr PrimDataType Float = PrimDataType::Float;
   static constexpr PrimDataType Half = PrimDataType::Half;
-  static constexpr PrimDataType Float4_e2m1 = PrimDataType::Float4_e2m1;
+  static constexpr PrimDataType Float4_e2m1fn = PrimDataType::Float4_e2m1fn;
+  static constexpr PrimDataType Float4_e2m1fn_x2 =
+      PrimDataType::Float4_e2m1fn_x2;
   static constexpr PrimDataType Float8_e4m3fn = PrimDataType::Float8_e4m3fn;
   static constexpr PrimDataType Float8_e5m2 = PrimDataType::Float8_e5m2;
   static constexpr PrimDataType Float8_e8m0fnu = PrimDataType::Float8_e8m0fnu;
@@ -274,6 +278,10 @@ inline bool isFloatingPointType(DataType dtype) {
       dtype == DataType::Float8_e8m0fnu;
 }
 
+inline bool isPackedType(const DataType& dtype) {
+  return dtype == DataType::Float4_e2m1fn_x2;
+}
+
 // Returns if the datatype is an integer type
 inline bool isIntegralType(DataType dtype) {
   return std::visit(
@@ -355,12 +363,6 @@ struct DataTypeToAtenType;
 template <typename NativeType>
 struct NativeTypeToDataType;
 
-template <at::ScalarType aten_type>
-struct AtenTypeToDataType;
-
-template <at::ScalarType aten_type>
-struct AtenTypeToNativeType;
-
 template <typename NativeType>
 struct IsPrimitiveNativeType : std::false_type {};
 
@@ -376,93 +378,68 @@ struct IsPrimitiveNativeType : std::false_type {};
   template <>                                                  \
   struct IsPrimitiveNativeType<native_type> : std::true_type {}
 
-#define DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(          \
-    data_type, at_type, native_type)                      \
-  DEFINE_DATATYPE_TO_NATIVE_TYPE(data_type, native_type); \
-  template <>                                             \
-  struct AtenTypeToDataType<at_type> {                    \
-    static constexpr PrimDataType type = data_type;       \
-  };                                                      \
-  template <>                                             \
-  struct AtenTypeToNativeType<at_type> {                  \
-    using type = native_type;                             \
-  }
-
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Float,
-    at::ScalarType::Float,
     float);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Double,
-    at::ScalarType::Double,
     double);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Half,
-    at::ScalarType::Half,
     at::Half);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::BFloat16,
-    at::ScalarType::BFloat16,
     at::BFloat16);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Float8_e4m3fn,
-    at::ScalarType::Float8_e4m3fn,
     at::Float8_e4m3fn);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Float8_e5m2,
-    at::ScalarType::Float8_e5m2,
     at::Float8_e5m2);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Float8_e8m0fnu,
-    at::ScalarType::Float8_e8m0fnu,
     at::Float8_e8m0fnu);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+// DEFINE_DATATYPE_TO_NATIVE_TYPE(
+//     DataType::Float4_e2m1fn,
+//     at::Float4_e2m1fn_x2);
+// DEFINE_DATATYPE_TO_NATIVE_TYPE(
+//     DataType::Float4_e2m1fn_x2,
+//     at::Float4_e2m1fn_x2);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Char,
-    at::ScalarType::Char,
     int8_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Short,
-    at::ScalarType::Short,
     int16_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Int32,
-    at::ScalarType::Int,
     int);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Int,
-    at::ScalarType::Long,
     int64_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Byte,
-    at::ScalarType::Byte,
     uint8_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::UInt16,
-    at::ScalarType::UInt16,
     uint16_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::UInt32,
-    at::ScalarType::UInt32,
     uint32_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::UInt64,
-    at::ScalarType::UInt64,
     uint64_t);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::Bool,
-    at::ScalarType::Bool,
     bool);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::ComplexFloat,
-    at::ScalarType::ComplexFloat,
     std::complex<float>);
-DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE(
+DEFINE_DATATYPE_TO_NATIVE_TYPE(
     DataType::ComplexDouble,
-    at::ScalarType::ComplexDouble,
     std::complex<double>);
 
 #undef DEFINE_DATATYPE_TO_NATIVE_TYPE
-#undef DEFINE_DATATYPE_TO_ATEN_AND_NATIVE_TYPE
 
 inline DataType getDataType(const PolymorphicValue& value) {
   std::optional<DataType> dtype = std::nullopt;
@@ -1119,7 +1096,9 @@ constexpr inline size_t primDataTypeSizeBit(PrimDataType type) {
       return sizeof(at::Float8_e5m2) * 8;
     case DataType::Float8_e8m0fnu:
       return sizeof(at::Float8_e8m0fnu) * 8;
-    case DataType::Float4_e2m1:
+    case DataType::Float4_e2m1fn_x2:
+      return 8;
+    case DataType::Float4_e2m1fn:
       return 4;
     case DataType::Index:
       NVF_THROW("The actual type of Index is only known at compile time.");

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -378,66 +378,26 @@ struct IsPrimitiveNativeType : std::false_type {};
   template <>                                                  \
   struct IsPrimitiveNativeType<native_type> : std::true_type {}
 
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Float,
-    float);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Double,
-    double);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Half,
-    at::Half);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::BFloat16,
-    at::BFloat16);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Float8_e4m3fn,
-    at::Float8_e4m3fn);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Float8_e5m2,
-    at::Float8_e5m2);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Float8_e8m0fnu,
-    at::Float8_e8m0fnu);
-// DEFINE_DATATYPE_TO_NATIVE_TYPE(
-//     DataType::Float4_e2m1fn,
-//     at::Float4_e2m1fn_x2);
-// DEFINE_DATATYPE_TO_NATIVE_TYPE(
-//     DataType::Float4_e2m1fn_x2,
-//     at::Float4_e2m1fn_x2);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Char,
-    int8_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Short,
-    int16_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Int32,
-    int);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Int,
-    int64_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Byte,
-    uint8_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::UInt16,
-    uint16_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::UInt32,
-    uint32_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::UInt64,
-    uint64_t);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::Bool,
-    bool);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::ComplexFloat,
-    std::complex<float>);
-DEFINE_DATATYPE_TO_NATIVE_TYPE(
-    DataType::ComplexDouble,
-    std::complex<double>);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float, float);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Double, double);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Half, at::Half);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::BFloat16, at::BFloat16);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float8_e4m3fn, at::Float8_e4m3fn);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float8_e5m2, at::Float8_e5m2);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float8_e8m0fnu, at::Float8_e8m0fnu);
+// DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Float4_e2m1fn_x2,
+// at::Float4_e2m1fn_x2);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Char, int8_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Short, int16_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Int32, int);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Int, int64_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Byte, uint8_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::UInt16, uint16_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::UInt32, uint32_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::UInt64, uint64_t);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::Bool, bool);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::ComplexFloat, std::complex<float>);
+DEFINE_DATATYPE_TO_NATIVE_TYPE(DataType::ComplexDouble, std::complex<double>);
 
 #undef DEFINE_DATATYPE_TO_NATIVE_TYPE
 

--- a/csrc/type_promotion.cpp
+++ b/csrc/type_promotion.cpp
@@ -61,8 +61,7 @@ ResultTypeState updateResultTypeState(
   DataType current = scalar;
   if (scalar == DataType::Half || scalar == DataType::BFloat16 ||
       scalar == DataType::Float8_e4m3fn || scalar == DataType::Float8_e5m2 ||
-      scalar == DataType::Float8_e8m0fnu ||
-      scalar == DataType::Float4_e2m1fn) {
+      scalar == DataType::Float8_e8m0fnu || scalar == DataType::Float4_e2m1fn) {
     current = DataType::Float;
   }
   new_state.wrappedResult =

--- a/csrc/type_promotion.cpp
+++ b/csrc/type_promotion.cpp
@@ -61,7 +61,8 @@ ResultTypeState updateResultTypeState(
   DataType current = scalar;
   if (scalar == DataType::Half || scalar == DataType::BFloat16 ||
       scalar == DataType::Float8_e4m3fn || scalar == DataType::Float8_e5m2 ||
-      scalar == DataType::Float8_e8m0fnu) {
+      scalar == DataType::Float8_e8m0fnu ||
+      scalar == DataType::Float4_e2m1fn) {
     current = DataType::Float;
   }
   new_state.wrappedResult =
@@ -203,7 +204,8 @@ DataType computeTypes(
       (common_type == DataType::Half || common_type == DataType::BFloat16 ||
        common_type == DataType::Float8_e4m3fn ||
        common_type == DataType::Float8_e5m2 ||
-       common_type == DataType::Float8_e8m0fnu)) {
+       common_type == DataType::Float8_e8m0fnu ||
+       common_type == DataType::Float4_e2m1fn)) {
     common_type = DataType::Float;
   }
 

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -104,10 +104,12 @@ std::pair<double, double> getTolerance(
         return {abs_tol, abs_tol * 0.01};
       }
     }
-    // TODO: fp8 likely will need higher tolerance.
+    // TODO: fp8 & fp4 likely will need higher tolerance.
     case DataType::Float8_e4m3fn:
     case DataType::Float8_e5m2:
     case DataType::Float8_e8m0fnu:
+    case DataType::Float4_e2m1fn:
+    case DataType::Float4_e2m1fn_x2:
     case DataType::BFloat16: {
       // Copied from float case
       const auto& sum_tolerance_entry = tolerances.sum_tolerances_half;

--- a/python/nvfuser/pytorch_utils.py
+++ b/python/nvfuser/pytorch_utils.py
@@ -22,6 +22,7 @@ _torch_dtype_to_nvfuser_dtype_map = {
     torch.float8_e4m3fn: DataType.Float8_e4m3fn,
     torch.float8_e5m2: DataType.Float8_e5m2,
     torch.float8_e8m0fnu: DataType.Float8_e8m0fnu,
+    # torch.float4_e2m1fn_x2: DataType.Float4_e2m1fn_x2,
     torch.long: DataType.Int,
     torch.int: DataType.Int32,
     torch.bool: DataType.Bool,

--- a/python/nvfuser/testing/utils.py
+++ b/python/nvfuser/testing/utils.py
@@ -91,6 +91,7 @@ map_dtype_to_str = {
     torch.float8_e4m3fn: "float8_e4m3fn",
     torch.float8_e5m2: "float8_e5m2",
     torch.float8_e8m0fnu: "float8_e8m0fnu",
+    # torch.float4_e2m1fn_x2: "float4_e2m1fn_x2",
     torch.bfloat16: "bfloat16",
     torch.float16: "float16",
     torch.float32: "float32",

--- a/python/python_common/python_utils.cpp
+++ b/python/python_common/python_utils.cpp
@@ -266,6 +266,10 @@ const char* dtypeToPyString(PrimDataType t) {
       return "DataType.Float8_e5m2";
     case DataType::Float8_e8m0fnu:
       return "DataType.Float8_e8m0fnu";
+    case DataType::Float4_e2m1fn:
+      return "DataType.Float4_e2m1fn";
+    case DataType::Float4_e2m1fn_x2:
+      return "DataType.Float4_e2m1fn_x2";
     case DataType::Int:
       return "DataType.Int";
     case DataType::Int32:

--- a/python/python_direct/enum.cpp
+++ b/python/python_direct/enum.cpp
@@ -28,6 +28,8 @@ void bindEnums(py::module& nvfuser) {
       .value("Float8_e4m3fn", DataType::Float8_e4m3fn)
       .value("Float8_e5m2", DataType::Float8_e5m2)
       .value("Float8_e8m0fnu", DataType::Float8_e8m0fnu)
+      .value("Float4_e2m1fn", DataType::Float4_e2m1fn)
+      .value("Float4_e2m1fn_x2", DataType::Float4_e2m1fn_x2)
       .value("ComplexFloat", DataType::ComplexFloat)
       .value("ComplexDouble", DataType::ComplexDouble)
       .value("Null", DataType::Null);

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -675,6 +675,8 @@ void initNvFuserPythonBindings(PyObject* module) {
       .value("Float8_e4m3fn", DataType::Float8_e4m3fn)
       .value("Float8_e5m2", DataType::Float8_e5m2)
       .value("Float8_e8m0fnu", DataType::Float8_e8m0fnu)
+      .value("Float4_e2m1fn", DataType::Float4_e2m1fn)
+      .value("Float4_e2m1fn_x2", DataType::Float4_e2m1fn_x2)
       .value("ComplexFloat", DataType::ComplexFloat)
       .value("ComplexDouble", DataType::ComplexDouble)
       .value("Null", DataType::Null);

--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -49,7 +49,7 @@ constexpr int64_t vecSizeBit(int64_t vec_size) {
 }
 
 template <>
-constexpr int64_t vecSizeBit<e2m1>(int64_t vec_size) {
+constexpr int64_t vecSizeBit<__e2m1>(int64_t vec_size) {
   return vec_size * 4;
 }
 

--- a/runtime/fp4_support.cu
+++ b/runtime/fp4_support.cu
@@ -23,7 +23,7 @@ struct __e2m1_ptr {
     // it. assert(index % 2 == 0);
     return raw_ptr[index / 2];
   }
-  e2m1& operator[](int64_t index) {
+  __e2m1& operator[](int64_t index) {
     // For performance reason, we do not check the index is even, but we assume
     // it. assert(index % 2 == 0);
     return raw_ptr[index / 2];

--- a/runtime/fp4_support.cu
+++ b/runtime/fp4_support.cu
@@ -6,19 +6,19 @@
  */
 // clang-format on
 
-// e2m1 is just a placeholder for the fp4 type.
+// __e2m1 is just a placeholder for the fp4 type.
 // Because its size can not be represented as a whole byte, we can not really
 // implement a single fp4 number.
-struct e2m1 {};
+struct __e2m1 {};
 
-static_assert(sizeof(e2m1) == 1, "e2m1 must be 1 byte");
+static_assert(sizeof(__e2m1) == 1, "__e2m1 must be 1 byte");
 
-struct e2m1_ptr {
-  e2m1* raw_ptr;
-  e2m1_ptr(void* ptr) : raw_ptr((e2m1*)ptr) {}
-  e2m1_ptr(const e2m1_ptr& other) = default;
-  e2m1_ptr& operator=(const e2m1_ptr& other) = default;
-  e2m1 operator[](int64_t index) const {
+struct __e2m1_ptr {
+  __e2m1* raw_ptr;
+  __e2m1_ptr(void* ptr) : raw_ptr((__e2m1*)ptr) {}
+  __e2m1_ptr(const __e2m1_ptr& other) = default;
+  __e2m1_ptr& operator=(const __e2m1_ptr& other) = default;
+  __e2m1 operator[](int64_t index) const {
     // For performance reason, we do not check the index is even, but we assume
     // it. assert(index % 2 == 0);
     return raw_ptr[index / 2];
@@ -28,20 +28,20 @@ struct e2m1_ptr {
     // it. assert(index % 2 == 0);
     return raw_ptr[index / 2];
   }
-  e2m1_ptr operator+(int64_t offset) const {
+  __e2m1_ptr operator+(int64_t offset) const {
     // For performance reason, we do not check the offset is even, but we assume
     // it. assert(offset % 2 == 0);
-    return e2m1_ptr(raw_ptr + offset / 2);
+    return __e2m1_ptr(raw_ptr + offset / 2);
   }
-  e2m1_ptr operator-(int64_t offset) const {
+  __e2m1_ptr operator-(int64_t offset) const {
     // For performance reason, we do not check the offset is even, but we assume
     // it. assert(offset % 2 == 0);
-    return e2m1_ptr(raw_ptr - offset / 2);
+    return __e2m1_ptr(raw_ptr - offset / 2);
   }
-  e2m1 operator*() const {
+  __e2m1 operator*() const {
     return *raw_ptr;
   }
-  e2m1& operator*() {
+  __e2m1& operator*() {
     return *raw_ptr;
   }
 };

--- a/runtime/tensor.cu
+++ b/runtime/tensor.cu
@@ -12,8 +12,8 @@ struct PointerHelper {
 };
 
 template <>
-struct PointerHelper<e2m1> {
-  using type = e2m1_ptr;
+struct PointerHelper<__e2m1> {
+  using type = __e2m1_ptr;
 };
 
 template <typename T>

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -2873,8 +2873,8 @@ TEST_P(Float4E2m1ManualScheduleTestAllArch, CopyKernelContiguous) {
   FusionGuard fg(&fusion);
 
   TensorView* tv0 = dynamic_shape
-      ? makeContigTensor(1, DataType::Float4_e2m1)
-      : makeContigConcreteTensor({2048}, DataType::Float4_e2m1);
+      ? makeContigTensor(1, DataType::Float4_e2m1fn)
+      : makeContigConcreteTensor({2048}, DataType::Float4_e2m1fn);
   fusion.addInput(tv0);
   TensorView* tv1 = set(tv0);
   fusion.addOutput(tv1);
@@ -2886,7 +2886,8 @@ TEST_P(Float4E2m1ManualScheduleTestAllArch, CopyKernelContiguous) {
   inlineMost();
 
   auto options = at::TensorOptions().dtype(torch::kUInt8).device(at::kCUDA, 0);
-  at::Tensor input = at::randint(0, 256, {1024}, options);
+  at::Tensor input = at::randint(0, 256, {1024}, options)
+                         .view(torch::/*kFloat4_e2m1fnx2*/ kUInt8);
 
   KernelExecutor ke;
   if (vectorize_factor == 1) {
@@ -2909,13 +2910,13 @@ TEST_P(Float4E2m1ManualScheduleTestAllArch, CopyKernelDiscontiguous) {
 
   TensorView* tv0 = dynamic_shape ? TensorViewBuilder()
                                         .ndims(2)
-                                        .dtype(DataType::Float4_e2m1)
+                                        .dtype(DataType::Float4_e2m1fn)
                                         .shape({-1, -1})
                                         .contiguity({false, true})
                                         .build()
                                   : TensorViewBuilder()
                                         .ndims(2)
-                                        .dtype(DataType::Float4_e2m1)
+                                        .dtype(DataType::Float4_e2m1fn)
                                         .shape({2048, 2048})
                                         .contiguity({false, true})
                                         .build();
@@ -2933,8 +2934,9 @@ TEST_P(Float4E2m1ManualScheduleTestAllArch, CopyKernelDiscontiguous) {
   inlineMost();
 
   auto options = at::TensorOptions().dtype(torch::kUInt8).device(at::kCUDA, 0);
-  at::Tensor input =
-      at::randint(0, 256, {2048, 2048}, options).narrow(1, 0, 1024);
+  at::Tensor input = at::randint(0, 256, {2048, 2048}, options)
+                         .narrow(1, 0, 1024)
+                         .view(torch::/*kFloat4_e2m1fnx2*/ kUInt8);
 
   KernelExecutor ke;
   if (vectorize_factor == 1) {
@@ -2986,7 +2988,7 @@ TEST_F(Float4E2m1Test, CopyKernelDiscontiguousLastDim) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
-  TensorView* tv0 = makeSymbolicTensor(1, DataType::Float4_e2m1);
+  TensorView* tv0 = makeSymbolicTensor(1, DataType::Float4_e2m1fn);
   fusion.addInput(tv0);
   TensorView* tv1 = set(tv0);
   fusion.addOutput(tv1);
@@ -2998,8 +3000,10 @@ TEST_F(Float4E2m1Test, CopyKernelDiscontiguousLastDim) {
   inlineMost();
 
   auto options = at::TensorOptions().dtype(torch::kUInt8).device(at::kCUDA, 0);
-  at::Tensor input =
-      at::randint(0, 256, {1024, 2}, options).narrow(1, 0, 1).squeeze();
+  at::Tensor input = at::randint(0, 256, {1024, 2}, options)
+                         .narrow(1, 0, 1)
+                         .squeeze()
+                         .view(torch::/*kFloat4_e2m1fnx2*/ kUInt8);
 
   KernelExecutor ke;
 


### PR DESCRIPTION
- Renamed `DataType::Float4_e2m1` as `DataType::Float4_e2m1fn` to be more consistent with PyTorch
- Added `DataType::Float4_e2m1fn_x2`, which in theory should be the data type to represent fp4 tensors. This new data type in theory should correspond to `at::ScalarType::Float4_e2m1fn_x2`. Unfortunately, because `at::ScalarType::Float4_e2m1fn_x2` is only added recently and not available in the latest stable release of PyTorch (2.7.1), I have to comment out some code, so effectively we are still using `at::ScalarType::Byte` to represent fp4 tensor. Per our internal discussion, we are only interested in supporting nightly release, so I will uncomment these code in my next PR. I want to split the "add feature" and "break stable" as two PRs, so that in the future we can easily revert just in case.
- Added a few missing pieces among our codebase for `DataType::Float4_e2m1fn`.