### PR TITLE
Support importing both nvfuser and nvfuser_direct modules

### DIFF
--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys
+import warnings
 
-assert (
-    "nvfuser_direct" not in sys.modules
-), "Cannot import nvfuser if nvfuser_direct module is already imported."
+if "nvfuser_direct" in sys.modules:
+    warnings.warn(
+        "Be careful! You've imported nvfuser when the nvfuser_direct module is already imported.",
+        UserWarning,
+    )
 
 import logging
 import os

--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import sys
+import warnings
 
-assert (
-    "nvfuser" not in sys.modules
-), "Cannot import nvfuser_direct if nvfuser module is already imported."
+if "nvfuser" in sys.modules:
+    warnings.warn(
+        "Be careful! You've imported nvfuser_direct when the nvfuser module is already imported.",
+        UserWarning,
+    )
 
 import os
 import torch

--- a/python/python_direct/enum.cpp
+++ b/python/python_direct/enum.cpp
@@ -16,7 +16,7 @@ void bindEnums(py::module& nvfuser) {
   //! DataTypes supported by nvFuser in the FusionDefinition. The python
   //! DataType maps to the CPP PrimDataType. On the CPP side, there is also a
   //! DateType enum that includes struct, array, pointer, or opaque datatypes.
-  py::enum_<PrimDataType>(nvfuser, "DataType")
+  py::enum_<PrimDataType>(nvfuser, "DataType", py::module_local())
       .value("Double", DataType::Double)
       .value("Float", DataType::Float)
       .value("Half", DataType::Half)

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -663,7 +663,7 @@ void initNvFuserPythonBindings(PyObject* module) {
   nvfuser.def("clone", clone);
 
   //! DataTypes supported by nvFuser in the FusionDefinition
-  py::enum_<PrimDataType>(nvfuser, "DataType")
+  py::enum_<PrimDataType>(nvfuser, "DataType", py::module_local())
       .value("Double", DataType::Double)
       .value("Float", DataType::Float)
       .value("Half", DataType::Half)

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -4989,13 +4989,17 @@ fd.execute(inputs)
         self.assertEqual(nvf_out[0], ref_inp.relu())
 
     def test_import_conflict_nvfuser_then_direct(self):
-        try:
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
             import nvfuser  # noqa: F401
             import nvfuser_direct  # noqa: F401
-        except AssertionError as e:
-            expected_msg = (
-                "Cannot import nvfuser_direct if nvfuser module is already imported."
+
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert (
+                "Be careful! You've imported nvfuser_direct when the nvfuser module is already imported."
+                in str(w[-1].message)
             )
-            assert expected_msg in str(e)
-            return
-        raise AssertionError("Expected AssertionError from imports.")

--- a/tests/python_direct/test_import.py
+++ b/tests/python_direct/test_import.py
@@ -12,13 +12,17 @@ def test_import_correct():
 
 
 def test_import_conflict_direct_then_nvfuser():
-    try:
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
         import nvfuser_direct  # noqa: F401
         import nvfuser  # noqa: F401
-    except AssertionError as e:
-        expected_msg = (
-            "Cannot import nvfuser if nvfuser_direct module is already imported."
+
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert (
+            "Be careful! You've imported nvfuser when the nvfuser_direct module is already imported."
+            in str(w[-1].message)
         )
-        assert expected_msg in str(e)
-        return
-    raise AssertionError("Expected AssertionError from imports.")


### PR DESCRIPTION
This PR modifies `nvfuser` and `nvfuser_direct` extensions to allow both of them to be imported in the same script.

* Change assertion to warning
* Add `py::module_local()` to `DataType` enum that is common between both extensions.

The `DataType` is now local to the individual extension rather than the global namespace.