### PR TITLE
Remove setup_default_process_group's dependency on nvfuser

### DIFF
--- a/tests/python/multidevice/conftest.py
+++ b/tests/python/multidevice/conftest.py
@@ -2,15 +2,34 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-import nvfuser
 import os
+from typing import Iterable
+
 import pytest
+
 import torch
 import torch.distributed as dist
+
+import nvfuser
 
 
 class MultideviceTest:
     def __init__(self):
+        os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
+
+        # Reset the cache here to work around a bug in FusionDefintion.execute.
+        # FusionDefinition._finalize_definition maps the same `definition` to the
+        # same FusionSchedules and therefore the same FusionExecutorCache. This was
+        # correct until multiple FusionDefinitions started to have the same
+        # `definition` but different `multidevice_schedule`s. This seems to be a
+        # known issue beacuse a similar workaround for single-GPU schedules is done
+        # here:
+        # https://github.com/NVIDIA/Fuser/blob/f44f1913c26f8325099ab6fe46d678cbea435658/tests/python/test_schedule_ops.py#L115.
+        #
+        # I couldn't think of an easy way to fix this issue properly. Also, that
+        # FusionCache is obsolete makes me less motivated to do so.
+        nvfuser.FusionCache.reset()
+
         self._communicator = nvfuser.Communicator.instance()
 
         # This way, when individual tests create unsharded input, each rank
@@ -50,48 +69,44 @@ class MultideviceTest:
 
 @pytest.fixture
 def multidevice_test():
-    os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
-
-    # Reset the cache here to work around a bug in FusionDefintion.execute.
-    # FusionDefinition._finalize_definition maps the same `definition` to the
-    # same FusionSchedules and therefore the same FusionExecutorCache. This was
-    # correct until multiple FusionDefinitions started to have the same
-    # `definition` but different `multidevice_schedule`s. This seems to be a
-    # known issue beacuse a similar workaround for single-GPU schedules is done
-    # here:
-    # https://github.com/NVIDIA/Fuser/blob/f44f1913c26f8325099ab6fe46d678cbea435658/tests/python/test_schedule_ops.py#L115.
-    #
-    # I couldn't think of an easy way to fix this issue properly. Also, that
-    # FusionCache is obsolete makes me less motivated to do so.
-    nvfuser.FusionCache.reset()
-
     fixture = MultideviceTest()
     yield fixture
     # Sync all ranks after each test for isolation.
     fixture.communicator.barrier()
 
 
+def get_env(envs: Iterable[str], /, *, default: str) -> str:
+    for env in envs:
+        if value := os.environ.get(env):
+            return value
+    return default
+
+
 # Set up the default process group for torch APIs like
 # dist.device_mesh.init_device_mesh.
 #
-# This fixture is used by multi-GPU tests that use torch.distributed.
+# This fixture is used by multi-GPU tests that use torch.distributed directly.
 #
 # I use "session" instead of "module" because
 # https://github.com/pytorch/pytorch/issues/119196 reported race conditions
 # when reinitializing process groups.
 @pytest.fixture(scope="session")
 def setup_default_process_group():
-    communicator = nvfuser.Communicator.instance()
+    # I avoided using nvfuser.Communicator to minimize fixture dependencies on
+    # nvFuser. This makes the transition from legacy bindings to direct
+    # bindings easier.
+    rank = int(get_env(["OMPI_COMM_WORLD_RANK", "RANK"], default="0"))
+    world_size = int(get_env(["OMPI_COMM_WORLD_SIZE", "WORLD_SIZE"], default="1"))
+    local_rank = int(get_env(["OMPI_COMM_WORLD_LOCAL_RANK", "LOCAL_RANK"], default="0"))
 
-    local_rank = communicator.local_rank()
     torch.cuda.set_device(local_rank)
 
     # The default port as used by https://github.com/pytorch/pytorch/blob/45a8b5682eb69d865cbf68c7f2f689b56b4efd53/torch/csrc/distributed/c10d/TCPStore.hpp#L51.
     dist.init_process_group(
         backend="nccl",
         init_method="tcp://localhost:29500",
-        world_size=communicator.size(),
-        rank=communicator.rank(),
+        world_size=world_size,
+        rank=rank,
         device_id=torch.device(f"cuda:{local_rank}"),
     )
     yield


### PR DESCRIPTION
to make direct bindings transition easier.