### PR TITLE
Check driverStatus for cudaGetDriverEntryPoint

### DIFF
--- a/csrc/driver_api.cpp
+++ b/csrc/driver_api.cpp
@@ -65,43 +65,54 @@ namespace {
 void getDriverEntryPoint(
     const char* symbol,
     unsigned int version,
-    void** entry_point) {
+    void** entry_point,
+    cudaDriverEntryPointQueryResult* query_result) {
 #if (CUDA_VERSION >= 12050)
   NVFUSER_CUDA_RT_SAFE_CALL(cudaGetDriverEntryPointByVersion(
-      symbol, entry_point, version, cudaEnableDefault));
+      symbol, entry_point, version, cudaEnableDefault, query_result));
 #else
   (void)version;
-  NVFUSER_CUDA_RT_SAFE_CALL(
-      cudaGetDriverEntryPoint(symbol, entry_point, cudaEnableDefault));
+  NVFUSER_CUDA_RT_SAFE_CALL(cudaGetDriverEntryPoint(
+      symbol, entry_point, cudaEnableDefault, query_result));
 #endif
 }
 } // namespace
 
-#define DEFINE_DRIVER_API_WRAPPER(funcName, version)                     \
-  namespace {                                                            \
-  template <typename ReturnType, typename... Args>                       \
-  struct funcName##Loader {                                              \
-    static ReturnType lazilyLoadAndInvoke(Args... args) {                \
-      static auto* entry_point = [&]() {                                 \
-        decltype(::funcName)* entry_point;                               \
-        getDriverEntryPoint(                                             \
-            #funcName, version, reinterpret_cast<void**>(&entry_point)); \
-        return entry_point;                                              \
-      }();                                                               \
-      return entry_point(args...);                                       \
-    }                                                                    \
-    /* This ctor is just a CTAD helper, it is only used in a */          \
-    /* non-evaluated environment*/                                       \
-    funcName##Loader(ReturnType(Args...)){};                             \
-  };                                                                     \
-                                                                         \
-  /* Use CTAD rule to deduct return and argument types */                \
-  template <typename ReturnType, typename... Args>                       \
-  funcName##Loader(ReturnType(Args...))                                  \
-      ->funcName##Loader<ReturnType, Args...>;                           \
-  } /* namespace */                                                      \
-                                                                         \
-  decltype(::funcName)* funcName =                                       \
+#define DEFINE_DRIVER_API_WRAPPER(funcName, version)            \
+  namespace {                                                   \
+  template <typename ReturnType, typename... Args>              \
+  struct funcName##Loader {                                     \
+    static ReturnType lazilyLoadAndInvoke(Args... args) {       \
+      static auto* entry_point = [&]() {                        \
+        decltype(::funcName)* entry_point;                      \
+        cudaDriverEntryPointQueryResult query_result;           \
+        getDriverEntryPoint(                                    \
+            #funcName,                                          \
+            version,                                            \
+            reinterpret_cast<void**>(&entry_point),             \
+            &query_result);                                     \
+        NVF_CHECK(                                              \
+            query_result == cudaDriverEntryPointSuccess,        \
+            "Failed to get the entry point for ",               \
+            #funcName,                                          \
+            ": ",                                               \
+            query_result);                                      \
+        return entry_point;                                     \
+      }();                                                      \
+      return entry_point(args...);                              \
+    }                                                           \
+    /* This ctor is just a CTAD helper, it is only used in a */ \
+    /* non-evaluated environment*/                              \
+    funcName##Loader(ReturnType(Args...)){};                    \
+  };                                                            \
+                                                                \
+  /* Use CTAD rule to deduct return and argument types */       \
+  template <typename ReturnType, typename... Args>              \
+  funcName##Loader(ReturnType(Args...))                         \
+      ->funcName##Loader<ReturnType, Args...>;                  \
+  } /* namespace */                                             \
+                                                                \
+  decltype(::funcName)* funcName =                              \
       decltype(funcName##Loader(::funcName))::lazilyLoadAndInvoke
 
 namespace nvfuser {

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -40,20 +40,20 @@ namespace nvfuser {
 // to go lower than that. When we increase the minimum supported version, we
 // can accordingly increase the requested versions. However, we don't have to
 // unless new driver capabilities are needed.
-#define ALL_DRIVER_API_WRAPPER_CUDA(fn) \
-  fn(cuDeviceGetAttribute, 11000);      \
-  fn(cuDeviceGetName, 11000);           \
-  fn(cuFuncGetAttribute, 11000);        \
-  fn(cuFuncSetAttribute, 11000);        \
-  fn(cuGetErrorName, 11000);            \
-  fn(cuGetErrorString, 11000);          \
-  fn(cuLaunchCooperativeKernel, 11000); \
-  fn(cuLaunchKernel, 11000);            \
-  fn(cuModuleGetFunction, 11000);       \
-  fn(cuModuleLoadData, 11000);          \
-  fn(cuModuleLoadDataEx, 11000);        \
-  fn(cuModuleUnload, 11000);            \
-  fn(cuMemGetAddressRange, 11000);      \
+#define ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn) \
+  fn(cuDeviceGetAttribute, 11000);                     \
+  fn(cuDeviceGetName, 11000);                          \
+  fn(cuFuncGetAttribute, 11000);                       \
+  fn(cuFuncSetAttribute, 11000);                       \
+  fn(cuGetErrorName, 11000);                           \
+  fn(cuGetErrorString, 11000);                         \
+  fn(cuLaunchCooperativeKernel, 11000);                \
+  fn(cuLaunchKernel, 11000);                           \
+  fn(cuModuleGetFunction, 11000);                      \
+  fn(cuModuleLoadData, 11000);                         \
+  fn(cuModuleLoadDataEx, 11000);                       \
+  fn(cuModuleUnload, 11000);                           \
+  fn(cuMemGetAddressRange, 11000);                     \
   fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000)
 
 // Stream memory operations (e.g. cuStreamWriteValue32) are specified for both
@@ -66,15 +66,15 @@ namespace nvfuser {
 // integrated into the vanilla APIs and are therefore removed. Refer to
 // https://docs.nvidia.com/cuda/archive/11.7.1/cuda-driver-api/group__CUDA__MEMOP.html
 #if (CUDA_VERSION >= 12000)
-#define ALL_DRIVER_API_WRAPPER(fn) \
-  ALL_DRIVER_API_WRAPPER_CUDA(fn); \
-  fn(cuStreamWaitValue32, 12000);  \
-  fn(cuStreamWriteValue32, 12000); \
+#define ALL_DRIVER_API_WRAPPER(fn)                \
+  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
+  fn(cuStreamWaitValue32, 12000);                 \
+  fn(cuStreamWriteValue32, 12000);                \
   fn(cuTensorMapEncodeTiled, 12000)
 #elif (CUDA_VERSION >= 11000)
-#define ALL_DRIVER_API_WRAPPER(fn) \
-  ALL_DRIVER_API_WRAPPER_CUDA(fn); \
-  fn(cuStreamWaitValue32, 11000);  \
+#define ALL_DRIVER_API_WRAPPER(fn)                \
+  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
+  fn(cuStreamWaitValue32, 11000);                 \
   fn(cuStreamWriteValue32, 11000)
 #else
 #error "CUDA_VERSION < 11000 isn't supported."

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -1826,4 +1826,25 @@ std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
   }
 }
 
+std::ostream& operator<<(
+    std::ostream& os,
+    const cudaDriverEntryPointQueryResult result) {
+  switch (result) {
+    case cudaDriverEntryPointSuccess:
+      os << "Success";
+      break;
+    case cudaDriverEntryPointSymbolNotFound:
+      os << "SymbolNotFound";
+      break;
+    case cudaDriverEntryPointVersionNotSufficent:
+      os << "VersionNotSufficient";
+      break;
+    default:
+      NVF_THROW(
+          "Unknown cudaDriverEntryPointQueryResult: ",
+          static_cast<int>(result));
+  }
+  return os;
+}
+
 } // namespace nvfuser

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -7,14 +7,6 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
-#include <macros.h>
-#include <visibility.h>
-
-#include <c10/core/ScalarType.h>
-
-#include <polymorphic_value.h>
-
 #include <array>
 #include <complex>
 #include <cstdint>
@@ -26,6 +18,15 @@
 #include <typeinfo>
 #include <unordered_set>
 #include <variant>
+
+#include <cuda_runtime_api.h>
+
+#include <c10/core/ScalarType.h>
+
+#include <exceptions.h>
+#include <macros.h>
+#include <polymorphic_value.h>
+#include <visibility.h>
 
 #define NVF_TORCH_VERSION_GREATER(major, minor, patch)                \
   TORCH_VERSION_MAJOR > major ||                                      \
@@ -1171,5 +1172,7 @@ enum class TMemRegisterDataPath {
 };
 
 std::ostream& operator<<(std::ostream&, TMemRegisterDataPath);
+
+std::ostream& operator<<(std::ostream&, cudaDriverEntryPointQueryResult);
 
 } // namespace nvfuser


### PR DESCRIPTION
This is necessary because funcPtr can be null even when cudaGetDriverEntryPoint returns cudaSuccess. https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DRIVER__ENTRY__POINT.html