### PR TITLE
Move `TranslateNoReductionMatmul` to start

### DIFF
--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -43,6 +43,7 @@ namespace nvfuser::preseg_passes {
 
   // Replace TensorViews with zero extent. Outputs and inputs may still be empty
   OptimizationPass<RemoveEmptyPass>::runPass(fusion);
+  OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(fusion);
   // This pass should be placed before ConsecutiveCastPass as more
   // consecutive cast ops may be exposed by this pass
   OptimizationPass<TranslateRepeatToExpand>::runPass(fusion);
@@ -80,7 +81,6 @@ namespace nvfuser::preseg_passes {
 
   OptimizationPass<RemoveBcastSqueeze>::runPass(fusion);
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);
-  OptimizationPass<TranslateNoReductionMatmulToMulSqueeze>::runPass(fusion);
   OptimizationPass<MoveRepeatForwardPass>::runPass(fusion);
   OptimizationPass<MoveGatherPass>::runPass(fusion);
 

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -30,6 +30,7 @@
 namespace nvfuser::preseg_passes {
 
 using testing::ElementsAre;
+using testing::UnorderedElementsAre;
 
 using PresegTest = NVFuserTest;
 
@@ -1505,11 +1506,13 @@ TEST_P(TranslateNoReductionMatmulTest, Test) {
   auto outputs = executor_cache.runFusionWithInputs({t0, t1});
   testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
 
-  // Should be scheduled as a pointwise kernel
+  // Should be scheduled as a pointwise & expr-eval kernel
   FusionKernelRuntime* runtime = executor_cache.getMostRecentKernelRuntime();
   EXPECT_THAT(
       runtime->fusionSegments()->groups(),
-      ElementsAre(HeuristicIs(SchedulerType::PointWise)));
+      UnorderedElementsAre(
+          HeuristicIs(SchedulerType::ExprEval),
+          HeuristicIs(SchedulerType::PointWise)));
 }
 
 } // namespace nvfuser::preseg_passes


### PR DESCRIPTION
-> Inserts `castOp` in translation: `matmul->out()` has the same dtype as the inputs, whereas `mul` returns a float output
-> Move this pass to the start, since meta ops can be candidates for aliasing and other optimizations.