### PR TITLE
fix eval where

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -632,32 +632,7 @@ BinaryOp::BinaryOp(
   addInput(rhs);
   addDataAttribute(type);
 }
-namespace {
-// Helper function to call torch::where with appropriate overload
-at::Tensor evalWithTorchWhere(
-    const at::Tensor& condition,
-    const PolymorphicValue& b,
-    const PolymorphicValue& c) {
-  using namespace PolymorphicValue_functions;
-  // Check if b and c are tensors or scalars
-  bool b_is_tensor = b.is<at::Tensor>();
-  bool c_is_tensor = c.is<at::Tensor>();
 
-  if (b_is_tensor && c_is_tensor) {
-    // Both are tensors
-    return torch::where(condition, b.as<at::Tensor>(), c.as<at::Tensor>());
-  } else if (b_is_tensor && !c_is_tensor) {
-    // b is tensor, c is scalar
-    return torch::where(condition, b.as<at::Tensor>(), toScalar(c));
-  } else if (!b_is_tensor && c_is_tensor) {
-    // b is scalar, c is tensor
-    return torch::where(condition, toScalar(b), c.as<at::Tensor>());
-  } else {
-    // Both are scalars
-    return torch::where(condition, toScalar(b), toScalar(c));
-  }
-}
-} // namespace
 std::vector<PolymorphicValue> BinaryOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
@@ -854,13 +829,9 @@ std::vector<PolymorphicValue> TernaryOp::evaluate(
     case TernaryOpType::Threshold:
       return {(a <= b) ? c : a};
       break;
-    case TernaryOpType::Where: {
-      if (!a.is<at::Tensor>()) {
-        return {a.as<bool>() ? b : c};
-      }
-      return {evalWithTorchWhere(a.as<at::Tensor>(), b, c)};
+    case TernaryOpType::Where:
+      return {where(a, b, c)};
       break;
-    }
     default:
       NVF_CHECK(
           false,

--- a/tests/python/test_repro.py
+++ b/tests/python/test_repro.py
@@ -425,7 +425,6 @@ class TestRepro(NVFuserTest):
         inputs = []
         fd.validate(inputs)
 
-
     def test_ws_tma_normalization1(self):
         # Bug 5374765: Gemma-7b model fail with "Found two vectorized domains ... only one is allowed"
         def nvfuser_fusion_id8(fd: FusionDefinition) -> None:

--- a/tests/python/test_repro.py
+++ b/tests/python/test_repro.py
@@ -423,7 +423,8 @@ class TestRepro(NVFuserTest):
             nvfuser_fusion_id0(fd)
 
         inputs = []
-        fd.execute(inputs)
+        fd.validate(inputs)
+
 
     def test_ws_tma_normalization1(self):
         # Bug 5374765: Gemma-7b model fail with "Found two vectorized domains ... only one is allowed"


### PR DESCRIPTION
 **Add `where` function to PolymorphicValue_functions**

Before this PR, evaluation fails for ops `where(a,b,c)` when b or c is a scalar.

1. This PR added where function (csrc/polymorphic_value.h):

- New function that handles all combinations of tensor and scalar inputs for the where operation
- Properly dispatches to at::where with appropriate overloads
- Supports tensor-tensor, tensor-scalar, scalar-tensor, and scalar-scalar combinations

2. Added cpp tests and revised one python test to use `fd.validate()`
3. Other TernaryOps also need fix, but they are not used yet in python or cpp tests.