### PR TITLE
use 255 if compute_branch_regs is not set

### DIFF
--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -354,8 +354,9 @@ void getHeuristics(
       int64_t buffer_regs =
           round_up_reg_count(non_circular_buffered_smem_size, bdimx) +
           round_up_reg_count(regs_buffer_size, bdimx);
-      NVF_ERROR(ws.num_registers.has_value(), "num_registers is not set");
-      int64_t other_regs = ws.num_registers.value().second - buffer_regs;
+      int64_t compute_branch_regs =
+          ws.num_registers.has_value() ? ws.num_registers.value().second : 255L;
+      int64_t other_regs = compute_branch_regs - buffer_regs;
       return other_regs >= 64L;
     }
     return true;


### PR DESCRIPTION
**Fix corner case in warp-specialized circular buffer register sharing**

Found a corner case at benchmark `benchmarks/python/test_rmsnorm_bwd.py::test_rmsnorm_bwd_baseline_benchmark[dtype=torch.bfloat16-size=[16384_28928]-executor='thunder']`. 

For this case, the heuristics will try to use the warp-specialized approach on B200 and call `is_good_ws_heuristic()`, which contains the check `NVF_ERROR(ws.num_registers.has_value(), "num_registers is not set");`. However, this check is unnecessarily strict. 

The selected configuration uses `bdimx = 128`, `bdimy = 2`, resulting in 256 threads per block which is the maximum allowed, so register sharing is not needed and not set. 

To avoid this false error, the check is removed and replaced with: `int64_t compute_branch_regs = ws.num_registers.has_value() ? ws.num_registers.value().second : 255L;`.
