### PR TITLE
use tma only when persistent buffers are projected to inputs

### DIFF
--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -157,7 +157,6 @@ std::unique_ptr<ReductionParams> getInnerOuterPersistentHeuristics(
     return std::make_unique<ReductionParams>(
         InnerOuterPersistentKernelScheduler::schedulerType());
   };
-
   if (hp.is_warp_specialized ||
       preferWarpSpecialized(
           fusion, properties.total_iteration_numel, n_inner_reduction_tvs)) {


### PR DESCRIPTION
Current implementation of warp specialized TMA normalization assumes persistent buffers are projected to inputs, making TMA loading beneficial.
If not, shared memory persistent buffers cannot use TMA since their producers are not inputs.

Project to inputs is not supported for fusion contains viewOps.