### PR TITLE
Backpropagate shardings to already sharded tvs

### DIFF
--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -119,29 +119,26 @@ DeviceIdxType DeviceMesh::maxDeviceId() const {
   return *std::max_element(vector_.begin(), vector_.end());
 }
 
-namespace {
-// Maps a parallel type to axis. Returns -1 if the parallel type is
-// not in the device mesh.
-int64_t ptypeToAxis(ParallelType ptype, int64_t ndims) {
+int64_t DeviceMesh::parallelTypeToAxis(ParallelType parallel_type) const {
   NVF_ERROR(
-      isParallelTypeDeviceDim(ptype),
+      isParallelTypeDeviceDim(parallel_type),
       "Attempting to index into DeviceMesh with a non-device parallel type",
-      ptype);
-  int64_t offset =
-      static_cast<int64_t>(ptype) - static_cast<int64_t>(ParallelType::DIDx);
+      parallel_type);
+  int64_t offset = static_cast<int64_t>(parallel_type) -
+      static_cast<int64_t>(ParallelType::DIDx);
+  int64_t ndims = rank();
   if (offset > ndims - 1) {
     return -1;
   }
   return ndims - 1 - offset;
 }
-} // namespace
 
 bool DeviceMesh::hasParallelType(ParallelType parallel_type) const {
-  return ptypeToAxis(parallel_type, rank()) != -1;
+  return parallelTypeToAxis(parallel_type) != -1;
 }
 
 int64_t DeviceMesh::size(const ParallelType parallel_type) const {
-  int64_t axis = ptypeToAxis(parallel_type, rank());
+  int64_t axis = parallelTypeToAxis(parallel_type);
   NVF_ERROR(
       axis != -1,
       "DeviceMesh of rank ",
@@ -154,7 +151,7 @@ int64_t DeviceMesh::size(const ParallelType parallel_type) const {
 std::vector<DeviceIdxType> DeviceMesh::getSlice(
     DeviceIdxType deviceId,
     ParallelType ptype) const {
-  int64_t axis = ptypeToAxis(ptype, rank());
+  int64_t axis = parallelTypeToAxis(ptype);
   NVF_ERROR(
       axis != -1,
       "DeviceMesh of rank ",

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -112,7 +112,10 @@ class DeviceMesh final {
   // Returns the max device id in the DeviceMesh.
   DeviceIdxType maxDeviceId() const;
 
-  // Returns a slice of the DeviceMesh accorinding to the device parallel type
+  // Returns true if the DeviceMesh has the specified parallel type
+  bool hasParallelType(ParallelType parallel_type) const;
+
+  // Returns a slice of the DeviceMesh according to the device parallel type
   // that contains the device
   // Ex: [[0 1 2]
   //      [3 4 5]]

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -112,6 +112,10 @@ class DeviceMesh final {
   // Returns the max device id in the DeviceMesh.
   DeviceIdxType maxDeviceId() const;
 
+  // Maps a parallel type to axis. Returns -1 if the parallel type is
+  // not in the device mesh.
+  int64_t parallelTypeToAxis(ParallelType parallel_type) const;
+
   // Returns true if the DeviceMesh has the specified parallel type
   bool hasParallelType(ParallelType parallel_type) const;
 

--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -488,10 +488,6 @@ void PropagateShardingsPass::runPass(Fusion* fusion) {
       sharding_candidates.push_back(tv);
     }
 
-    if (sharding_candidates.empty()) {
-      continue;
-    }
-
     for (TensorView* target : sharding_candidates) {
       std::unordered_set<ParallelType> selected_parallel_types =
           getParallelTypesToPropagate({target});

--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -493,7 +493,7 @@ void PropagateShardingsPass::runPass(Fusion* fusion) {
           getParallelTypesToPropagate({target});
       propagateDIDTransform(
           /*ref=*/ref_output,
-          /*tvs=*/{target},
+          /*tv=*/target,
           selected_parallel_types,
           PropagateDirection::kBackward);
     }

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -407,18 +407,20 @@ TEST_F(ShardingTest, ShardedInnerReshape) {
 TEST_F(ShardingTest, ShardedReshapeWithIndependentSplit) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
-  DeviceMesh mesh({0, 1});
-  int64_t d = mesh.size();
+  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
+  int64_t dx = mesh.size(ParallelType::DIDx);
+  int64_t dy = mesh.size(ParallelType::DIDy);
 
-  TensorView* tv0 = makeContigConcreteTensor({3 * d, 5, 7 * d, 9});
-  TensorView* tv1 = reshape(tv0, {3 * d, 5, 7 * d, 9}, {3 * d * 5, 7 * d * 9});
+  TensorView* tv0 = makeContigConcreteTensor({3 * dx, 5, 7 * dy, 9});
+  TensorView* tv1 =
+      reshape(tv0, {3 * dx, 5, 7 * dy, 9}, {3 * dx * 5, 7 * dy * 9});
   fusion->addInput(tv0);
   fusion->addOutput(tv1);
 
   tv0->setDeviceMesh(mesh);
-  tv0->outer_split(0, d);
+  tv0->outer_split(0, dx);
   tv0->axis(0)->parallelize(ParallelType::DIDx);
-  tv0->outer_split(3, d);
+  tv0->outer_split(3, dy);
   tv0->axis(3)->parallelize(ParallelType::DIDy);
 
   preseg_passes::OptimizationPass<
@@ -431,8 +433,7 @@ TEST_F(ShardingTest, ShardedReshapeWithIndependentSplit) {
 TEST_F(ShardingTest, PropagationDoesNotOverwrite) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
-  DeviceMesh mesh({0, 1});
-  auto d = mesh.size();
+  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -440,11 +441,11 @@ TEST_F(ShardingTest, PropagationDoesNotOverwrite) {
   TensorView* tv3 = add(tv0, tv2);
 
   tv0->setDeviceMesh(mesh);
-  tv0->outer_split(0, d);
+  tv0->outer_split(0, mesh.size(ParallelType::DIDx));
   tv0->axis(0)->parallelize(ParallelType::DIDx);
 
   tv1->setDeviceMesh(mesh);
-  tv1->outer_split(0, d);
+  tv1->outer_split(0, mesh.size(ParallelType::DIDy));
   tv1->axis(0)->parallelize(ParallelType::DIDy);
 
   fusion->addInput(tv0);
@@ -460,6 +461,38 @@ TEST_F(ShardingTest, PropagationDoesNotOverwrite) {
   EXPECT_EQ(getShardedLoopAxis(tv1, ParallelType::DIDy), 0);
   EXPECT_EQ(getShardedLoopAxis(tv2, ParallelType::DIDy), 0);
   EXPECT_EQ(getShardedLoopAxis(tv3, ParallelType::DIDx), 0);
+}
+
+TEST_F(ShardingTest, BackpropagateToShardedTvs) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
+
+  TensorView* tv0 = makeContigTensor(2);
+  TensorView* tv1 = makeContigTensor(2);
+  TensorView* tv2 = set(tv1);
+  TensorView* tv3 = add(tv0, tv2);
+
+  tv0->setDeviceMesh(mesh);
+  tv0->outer_split(0, mesh.size(ParallelType::DIDx));
+  tv0->axis(0)->parallelize(ParallelType::DIDx);
+
+  tv1->setDeviceMesh(mesh);
+  tv1->outer_split(1, mesh.size(ParallelType::DIDy));
+  tv1->axis(1)->parallelize(ParallelType::DIDy);
+
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  fusion->addOutput(tv3);
+
+  preseg_passes::OptimizationPass<
+      preseg_passes::PropagateShardingsPass>::runPass(fusion.get());
+
+  // tv2 should be sharded on DIDx through backpropagation.
+  for (auto* tv : {tv2, tv3}) {
+    EXPECT_EQ(getShardedLogicalAxis(tv, ParallelType::DIDx), 0);
+    EXPECT_EQ(getShardedLogicalAxis(tv, ParallelType::DIDy), 1);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -138,7 +138,7 @@ TEST_F(ShardingTest, ShardedAllocationDomain) {
   TensorView* c = add(a, b);
   TensorView* d = sum(c, {1});
 
-  DeviceMesh mesh = DeviceMesh::createForNumDevices(3);
+  auto mesh = DeviceMesh::createForNumDevices(3);
   for (auto tv : {a, b, c, d}) {
     tv->setDeviceMesh(mesh);
   }
@@ -225,7 +225,7 @@ TEST_F(ShardingTest, MultiDimDeviceMesh) {
   EXPECT_EQ(mesh.getSlice(1, ParallelType::DIDy), slice_didy_12);
   EXPECT_EQ(mesh.getSlice(2, ParallelType::DIDy), slice_didy_12);
 
-  DeviceMesh mesh3d = DeviceMesh::createForShape({2, 3, 4});
+  auto mesh3d = DeviceMesh::createForShape({2, 3, 4});
   std::vector<DeviceIdxType> slice_didz = {6, 18};
   std::vector<DeviceIdxType> slice_didy = {14, 18, 22};
   std::vector<DeviceIdxType> slice_didx = {16, 17, 18, 19};
@@ -407,7 +407,7 @@ TEST_F(ShardingTest, ShardedInnerReshape) {
 TEST_F(ShardingTest, ShardedReshapeWithIndependentSplit) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
-  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
+  auto mesh = DeviceMesh::createForShape({2, 3});
   int64_t dx = mesh.size(ParallelType::DIDx);
   int64_t dy = mesh.size(ParallelType::DIDy);
 
@@ -433,7 +433,7 @@ TEST_F(ShardingTest, ShardedReshapeWithIndependentSplit) {
 TEST_F(ShardingTest, PropagationDoesNotOverwrite) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
-  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
+  auto mesh = DeviceMesh::createForShape({2, 3});
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);
@@ -466,7 +466,7 @@ TEST_F(ShardingTest, PropagationDoesNotOverwrite) {
 TEST_F(ShardingTest, BackpropagateToShardedTvs) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
-  DeviceMesh mesh = DeviceMesh::createForShape({2, 3});
+  auto mesh = DeviceMesh::createForShape({2, 3});
 
   TensorView* tv0 = makeContigTensor(2);
   TensorView* tv1 = makeContigTensor(2);


### PR DESCRIPTION
1. Backpropagates parallel types not already present on a tensorview
2. Extends some functionality of device mesh for DIDy, DIDz.

Issue #4787.