### PR TITLE
Add test fusion definitions for stream lowering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,6 +806,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_move_repeat_forward.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_mutator.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_no_op.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_overlap.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_persistent_buffer.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_pointwise.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_polymorphic_value.cpp

--- a/tests/cpp/test_overlap.cpp
+++ b/tests/cpp/test_overlap.cpp
@@ -1,0 +1,45 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gtest/gtest.h>
+
+#include <ops/all_ops.h>
+#include <tests/cpp/utils.h>
+
+namespace nvfuser {
+
+using OverlapTest = NVFuserTest;
+
+TEST_F(OverlapTest, ColumnParallelLinear_Forward) {
+  constexpr int64_t h = 12288;
+  constexpr int64_t d = 2;
+
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  TensorView* in = makeContigConcreteTensor({-1, h}, DataType::BFloat16);
+  TensorView* w = makeContigConcreteTensor({h * 4, h}, DataType::BFloat16);
+  TensorView* out = linear(in, w, nullptr);
+
+  in->outer_split(0, d);
+  in->axis(0)->parallelize(ParallelType::DIDx);
+  w->outer_split(0, d);
+  w->axis(0)->parallelize(ParallelType::DIDx);
+  out->outer_split(1, d);
+  out->axis(1)->parallelize(ParallelType::DIDx);
+  out->outer_split(0, d);
+  out->axis(0)->parallelize(ParallelType::Stream);
+
+  fusion->addInput(in);
+  fusion->addInput(w);
+  fusion->addOutput(out);
+
+  fusion->print();
+}
+
+} // namespace nvfuser

--- a/tests/cpp/test_overlap.cpp
+++ b/tests/cpp/test_overlap.cpp
@@ -206,8 +206,9 @@ TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_InputGrad) {
   in->axis(0)->parallelize(ParallelType::Stream);
 }
 
-// TODO: add tests for row-wise parallel linear without sequence dimension
+// TODO: add tests for row-wise parallel linear without sequence parallelism
 
-// TODO: add tests for collective-based overlapping when layouts are in favor
+// TODO: add tests for collective-based overlapping for which layouts are in
+// favor
 
 } // namespace nvfuser

--- a/tests/cpp/test_overlap.cpp
+++ b/tests/cpp/test_overlap.cpp
@@ -13,9 +13,9 @@
 
 namespace nvfuser {
 
-using OverlapTest = NVFuserTest;
+using RingBasedOverlapTest = NVFuserTest;
 
-TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_Forward) {
+TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_Forward) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 
@@ -44,11 +44,11 @@ TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_Forward) {
   out->outer_split(0, d);
   // A Swizzle is needed to represent a cyclic shift needed for ring-based
   // overlapping: http://nv/eNL. This is not implemented yet and therefore
-  // omitted in all tests.
+  // omitted in all `RingBasedOverlapTest`s.
   out->axis(0)->parallelize(ParallelType::Stream);
 }
 
-TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_WeightGrad) {
+TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_WeightGrad) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 
@@ -78,7 +78,7 @@ TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_WeightGrad) {
   w->axis(-2)->parallelize(ParallelType::Stream);
 }
 
-TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_InputGrad) {
+TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_InputGrad) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 
@@ -114,7 +114,7 @@ TEST_F(OverlapTest, ColumnAndSequenceParallelLinear_InputGrad) {
   in->axis(-2)->parallelize(ParallelType::DIDx);
 }
 
-TEST_F(OverlapTest, RowAndSequenceParallelLinear_Forward) {
+TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_Forward) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 
@@ -146,7 +146,7 @@ TEST_F(OverlapTest, RowAndSequenceParallelLinear_Forward) {
   out->axis(-2)->parallelize(ParallelType::DIDx);
 }
 
-TEST_F(OverlapTest, RowAndSequenceParallelLinear_WeightGrad) {
+TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_WeightGrad) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 
@@ -176,7 +176,7 @@ TEST_F(OverlapTest, RowAndSequenceParallelLinear_WeightGrad) {
   w->axis(-2)->parallelize(ParallelType::Stream);
 }
 
-TEST_F(OverlapTest, RowAndSequenceParallelLinear_InputGrad) {
+TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_InputGrad) {
   constexpr int64_t h = 12288;
   constexpr int64_t d = 2;
 

--- a/tests/cpp/test_overlap.cpp
+++ b/tests/cpp/test_overlap.cpp
@@ -41,6 +41,7 @@ TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_Forward) {
   w->axis(0)->parallelize(ParallelType::DIDx);
   out->outer_split(1, d);
   out->axis(1)->parallelize(ParallelType::DIDx);
+
   out->outer_split(0, d);
   // A Swizzle is needed to represent a cyclic shift needed for ring-based
   // overlapping: http://nv/eNL. This is not implemented yet and therefore
@@ -70,10 +71,11 @@ TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_WeightGrad) {
 
   in->outer_split(0, d);
   in->axis(0)->parallelize(ParallelType::DIDx);
-  out->outer_split(1, d);
-  out->axis(1)->parallelize(ParallelType::DIDx);
   w->outer_split(0, d);
   w->axis(0)->parallelize(ParallelType::DIDx);
+  out->outer_split(1, d);
+  out->axis(1)->parallelize(ParallelType::DIDx);
+
   w->outer_split(-1, d);
   w->axis(-2)->parallelize(ParallelType::Stream);
 }
@@ -98,20 +100,23 @@ TEST_F(RingBasedOverlapTest, ColumnAndSequenceParallelLinear_InputGrad) {
     tv->setDeviceMesh(mesh);
   }
 
+  in->outer_split(0, d);
+  in->axis(0)->parallelize(ParallelType::DIDx);
+  // For computing input gradients, `in` is the output and its reduction
+  // dimension needs to be sharded.
+  in->outer_split(-1, d);
+  in->axis(-2)->parallelize(ParallelType::DIDx);
+  w->outer_split(0, d);
+  w->axis(0)->parallelize(ParallelType::DIDx);
   out->outer_split(1, d);
   out->axis(1)->parallelize(ParallelType::DIDx);
+
   // This is debatable. On the one hand, we want to express the intention to
   // stream-parallelize the sequence dimension. On the other hand, we want to
   // avoid parallelizing a fusion input because a fusion input doesn't have a
   // producer.
   out->outer_split(0, d);
   out->axis(0)->parallelize(ParallelType::Stream);
-  w->outer_split(0, d);
-  w->axis(0)->parallelize(ParallelType::DIDx);
-  in->outer_split(0, d);
-  in->axis(0)->parallelize(ParallelType::DIDx);
-  in->outer_split(-1, d);
-  in->axis(-2)->parallelize(ParallelType::DIDx);
 }
 
 TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_Forward) {
@@ -136,14 +141,15 @@ TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_Forward) {
 
   in->outer_split(1, d);
   in->axis(1)->parallelize(ParallelType::DIDx);
-  in->outer_split(0, d);
-  in->axis(0)->parallelize(ParallelType::Stream);
   w->outer_split(1, d);
   w->axis(1)->parallelize(ParallelType::DIDx);
   out->outer_split(0, d);
   out->axis(0)->parallelize(ParallelType::DIDx);
   out->outer_split(-1, d);
   out->axis(-2)->parallelize(ParallelType::DIDx);
+
+  in->outer_split(0, d);
+  in->axis(0)->parallelize(ParallelType::Stream);
 }
 
 TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_WeightGrad) {
@@ -168,10 +174,11 @@ TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_WeightGrad) {
 
   in->outer_split(1, d);
   in->axis(1)->parallelize(ParallelType::DIDx);
-  out->outer_split(0, d);
-  out->axis(0)->parallelize(ParallelType::DIDx);
   w->outer_split(1, d);
   w->axis(1)->parallelize(ParallelType::DIDx);
+  out->outer_split(0, d);
+  out->axis(0)->parallelize(ParallelType::DIDx);
+
   w->outer_split(-1, d);
   w->axis(-2)->parallelize(ParallelType::Stream);
 }
@@ -196,12 +203,13 @@ TEST_F(RingBasedOverlapTest, RowAndSequenceParallelLinear_InputGrad) {
     tv->setDeviceMesh(mesh);
   }
 
-  out->outer_split(0, d);
-  out->axis(0)->parallelize(ParallelType::DIDx);
-  w->outer_split(1, d);
-  w->axis(1)->parallelize(ParallelType::DIDx);
   in->outer_split(1, d);
   in->axis(1)->parallelize(ParallelType::DIDx);
+  w->outer_split(1, d);
+  w->axis(1)->parallelize(ParallelType::DIDx);
+  out->outer_split(0, d);
+  out->axis(0)->parallelize(ParallelType::DIDx);
+
   in->outer_split(0, d);
   in->axis(0)->parallelize(ParallelType::Stream);
 }


### PR DESCRIPTION
These fusion definitions obviously don't run with FusionExecutorCache yet. I'm adding them merely to clarify the use cases for stream lowering. 