### PR TITLE
C++ representation of SGLang's MOE prepare_input kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -826,6 +826,13 @@ if(BUILD_TEST)
   add_test(test_topk "${TOPK_TEST_SRCS}" ${TOPK_TEST_KERNELS})
   list(APPEND TEST_BINARIES test_topk)
 
+  set(MOE_TEST_SRCS)
+  list(APPEND MOE_TEST_SRCS
+    ${NVFUSER_ROOT}/tests/cpp/test_moe.cpp
+  )
+  add_test(test_moe "${MOE_TEST_SRCS}" "")
+  list(APPEND TEST_BINARIES test_moe)
+
   set(MULTIDEVICE_TEST_SRCS)
   list(APPEND MULTIDEVICE_TEST_SRCS
     ${NVFUSER_ROOT}/tests/cpp/multidevice.cpp


### PR DESCRIPTION
Added unit tests to demonstrate nvFuser representations of `prepare_moe_input` in SGLang MoE. For the Python version, see this internal [repository](http://nv/eLz).

The intention is just demonstrating how the MoE gate logic could be represented, including prefix sum. We would need more pluming work to make it work through Thunder.
