### PR TITLE
[WIP] Insert fences in insertRawThreadSynchronization

### DIFF
--- a/csrc/device_lower/pass/insert_syncs.cpp
+++ b/csrc/device_lower/pass/insert_syncs.cpp
@@ -494,12 +494,6 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
                     expr->fusion()->zeroVal()),
                 expr->fusion()->zeroVal(DataType::UInt32)));
       }
-    } else if (ir_utils::isCpAsyncBulkStore(expr)) {
-      // Add a fence before TMA store so that writes in the generic proxy is
-      // visible to the async proxy.
-      auto scope = scope_.empty() ? nullptr : scope_.back();
-      auto fence_async = IrBuilder::create<kir::FenceAsyncProxy>();
-      registerInsertBefore(expr, fence_async, scope);
     }
 
     // Insert sync exprs after async ops. For example, insert
@@ -698,11 +692,12 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
       }
     }
 
+    ForLoop* placed_in_fl = nullptr;
+    Expr* place_before = nullptr;
     if (sync_within_fl == nullptr) {
       // Sync should be placed at global scope, after its outer most loop if
       // it has one.
-      Expr* place_before =
-          !for_loops_.empty() ? for_loops_[0] : insert_before_expr;
+      place_before = !for_loops_.empty() ? for_loops_[0] : insert_before_expr;
       // Find location in exprs_
       auto place_before_it =
           std::find(exprs_.begin(), exprs_.end(), place_before);
@@ -716,13 +711,11 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
         registerInsertBefore(place_before, maybe_alloc, nullptr);
       }
       registerInsertBefore(*(place_before_it), sync_expr, nullptr);
-      return nullptr;
     } else {
       auto sync_within_loop_it =
           std::find(for_loops_.begin(), for_loops_.end(), sync_within_fl);
 
       auto place_in = *sync_within_loop_it;
-      Expr* place_before = nullptr;
 
       if (sync_within_loop_it + 1 == for_loops_.end()) {
         // Inline, place before expr
@@ -735,8 +728,53 @@ class ReadAfterWriteSyncs : public kir::ExprMutator {
       if (maybe_alloc != nullptr) {
         registerInsertBefore(place_before, maybe_alloc, &place_in->body());
       }
-      return place_in;
+      placed_in_fl = place_in;
     }
+
+    // Insert fence if necessary
+    // We insert a ProxyFence whenever the consuming operation
+    // (insert_before_expr) is in the async proxy and any of the definitions of
+    // last_writes is in the generic proxy
+    const lower_utils::MemoryProxy consumer_proxy =
+        lower_utils::getMemoryProxy(insert_before_expr);
+    std::unordered_set<MemoryType> guarded_memtypes;
+    bool needs_proxy_fence = false;
+    for (Expr* write_expr : last_writes) {
+      // Determine whether an implicit fence is guaranteed or if we need to
+      // insert one
+      if (auto* mma = dynamic_cast<MmaOp*>(write_expr);
+          mma && mma->isHopper()) {
+        // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-warpgroup-level-matrix-async-proxy
+        continue;
+      }
+      if (ir_utils::isCpAsyncOp(write_expr) ||
+          ir_utils::isCpAsyncBulk(write_expr)) {
+        // https://docs.nvidia.com/cuda/parallel-thread-execution/#async-proxy
+        continue;
+      }
+      if (lower_utils::getMemoryProxy(write_expr) != consumer_proxy) {
+        needs_proxy_fence = true;
+        // If this expression requires a fence, determine which memory space(s)
+        // need to be fenced.
+        for (Val* out_val : write_expr->outputs()) {
+          if (auto* tv = dynamic_cast<TensorView*>(out_val)) {
+            guarded_memtypes.insert(tv->getMemoryType());
+          }
+        }
+      }
+    }
+
+    if (needs_proxy_fence) {
+      NVF_ERROR(
+          guarded_memtypes.size() == 1 &&
+              guarded_memtypes.count(MemoryType::Shared) == 1,
+          "We currently only support fence.proxy.async.shared::cta, but other "
+          "memory types were detected.");
+      auto* fence_expr = IrBuilder::create<kir::FenceAsyncProxy>();
+      registerInsertBefore(place_before, fence_expr, &placed_in_fl->body());
+    }
+
+    return placed_in_fl;
   }
 
   void handle(kir::IfThenElse* ite) final {

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -2157,6 +2157,19 @@ bool isCopyOnly(Val* val) {
   return true;
 }
 
+MemoryProxy getMemoryProxy(Expr* expr) {
+  if (ir_utils::isCpAsyncOp(expr) || ir_utils::isCpAsyncBulk(expr) ||
+      expr->isOneOf<kir::AsyncCommit, kir::AsyncWait>()) {
+    return MemoryProxy::Async;
+  }
+
+  // TODO: Any operation that accesses a TensorMap should return
+  // MemoryProxy::TensorMap. I don't think we every explicitly access these
+  // currently.
+
+  return MemoryProxy::Generic;
+}
+
 } // namespace lower_utils
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.h
+++ b/csrc/device_lower/utils.h
@@ -392,5 +392,10 @@ bool isCopyOnly(Expr* expr);
 // on it.
 bool isCopyOnly(Val* val);
 
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#proxies
+enum class MemoryProxy { Generic, Async, TensorMap };
+
+MemoryProxy getMemoryProxy(Expr* expr);
+
 } // namespace lower_utils
 } // namespace nvfuser


### PR DESCRIPTION
Whenever we insert a sync, this PR adds a simple analysis to determine whether a memory fence is required and if so it adds a `FenceAsyncProxy`. This is not sufficient to completely address #4808 because:
1. It only affects syncs inserted in this pass, while mbarrier syncs are inserted in circular buffering as well.
2. It does not affect the `wgmma::fence` which is inserted in another part of this pass
3. It does not predicate the fence based on predicates of the consumers and even if it did, we do not use `expr->predicate()` for TMA stores yet.