### PR TITLE
Disable NVRTC caching when observing ptxas output in matmul tests

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4139,6 +4139,9 @@ TEST_P(MLPBenchmarkTest, FwdGEMM) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4189,6 +4192,9 @@ TEST_P(MLPBenchmarkTest, FwdGEMM_BroadcastInputs) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4240,6 +4246,9 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueBiasFusion) {
 
   KernelArgumentHolder inputs = {t0, t1, t2};
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4305,6 +4314,9 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueSiluFusion) {
 
   KernelArgumentHolder inputs = {t0, t1, t2};
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4374,6 +4386,9 @@ TEST_P(MLPBenchmarkTest, FwdEpilogueFusion_BroadcastInputs) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4458,6 +4473,9 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4549,6 +4567,9 @@ TEST_P(MLPBenchmarkTest, FwdHorizontalFusion_BroadcastInputs) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();
@@ -4601,6 +4622,9 @@ TEST_P(MLPBenchmarkTest, BatchGEMM) {
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
       ->schedule(&fusion, &mparams);
 
+  // Disable NVRTC caching so that we can reliably observe ptxas output
+  DisableOptionsGuard dog;
+  DisableOptionsGuard::getCurOptions().set(DisableOption::NvrtcCaching);
   CompileParams compile_opts;
   compile_opts.enable_ptxas_verbose = true;
   captureStdout();


### PR DESCRIPTION
This fixes failures introduced by CUDA 13's NVRTC caching.