### PR TITLE
Restrict fence.proxy.async to shared::cta

### DIFF
--- a/csrc/device_lower/pass/inline_ptx.cpp
+++ b/csrc/device_lower/pass/inline_ptx.cpp
@@ -412,7 +412,7 @@ class LowerToInlinePtx : public kir::ExprMutator {
     registerReplace(
         fence,
         IrBuilder::create<kir::Asm>(
-            "fence.proxy.async",
+            "fence.proxy.async.shared::cta",
             std::vector<Val*>{},
             std::vector<Val*>{},
             kir::Asm::Options{/*volatile=*/true}));


### PR DESCRIPTION
We only currently use the `kir::FenceAsyncProxy` expression type to avoid shared memory WARs. Adding this modifier to the PTX instruction means we don't need to wait for gmem writes to be available to the epilogue threads, which saves time.
Note that cutlass also only uses `fence.proxy.async` with this modifier: https://github.com/NVIDIA/cutlass/blob/9baa06dd57804ce8fb5efe9e471b3451341522c6/include/cutlass/arch/barrier.h#L717

In testing this took our small LLM
problem set from 84% to 90% of cublas (ignoring split-K). Note that we should also predicate the `fenceAsyncProxy` calls to match the predicates in the consumer expressions -- currently meaning in TMA stores. This can also give us a speedup but I have not yet automated that.

PTX doc: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar