### PR TITLE
don't just check last loop domain for vectorization

### DIFF
--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -823,7 +823,14 @@ void scheduleFusion(Fusion* fusion, const ReductionParams* rparams) {
         }
         // skip tvs that are already vectorized in general vectorization
         // analysis and propagation.
-        if (cached_tv->axis(-1)->getParallelType() == ParallelType::Vectorize) {
+        // The last iter dim may be a broadcast, so we need to check all the
+        // iter dims.
+        if (std::any_of(
+                cached_tv->domain()->loop().begin(),
+                cached_tv->domain()->loop().end(),
+                [](const IterDomain* id) {
+                  return id->getParallelType() == ParallelType::Vectorize;
+                })) {
           continue;
         }
 


### PR DESCRIPTION
The last iter dim may be a broadcast, so we need to check all the iter dims.