### PR TITLE
Use loop domain in  `unshardedSizes` for fusion inputs with DID parallelization

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -69,8 +69,9 @@ bool isSharded(const TensorView* tv) {
 
 std::unordered_map<ParallelType, IterDomain*> mapDeviceAndStreamParallelTypeToId(
     const std::vector<IterDomain*>& domain) {
-  std::unordered_set<ParallelType> parallel_types =
+  const std::unordered_set<ParallelType>& parallel_types =
       deviceAndStreamParallelTypes();
+
   std::unordered_map<ParallelType, IterDomain*> parallel_type_to_id;
   parallel_type_to_id.reserve(parallel_types.size());
 
@@ -191,7 +192,7 @@ int64_t getShardedLogicalAxis(
     const TensorView* tv,
     const ParallelType parallel_type) {
   // Find the IterDomain that is parallelized on the given parallel type.
-  std::unordered_map<ParallelType, IterDomain*> parallel_type_to_id =
+  const std::unordered_map<ParallelType, IterDomain*>& parallel_type_to_id =
       mapDeviceAndStreamParallelTypeToId(tv->getMaybeAllocationDomain());
   IterDomain* parallel_id = getOrDefault(parallel_type_to_id, parallel_type);
   return getShardedLogicalAxis(tv, parallel_id);
@@ -245,7 +246,7 @@ std::vector<int64_t> unshardedSizes(
   // We use the loop domain, since allocation and loop domain will have the
   // same DID parallelization.
 
-  std::unordered_map<ParallelType, IterDomain*> parallel_type_to_id =
+  const std::unordered_map<ParallelType, IterDomain*>& parallel_type_to_id =
       mapDeviceAndStreamParallelTypeToId(tv->getLoopDomain());
 
   for (ParallelType parallel_type : kParallelTypeDIDs) {
@@ -256,7 +257,6 @@ std::vector<int64_t> unshardedSizes(
     }
     unsharded_sizes.at(sharded_axis) *= tv->getDeviceMesh().size(parallel_type);
   }
-
   return unsharded_sizes;
 }
 

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -169,4 +169,12 @@ void propagateDIDTransform(
     int64_t did_pos,
     PropagateDirection direction);
 
+// Internal helper (anonymous namespace in .cpp):
+namespace {
+int64_t getShardedLogicalAxisInDomain(
+    const std::vector<IterDomain*>& logical_domain,
+    const std::vector<IterDomain*>& domain,
+    ParallelType parallel_type);
+}
+
 } // namespace nvfuser

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -169,12 +169,4 @@ void propagateDIDTransform(
     int64_t did_pos,
     PropagateDirection direction);
 
-// Internal helper (anonymous namespace in .cpp):
-namespace {
-int64_t getShardedLogicalAxisInDomain(
-    const std::vector<IterDomain*>& logical_domain,
-    const std::vector<IterDomain*>& domain,
-    ParallelType parallel_type);
-}
-
 } // namespace nvfuser

--- a/tests/python/multidevice/fusion_definition_wrapper.py
+++ b/tests/python/multidevice/fusion_definition_wrapper.py
@@ -68,7 +68,6 @@ class FusionDefinitionWrapper:
                         self.sched.parallelize(
                             in_tensor, dim, nvfuser.ParallelType.mesh_x
                         )
-                        self.sched.set_allocation_as_loop(in_tensor)
 
         return Model()
 

--- a/tests/python/multidevice/test_matmul.py
+++ b/tests/python/multidevice/test_matmul.py
@@ -88,7 +88,6 @@ def test_column_parallel_linear(multidevice_test):
             for t in [self.weight, self.bias]:
                 self.sched.split(t, 0, d, False)
                 self.sched.parallelize(t, 0, nvfuser.ParallelType.mesh_x)
-                self.sched.set_allocation_as_loop(t)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 
@@ -133,7 +132,6 @@ def test_row_parallel_linear(multidevice_test):
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.split(t, -1, d, False)
                 self.sched.parallelize(t, -2, nvfuser.ParallelType.mesh_x)
-                self.sched.set_allocation_as_loop(t)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 
@@ -171,7 +169,6 @@ def test_row_parallel_linear_with_bias(multidevice_test):
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.split(t, -1, d, False)
                 self.sched.parallelize(t, -2, nvfuser.ParallelType.mesh_x)
-                self.sched.set_allocation_as_loop(t)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 
@@ -209,7 +206,6 @@ def test_linear_reduce_scatter(multidevice_test):
                 self.sched._set_device_mesh(t, mesh)
                 self.sched.split(t, -1, d, False)
                 self.sched.parallelize(t, -2, nvfuser.ParallelType.mesh_x)
-                self.sched.set_allocation_as_loop(t)
 
             # Scatter
             self.sched.split(self.out, 1, d, False)
@@ -259,13 +255,11 @@ def test_column_parallel_matmul(multidevice_test):
             # Shard N for weight (K, N)
             self.sched.split(self.weight, -1, d, False)
             self.sched.parallelize(self.weight, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.weight)
 
             # Output of linear: {.., i{M}, i{N}, r{K}}
             # Shard N -> axis(-2)
             self.sched.split(self.out, -2, d, False)
             self.sched.parallelize(self.out, -3, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.out)
 
     torch.cuda.set_device(multidevice_test.local_rank)
 
@@ -312,12 +306,10 @@ def test_row_parallel_matmul(multidevice_test):
             # Shard K for inp (M, K)
             self.sched.split(self.inp, -1, d, False)
             self.sched.parallelize(self.inp, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.inp)
 
             # Shard K for weight (K, N)
             self.sched.split(self.weight, 0, d, False)
             self.sched.parallelize(self.weight, 0, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.weight)
 
             # [i{M}, i{N}, r{K}]
             self.sched.split(self.out, -1, d, False)
@@ -376,7 +368,6 @@ def test_column_parallel_grouped_mm(multidevice_test):
 
             self.sched.split(self.w, -1, d, False)
             self.sched.parallelize(self.w, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.w)
 
     m = 32
     inp = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
@@ -432,11 +423,9 @@ def test_row_parallel_grouped_mm(multidevice_test):
 
             self.sched.split(self.inp, -1, d, False)
             self.sched.parallelize(self.inp, -2, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.inp)
 
             self.sched.split(self.w, 1, d, False)
             self.sched.parallelize(self.w, 1, nvfuser.ParallelType.mesh_x)
-            self.sched.set_allocation_as_loop(self.w)
 
     m = 32
     inp = torch.randint(-2, 3, (m, k), dtype=torch.bfloat16)


### PR DESCRIPTION
Allocation domain is not set during concretization. Hence, switching to use loop domain for DID parallelization instead. 