### PR TITLE
Set `disable_replace_uniform` to `True` for thunder benchmarks

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -59,7 +59,11 @@ def with_executor(executor: str, fwd_fn: Callable, **kwargs) -> Callable:
     # It is required for both correctness and performance for backward pass when dropout is involved.
     if executor == "thunder":
         return thunder.jit(
-            fwd_fn, nv_enable_bookend=False, disable_replace_uniform = True, executors=[nvfuserex], **kwargs
+            fwd_fn,
+            nv_enable_bookend=False,
+            disable_replace_uniform=True,
+            executors=[nvfuserex],
+            **kwargs,
         )
     if executor == "thunder-torchcompile":
         return thunder.jit(fwd_fn, executors=["torchcompile"], **kwargs)


### PR DESCRIPTION
When `disable_replace_uniform = True`, dropout masks are saved in fwd pass and reused in bwd pass. It improves performance about 1.8x in `dropout + rms norm bwd` , see https://github.com/NVIDIA/Fuser/issues/4625.

Recent changes in Thunder have caused these tests to fail unless they are explicitly run with  `disable_replace_uniform = True`. Without doing so, fusions involving dropout will trigger the following error.
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @torch.no_grad()
    @no_autocast
    def backward_fn(saved_for_backward, cotangents):
      # saved_for_backward: "Collection"
      # cotangents: "Collection"
      C0, C1, = saved_for_backward
      # C0: "Collection"
      # C1: "Collection"
      clear_mutable_collection(saved_for_backward)
      del saved_for_backward
      t51, = cotangents
      # t51: "cuda:0 f32[256, 4, 4]"
      clear_mutable_collection(cotangents)
      del cotangents
      t34, = C0
      # t34: "cuda:0 f32[256, 4, 4]"
      clear_mutable_collection(C0)
      del C0
>     i58, i57, = C1
E     ValueError: not enough values to unpack (expected 2, got 0)
```