### PR TITLE
revise msg to `originally detected persistent_buffers`  to avoid confusion

### DIFF
--- a/csrc/scheduler/normalization_utils.h
+++ b/csrc/scheduler/normalization_utils.h
@@ -236,8 +236,8 @@ struct PersistentKernelProperties {
        << "disable_project_to_avoid_recompute: "
        << disable_project_to_avoid_recompute << "\n"
        << "project_persistent_buffers: " << project_persistent_buffers << "\n"
-       << "persistent_buffers: " << toDelimitedString(persistent_buffers)
-       << "\n";
+       << "originally detected persistent_buffers: "
+       << toDelimitedString(persistent_buffers) << "\n";
     return ss.str();
   }
 };


### PR DESCRIPTION
The kernel for embedding fused with RMS norm uses the correct `bfloat16` buffer, but the output msg is confusing since it prints the originally detected buffer which is float32.
Revise the msg to avoid confusion.