### PR TITLE
Switch ClusterDims from XYZ to MN

### DIFF
--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -303,7 +303,7 @@ class MatmulParams : public HeuristicParams {
   //!    C3 C4 D3 D4
   //!
   //! Note that this is done at the CGA tile level in case cluster_dims is
-  //! something other than {1, 1, 1}
+  //! something other than {1, 1}
   std::pair<int, int> grid_traversal_factor = {1, 1};
 
   //! Unswizzle MMA results in shared memory to get
@@ -331,11 +331,11 @@ class MatmulParams : public HeuristicParams {
   //!
   //! When cta_order == ColumnMajor, M is parallelized BIDx and N is
   //! parallelized BIDy. In that case, the cluster dimension X will apply to the
-  //! M dimension and Y will apply to N. If cluster_dims = {2, 4, 1} in that
+  //! M dimension and Y will apply to N. If cluster_dims = {2, 4} in that
   //! case and the cta_tile is {128, 256, 64} then the "CGA tile" would be {256,
   //! 1024, 64}.
   //!
-  //! If however cta_order were RowMajor and cluster_dims = {2, 4, 1}, the
+  //! If however cta_order were RowMajor and cluster_dims = {2, 4}, the
   //! parallelization of M and N is swapped so the CGA tile would become {512,
   //! 512, 64}. This example shows that it is important to manage the cluster
   //! dims in conjunction with the CTA tile and CTA order. Also note that "grid
@@ -344,12 +344,11 @@ class MatmulParams : public HeuristicParams {
   //!
   //! The Z dimension must currently be 1.
   struct ClusterDims {
-    int64_t x = 1;
-    int64_t y = 1;
-    int64_t z = 1;
+    int64_t m = 1;
+    int64_t n = 1;
 
     bool operator==(const ClusterDims& other) const {
-      return x == other.x && y == other.y && z == other.z;
+      return m == other.m && n == other.n;
     }
 
     bool operator!=(const ClusterDims& other) const {
@@ -358,15 +357,13 @@ class MatmulParams : public HeuristicParams {
 
     std::string toString() const {
       std::stringstream ss;
-      ss << "__cluster_dims__(" << x << ", " << y << ", " << z << ")";
+      ss << "__cluster_dims__(" << m << ", " << n << ")";
       return ss.str();
     }
 
     size_t hash() const {
-      return std::hash<size_t>{}(
-                 (static_cast<size_t>(x) << 32) |
-                 (static_cast<size_t>(y)) << 16) |
-          (static_cast<size_t>(z));
+      return std::hash<size_t>{}((static_cast<size_t>(m)) << 16) |
+          (static_cast<size_t>(n));
     }
   } cluster_dims;
 

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -139,9 +139,9 @@ void copyParamsToConfig(KernelConfig* config, const MatmulParams* mparams) {
   setConfigTile(config->cta_tile, mparams->tile_sizes.cta_tile);
   setConfigTile(config->warp_tile, mparams->tile_sizes.warp_tile);
   setConfigTile(config->instruction_tile, getMmaOpShape(mparams->mma_macro));
-  config->cluster_dims[0] = mparams->cluster_dims.x;
-  config->cluster_dims[1] = mparams->cluster_dims.y;
-  config->cluster_dims[2] = mparams->cluster_dims.z;
+  config->cluster_dims[0] = mparams->cluster_dims.m;
+  config->cluster_dims[1] = mparams->cluster_dims.n;
+  config->cluster_dims[2] = 1;
   config->splitk_factor = mparams->splitk_factor;
   config->grid_swizzle_factor = mparams->grid_traversal_factor.first;
   config->cta_order =
@@ -164,9 +164,12 @@ void copyConfigToParams(MatmulParams* mparams, const KernelConfig* config) {
   };
   setGemmTile(mparams->tile_sizes.cta_tile, config->cta_tile);
   setGemmTile(mparams->tile_sizes.warp_tile, config->warp_tile);
-  mparams->cluster_dims.x = config->cluster_dims[0];
-  mparams->cluster_dims.y = config->cluster_dims[1];
-  mparams->cluster_dims.z = config->cluster_dims[2];
+  mparams->cluster_dims.m = config->cluster_dims[0];
+  mparams->cluster_dims.n = config->cluster_dims[1];
+  NVF_CHECK(
+      config->cluster_dims[2] == 1,
+      "cluster_dims[2] must be 1 but found ",
+      config->cluster_dims[2]);
   mparams->circular_buffer_options.smem_circular_buffer_stage =
       config->load_stages;
   mparams->circular_buffer_options.smem_circular_buffer_prefetch_gap =

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -144,11 +144,6 @@ void HopperPlus::validate() const {
   }
 
   NVF_CHECK(
-      params_->cluster_dims.z == 1,
-      "Cluster dims must have 1 in Z dimension but found ",
-      params_->cluster_dims.z);
-
-  NVF_CHECK(
       params_->tiling_strategy !=
           MatmulParams::TilingStrategy::DistributeStagesAcrossSMs,
       "Hopper+ matmul scheduler does not support distributing stages across "
@@ -376,8 +371,8 @@ std::vector<MatmulDimRole> HopperPlus::applyCgaAndCtaTilingWithSwizzling(
   // TODO: It might be more natural to just have a "CGA tile" as part of
   // params_->tile_sizes and infer cluster_dims from that
   GemmTile cga_tile{
-      params_->tile_sizes.cta_tile.m * params_->cluster_dims.x,
-      params_->tile_sizes.cta_tile.n * params_->cluster_dims.y,
+      params_->tile_sizes.cta_tile.m * params_->cluster_dims.m,
+      params_->tile_sizes.cta_tile.n * params_->cluster_dims.n,
       params_->tile_sizes.cta_tile.k};
 
   merged_roles = mma_utils::makeTile(tv, cga_tile, orig_merged_roles);
@@ -420,7 +415,7 @@ std::vector<MatmulDimRole> HopperPlus::applyCgaAndCtaTilingWithSwizzling(
         if (inner_extent.hasValue() && inner_extent.as<int64_t>() == 1L) {
           /* Special case: static shapes
           Suppose we have static shapes M=512, N=128 K=256 and our config is
-          cluster_dims={1, 1, 1}, cta_tile={128, 256, 64}, column major.
+          cluster_dims={1, 1}, cta_tile={128, 256, 64}, column major.
           This is the case in the AllocationDomainTest.BasicMatmul test.
           Then we will normally do the following non-persistent schedule for
           the N dimensions:
@@ -645,9 +640,7 @@ std::vector<std::vector<MatmulDimRole>> HopperPlus::blockTileTensors(
 int64_t HopperPlus::numCGAs() const {
   const int64_t num_sms =
       at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  return num_sms /
-      (params_->cluster_dims.x * params_->cluster_dims.y *
-       params_->cluster_dims.z);
+  return num_sms / (params_->cluster_dims.m * params_->cluster_dims.n);
 }
 
 void HopperPlus::inspectPrologues() const {

--- a/csrc/scheduler/matmul_hopper+.h
+++ b/csrc/scheduler/matmul_hopper+.h
@@ -161,13 +161,11 @@ class HopperPlus : public Common {
   //! Specifies the CGA dimensions by setting "cluster_dims" as fusion-managed
   //! data
   void setCGADims() const {
-    if (params_->cluster_dims != MatmulParams::ClusterDims{1, 1, 1}) {
+    if (params_->cluster_dims != MatmulParams::ClusterDims{1, 1}) {
       fusion_->manage(
           "cluster_dims",
           std::tuple<int64_t, int64_t, int64_t>{
-              params_->cluster_dims.x,
-              params_->cluster_dims.y,
-              params_->cluster_dims.z});
+              params_->cluster_dims.m, params_->cluster_dims.n, 1});
     }
   }
 

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -505,19 +505,19 @@ bool fillDefaultHopperHeuristic(
     // TODO: When this does not divide num_sms evenly, we should penalize using
     // large CGAs because they will leave some SMs idle.
     int64_t largest_cga = -1L;
-    MatmulParams::ClusterDims largest_cga_cfg{1, 1, 1};
+    MatmulParams::ClusterDims largest_cga_cfg{1, 1};
     // Allow CGAs larger than 2 only for small problems
     const int64_t max_cga_size =
         Mtiles * Ntiles > ((double)num_sms * .75) ? 2L : 4L;
-    for (int64_t cx : arange(1L, 9L)) {
-      for (int64_t cy : arange(1L, 9L)) {
-        int64_t cga_size = cx * cy;
-        if (Mtiles % cx != 0 || Ntiles % cy != 0 || cga_size > max_cga_size) {
+    for (int64_t cm : arange(1L, 9L)) {
+      for (int64_t cn : arange(1L, 9L)) {
+        int64_t cga_size = cm * cn;
+        if (Mtiles % cm != 0 || Ntiles % cn != 0 || cga_size > max_cga_size) {
           continue;
         }
         if (largest_cga == -1L || cga_size > largest_cga) {
           largest_cga = cga_size;
-          largest_cga_cfg = {cx, cy, 1};
+          largest_cga_cfg = {cm, cn};
         }
       }
     }
@@ -1103,7 +1103,7 @@ int64_t getMaxActiveClusters(const MatmulParams::ClusterDims& cluster_dims) {
   // space for 8 just to future-proof this
   thread_local std::array<int64_t, 16> cached_results;
 
-  const int64_t cluster_size = cluster_dims.x * cluster_dims.y * cluster_dims.z;
+  const int64_t cluster_size = cluster_dims.m * cluster_dims.n;
   if (cached_results.at(cluster_size) != 0L) {
     return cached_results.at(cluster_size);
   }
@@ -1248,9 +1248,9 @@ std::unique_ptr<MatmulParams> getMatmulHeuristics(
       if (mparams->tiling_strategy !=
               MatmulParams::TilingStrategy::OneTilePerCTA ||
           computeHopperBIDxTiles(mparams.get(), problem_shape) % 2 == 0) {
-        mparams->cluster_dims = {2, 1, 1};
+        mparams->cluster_dims = {2, 1};
       } else {
-        mparams->cluster_dims = {1, 1, 1};
+        mparams->cluster_dims = {1, 1};
       }
     }
 

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -510,10 +510,9 @@ void defineHeuristicParamBindings(py::module& nvfuser) {
       .value("row_major", MatmulParams::TileRasterizationOrder::RowMajor);
 
   py::class_<MatmulParams::ClusterDims>(nvfuser, "ClusterDims")
-      .def(py::init<int64_t, int64_t, int64_t>())
-      .PARAM(MatmulParams::ClusterDims, x)
-      .PARAM(MatmulParams::ClusterDims, y)
-      .PARAM(MatmulParams::ClusterDims, z)
+      .def(py::init<int64_t, int64_t>())
+      .PARAM(MatmulParams::ClusterDims, m)
+      .PARAM(MatmulParams::ClusterDims, n)
       .TOSTRINGMETHOD(MatmulParams::ClusterDims);
 
   py::enum_<MmaMacroEncode::Arch>(nvfuser, "MmaMacroArch")

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -3685,7 +3685,7 @@ MatmulParams defaultHopperParams() {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {1, 1, 1};
+  mparams.cluster_dims = {1, 1};
   mparams.promote_prologue_smem_reuse = true;
   return mparams;
 }
@@ -3863,7 +3863,7 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -3919,7 +3919,7 @@ TEST_F(HopperMatmulTest, HSH_TN_UseScheduler) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -3980,7 +3980,7 @@ TEST_F(HopperMatmulTest, HSH_NN_UseScheduler) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -4041,7 +4041,7 @@ TEST_F(HopperMatmulTest, HSH_TT_UseScheduler) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -4108,7 +4108,7 @@ class MLPBenchmarkTest
     mparams.splitk_factor = 1;
     mparams.grid_traversal_factor = {8, 1};
     mparams.use_smem_epilogue = true;
-    mparams.cluster_dims = {2, 1, 1};
+    mparams.cluster_dims = {2, 1};
     mparams.promote_prologue_smem_reuse = true;
   }
 };
@@ -4718,7 +4718,7 @@ TEST_F(HopperMatmulTest, HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = false;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -4784,7 +4784,7 @@ TEST_F(HopperMatmulTest, ScheduleWithTranslation) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {1, 1, 1};
+  mparams.cluster_dims = {1, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -4844,7 +4844,7 @@ TEST_F(HopperMatmulTest, IndexTypeValidation) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {1, 1, 1};
+  mparams.cluster_dims = {1, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   constexpr int64_t M = 1 << 17, N = 256, K = 1 << 17;
@@ -5172,7 +5172,7 @@ TEST_P(MLPGemmPersistentBroadcastInputs, NumWarpGroups) {
   // Legacy launch is faster than Cluster launch when using full 132 SM grid.
   // Cluster launch is better when using 128 SM grid that matches 2d grid
   // traveral.
-  mparams.cluster_dims = {1, 1, 1};
+  mparams.cluster_dims = {1, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -5253,7 +5253,7 @@ TEST_F(HopperMatmulTest, EpilogueBiasPersistentBroadcastInputs) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -5334,7 +5334,7 @@ TEST_F(HopperMatmulTest, EpilogueSiluPersistentBroadcastInputs) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -5405,7 +5405,7 @@ TEST_F(BlackwellMatmulTest, EpilogueBiasPersistentBroadcastInputs) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -5486,7 +5486,7 @@ TEST_F(BlackwellMatmulTest, EpilogueSiluPersistentBroadcastInputs) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = true;
-  mparams.cluster_dims = {2, 1, 1};
+  mparams.cluster_dims = {2, 1};
   mparams.promote_prologue_smem_reuse = true;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)
@@ -5556,7 +5556,7 @@ TEST_F(HopperMatmulTest, HSH_NT_SingleMathGroupSyncCheck) {
   mparams.circular_buffer_options.smem_circular_buffer_prefetch_gap = 1;
   mparams.splitk_factor = 1;
   mparams.use_smem_epilogue = false;
-  mparams.cluster_dims = {1, 1, 1};
+  mparams.cluster_dims = {1, 1};
   mparams.promote_prologue_smem_reuse = false;
 
   SchedulerEntry::makeSchedulerInstance(SchedulerType::Matmul)


### PR DESCRIPTION
We always require `cluster_dims.z==1` in the matmul scheduler and it is sometimes confusing to have x, y, z instead of m and n. Since we now always map x to m and y to n, I thought it would be more clear to rename those parameters.