### PR TITLE
disable nvrtc caching when ptxas_verbose is required

### DIFF
--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -555,16 +555,11 @@ void fillCompileOptions(
   if (isOptionEnabled(EnableOption::KernelProfile)) {
     nvrtc_compile_driver.setOption("-DNVFUSER_PROFILE_KERNEL");
   }
-  if (isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog) ||
+  bool is_ptxas_verbose = isDebugDumpEnabled(DebugDumpOption::PrintPtxasLog) ||
       isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) ||
       isOptionEnabled(EnableOption::WarnRegisterSpill) ||
-      compile_params.enable_ptxas_verbose) {
-    // disable nvrtc caching for ptxas verbose output
-    int major, minor;
-    NVFUSER_NVRTC_SAFE_CALL(nvrtcVersion(&major, &minor));
-    if ((major == 12 && minor >= 9) || major > 12) {
-      nvrtc_compile_driver.setOption("--no-cache");
-    }
+      compile_params.enable_ptxas_verbose;
+  if (is_ptxas_verbose) {
     // show register usage in compilation log
     if (compile_to_sass) {
       nvrtc_compile_driver.setOption("--ptxas-options");
@@ -614,7 +609,7 @@ void fillCompileOptions(
     }
   }
 
-  if (isOptionDisabled(DisableOption::NvrtcCaching)) {
+  if (isOptionDisabled(DisableOption::NvrtcCaching) || is_ptxas_verbose) {
     // JIT caching is introduced in 12.9. It's always disabled in
     // prior versions.
     int major, minor;

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -559,6 +559,12 @@ void fillCompileOptions(
       isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose) ||
       isOptionEnabled(EnableOption::WarnRegisterSpill) ||
       compile_params.enable_ptxas_verbose) {
+    // disable nvrtc caching for ptxas verbose output
+    int major, minor;
+    NVFUSER_NVRTC_SAFE_CALL(nvrtcVersion(&major, &minor));
+    if ((major == 12 && minor >= 9) || major > 12) {
+      nvrtc_compile_driver.setOption("--no-cache");
+    }
     // show register usage in compilation log
     if (compile_to_sass) {
       nvrtc_compile_driver.setOption("--ptxas-options");


### PR DESCRIPTION
Disable nvrtc caching when ptxas_verbose is needed, otherwise, no PTX information will be printed.