### PR TITLE
Read the right environmental variables for torchrun

### DIFF
--- a/csrc/multidevice/communicator.cpp
+++ b/csrc/multidevice/communicator.cpp
@@ -53,9 +53,15 @@ char* tryReadEnv(const std::vector<std::string>& envs) {
   return nullptr;
 }
 
-// Parse the environment to retrieve MPI rank, world size, local rank,
+// Parses the environment to retrieve MPI rank, world size, local rank,
 // local world size, and also master address and master port.
-// Returns true if the distributed configuration is valid, false otherwise
+//
+// We intend to support mpirun, torchrun
+// (https://docs.pytorch.org/docs/stable/elastic/run.html#environment-variables)
+// and slurm. However, only mpirun is tested in CI at this moment, so I
+// wouldn't be surprised the other launchers don't work out of the box.
+//
+// Returns true if the distributed configuration is valid, false otherwise.
 bool parseEnv(
     RankType& rank,
     int64_t& size,
@@ -63,10 +69,8 @@ bool parseEnv(
     int64_t& local_size,
     std::string& master_addr,
     int& master_port) {
-  char* env = nullptr;
-
   // retrieves the rank of the current process
-  env = tryReadEnv({"OMPI_COMM_WORLD_RANK", "WORLD_RANK", "SLURM_PROCID"});
+  char* env = tryReadEnv({"OMPI_COMM_WORLD_RANK", "RANK", "SLURM_PROCID"});
   if (env == nullptr) {
     return false;
   }
@@ -80,8 +84,8 @@ bool parseEnv(
   size = std::atoi(env);
 
   // retrieves the size of the communicator
-  env = tryReadEnv(
-      {"OMPI_COMM_WORLD_LOCAL_RANK", "WORLD_LOCAL_RANK", "SLURM_LOCALID"});
+  env =
+      tryReadEnv({"OMPI_COMM_WORLD_LOCAL_RANK", "LOCAL_RANK", "SLURM_LOCALID"});
   if (env == nullptr) {
     return false;
   }
@@ -90,7 +94,7 @@ bool parseEnv(
   // retrieves the size of the communicator
   env = tryReadEnv(
       {"OMPI_COMM_WORLD_LOCAL_SIZE",
-       "WORLD_LOCAL_SIZE",
+       "LOCAL_WORLD_SIZE",
        "SLURM_NTASKS_PER_NODE"});
   if (env == nullptr) {
     return false;


### PR DESCRIPTION
The old code probably got off sync at some point. I fixed it according to
https://docs.pytorch.org/docs/stable/elastic/run.html#environment-variables.