### PR TITLE
[cmake] Remove duplicate `enable_language(CUDA)` and `find_package(CUDAToolkit)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,6 @@ install(DIRECTORY "${NVFUSER_ROOT}/lib/dynamic_type/src/dynamic_type"
 
 set(CUTLASS_STATUS "N/A")
 if(BUILD_CUTLASS)
-  enable_language(CUDA)
 
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8)
     message(WARNING "Skip building CUTLASS because of incompatible CUDA ${CMAKE_CUDA_COMPILER_VERSION}")
@@ -511,7 +510,6 @@ if(BUILD_CUTLASS)
     add_compile_definitions(NVFUSER_ENABLE_CUTLASS)
     set(CUTLASS_STATUS "ENABLED")
 
-    find_package(CUDAToolkit REQUIRED)
     include(FetchContent)
 
     # cutlass


### PR DESCRIPTION
Following #4755.