### PR TITLE
Do not attempt to cancel reshape when not all tensors are dominated

### DIFF
--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -406,10 +406,21 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     // The tensors are going to be reordered to align with the largest
     // input. To make it work, merge operations for reshape should be
     // cancelled.
-#if 0
-    scheduler_tools::cancelReshapeInLoopDomains(
-        largest_input, /*skip_innermost_id=*/true);
-#endif
+
+    // Disabled for now to avoid scheduling errors in some HF
+    // models. Up to 10% perf loss is observed with the RoPE
+    // benchmarks. To re-enable the optimization, it probably makes
+    // more sense to first address the issue due to cyclic exact
+    // graphs. That is, scheduleLoopDomainsLike is potentially fairly
+    // powerful but due to cycles, only the update mode is used when
+    // propagating transformations from the reference tensor. This
+    // restriction makes it difficult to use more aggressive
+    // scheduling like setting the loop domain of a reshape output
+    // tensor as its root domain, which is what
+    // cancelReshapeInLoopDomains does.
+    //
+    // scheduler_tools::cancelReshapeInLoopDomains(
+    // largest_input, /*skip_innermost_id=*/true);
   }
 
   // Propagate Resize ops to producer tensors. This is safe as this

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -577,7 +577,7 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   // IDs. When propagating the loop domain of the reference tensor,
   // which has the repeat ID, the full loop domain is propagated only
   // to the tensors that have IDs that are mapped with the repeat
-  // ID. For the rest of the tensros, the repeat ID is dropped and
+  // ID. For the rest of the tensors, the repeat ID is dropped and
   // only the remaining loop domain is propagated.
   if (repeat_id_moved_to_outermost) {
     const auto& [tvs_with_repeat_id, tvs_without_repeat_id] = partitionTvsById(

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -406,8 +406,10 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     // The tensors are going to be reordered to align with the largest
     // input. To make it work, merge operations for reshape should be
     // cancelled.
+#if 0
     scheduler_tools::cancelReshapeInLoopDomains(
         largest_input, /*skip_innermost_id=*/true);
+#endif
   }
 
   // Propagate Resize ops to producer tensors. This is safe as this

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -417,7 +417,8 @@ void ResizeScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     // restriction makes it difficult to use more aggressive
     // scheduling like setting the loop domain of a reshape output
     // tensor as its root domain, which is what
-    // cancelReshapeInLoopDomains does.
+    // cancelReshapeInLoopDomains does. See test_reshape_cancellation
+    // for a repro.
     //
     // scheduler_tools::cancelReshapeInLoopDomains(
     // largest_input, /*skip_innermost_id=*/true);

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -598,29 +598,73 @@ void scheduleLoopDomainsBy(
 
 namespace {
 
-bool isDominatorOfAllTensors(TensorView* tv) {
-  auto all_dep_vals =
-      DependencyCheck::getAllValsBetween({tv}, tv->fusion()->outputs());
+bool enableReshapeCancellation(const std::vector<Expr*>& dep_exprs) {
+  ViewOp* reshape = nullptr;
+  for (const auto& expr : dep_exprs) {
+    if (expr->isA<ViewOp>()) {
+      if (reshape != nullptr) {
+        // Having multiple reshapes is not supported
+        return false;
+      } else {
+        reshape = expr->as<ViewOp>();
+      }
+    }
+  }
+
+  if (reshape == nullptr) {
+    // No reshape to cancel
+    return false;
+  }
+
+  Fusion* fusion = reshape->fusion();
+
+  auto reshape_in = reshape->in();
+  auto reshape_out = reshape->out();
+
+  // After this step, the scheduler assumes all of the
+  // tensors have compatible loop domains as that of the reference
+  // tensor. That should be the case all of the tensors coming after
+  // reshape_out. For any other tensor, one sufficient condition is
+  // if they come before reshape_in.
+
+  auto pre_tensors = DependencyCheck::getAllValsBetween(
+      {fusion->inputs().begin(), fusion->inputs().end()}, {reshape_in});
+
+  auto post_tensors = DependencyCheck::getAllValsBetween(
+      {reshape_out}, {fusion->outputs().begin(), fusion->outputs().end()});
+
   std::unordered_set<TensorView*> all_dep_tvs;
   std::ranges::copy(
-      all_dep_vals | std::views::filter([&](Val* v) {
+      pre_tensors | std::views::filter([&](Val* v) {
+        return v->isA<TensorView>();
+      }) | std::views::transform([](Val* v) { return v->as<TensorView>(); }),
+      std::inserter(all_dep_tvs, all_dep_tvs.end()));
+  std::ranges::copy(
+      post_tensors | std::views::filter([&](Val* v) {
         return v->isA<TensorView>();
       }) | std::views::transform([](Val* v) { return v->as<TensorView>(); }),
       std::inserter(all_dep_tvs, all_dep_tvs.end()));
 
-  auto all_tvs = tv->fusion()->allTvs();
-  std::unordered_set<TensorView*> all_tv_set{all_tvs.begin(), all_tvs.end()};
-  return all_dep_tvs == all_tv_set;
+  if (std::ranges::any_of(fusion->allTvs(), [&](TensorView* tv) {
+        return !all_dep_tvs.contains(tv);
+      })) {
+    return false;
+  }
+
+  return true;
 }
 
 } // namespace
 
 void cancelReshapeInLoopDomains(TensorView* from_tv, bool skip_innermost_id) {
-  if (!isDominatorOfAllTensors(from_tv)) {
+  Fusion* fusion = from_tv->fusion();
+  auto all_dep_exprs_from_tv =
+      DependencyCheck::getAllExprsBetween({from_tv}, fusion->outputs());
+
+  if (!enableReshapeCancellation(all_dep_exprs_from_tv)) {
     return;
   }
 
-  Fusion* fusion = from_tv->fusion();
   IdModel id_model(fusion, /*build_graphs=*/false);
   id_model.buildExactGraph();
   const auto& exact_graph = id_model.idGraph(IdMappingMode::EXACT);
@@ -642,9 +686,6 @@ void cancelReshapeInLoopDomains(TensorView* from_tv, bool skip_innermost_id) {
       reshape_dependent_ids.pushBack(val_g);
     }
   }
-
-  auto all_dep_exprs_from_tv =
-      DependencyCheck::getAllExprsBetween({from_tv}, fusion->outputs());
 
   // Visit all reshapes in a reverse topological order
   for (auto exprs_it = all_dep_exprs_from_tv.rbegin();

--- a/tests/cpp/test_rope.cpp
+++ b/tests/cpp/test_rope.cpp
@@ -1650,6 +1650,7 @@ TEST_P(LitgptRopeTest, Bwd) {
 // Testing the scheduling of an ending repeat pattern, which is
 // commonly seen in RoPE.
 TEST_F(RopeTest, EndingRepeat) {
+  GTEST_SKIP() << "Disabled due to as cancelReshape is disabled";
   auto fusion_ptr = std::make_unique<Fusion>();
   FusionGuard fg(fusion_ptr.get());
   Fusion& fusion = *fusion_ptr;
@@ -1731,6 +1732,8 @@ TEST_F(RopeTest, EndingRepeat) {
 // input tensor. A similar Pattern appears in the LitGPT Llama RoPE
 // module.
 TEST_F(RopeTest, EndingRepeatWithNoBroadcastOp) {
+  GTEST_SKIP() << "Disabled due to as cancelReshape is disabled";
+
   auto fusion_ptr = std::make_unique<Fusion>();
   FusionGuard fg(fusion_ptr.get());
   Fusion& fusion = *fusion_ptr;

--- a/tests/python/test_repro.py
+++ b/tests/python/test_repro.py
@@ -1364,3 +1364,165 @@ class TestRepro(NVFuserTest):
             ),
         ]
         fd.execute(inputs)
+
+    # Repro of https://github.com/NVIDIA/Fuser/pull/4823
+    def test_reshape_cancellation(self):
+        def nvfuser_fusion_id1(fd: FusionDefinition) -> None:
+            T0 = fd.define_tensor(
+                shape=[1, 2048, 24, 32],
+                contiguity=[None, True, True, False],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T1 = fd.define_tensor(
+                shape=[1, 2048, 24, 32],
+                contiguity=[None, True, True, False],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T2 = fd.define_tensor(
+                shape=[1, 2048, 24, 32],
+                contiguity=[None, True, True, False],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T3 = fd.define_tensor(
+                shape=[1, 2048, 4, 4608],
+                contiguity=[None, True, True, True],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T4 = fd.define_tensor(
+                shape=[1, 2048, 24, 32],
+                contiguity=[None, True, True, False],
+                dtype=DataType.BFloat16,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T5 = fd.define_tensor(
+                shape=[1, 2048, 24, 64],
+                contiguity=[None, True, None, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T6 = fd.define_tensor(
+                shape=[1, 2048, 24, 64],
+                contiguity=[None, True, True, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T7 = fd.define_tensor(
+                shape=[1, 2048, 24, 64],
+                contiguity=[None, True, True, True],
+                dtype=DataType.Float,
+                is_cpu=False,
+                stride_order=[3, 2, 1, 0],
+            )
+            T8 = fd.ops.cast(T0, dtype=DataType.Float)
+            T9 = fd.ops.neg(T8)
+            T10 = fd.ops.cast(T9, dtype=DataType.BFloat16)
+            T17 = fd.ops.broadcast_in_dim(
+                T1, shape=[1, 2048, 24, 32, 1], broadcast_dims=[0, 1, 2, 3]
+            )
+            T24 = fd.ops.broadcast_in_dim(
+                T10, shape=[1, 2048, 24, 32, 1], broadcast_dims=[0, 1, 2, 3]
+            )
+            T25 = fd.ops.cast(T2, dtype=DataType.Float)
+            T41 = fd.ops.slice(
+                T3,
+                start_indices=[0, 0, 0, 3072],
+                end_indices=[1, 2048, 4, 4608],
+                strides=[1, 1, 1, 1],
+                manual_normalization=0,
+            )
+            T42 = fd.ops.cat([T24, T17], dim=-1, manual_padding=0)
+            T43 = fd.ops.neg(T25)
+            T50 = fd.ops.reshape(T41, new_shape=[1, 2048, 4, 6, 256])
+            T56 = fd.ops.reshape(T42, new_shape=[1, 2048, 24, 64])
+            T57 = fd.ops.cast(T43, dtype=DataType.BFloat16)
+            T63 = fd.ops.reshape(T50, new_shape=[1, 2048, 24, 256])
+            T64 = fd.ops.cast(T56, dtype=DataType.Float)
+            T71 = fd.ops.broadcast_in_dim(
+                T4, shape=[1, 2048, 24, 32, 1], broadcast_dims=[0, 1, 2, 3]
+            )
+            T78 = fd.ops.broadcast_in_dim(
+                T57, shape=[1, 2048, 24, 32, 1], broadcast_dims=[0, 1, 2, 3]
+            )
+            T94 = fd.ops.slice(
+                T63,
+                start_indices=[0, 0, 0, 64],
+                end_indices=[1, 2048, 24, 256],
+                strides=[1, 1, 1, 1],
+                manual_normalization=0,
+            )
+            T95 = fd.ops.mul(T64, T5)
+            T111 = fd.ops.slice(
+                T3,
+                start_indices=[0, 0, 0, 0],
+                end_indices=[1, 2048, 4, 1536],
+                strides=[1, 1, 1, 1],
+                manual_normalization=0,
+            )
+            T112 = fd.ops.cat([T78, T71], dim=-1, manual_padding=0)
+            T113 = fd.ops.cast(T94, dtype=DataType.Float)
+            T114 = fd.ops.add(T6, T95)
+            T121 = fd.ops.reshape(T111, new_shape=[1, 2048, 4, 6, 256])
+            T127 = fd.ops.reshape(T112, new_shape=[1, 2048, 24, 64])
+            T128 = fd.ops.cat([T114, T113], dim=-1, manual_padding=0)
+            T134 = fd.ops.reshape(T121, new_shape=[1, 2048, 24, 256])
+            T135 = fd.ops.cast(T127, dtype=DataType.Float)
+            T136 = fd.ops.permute(T128, dims=[0, 2, 1, 3])
+            T152 = fd.ops.slice(
+                T134,
+                start_indices=[0, 0, 0, 64],
+                end_indices=[1, 2048, 24, 256],
+                strides=[1, 1, 1, 1],
+                manual_normalization=0,
+            )
+            T153 = fd.ops.mul(T135, T5)
+            T154 = fd.ops.cast(T136, dtype=DataType.BFloat16)
+            T155 = fd.ops.cast(T152, dtype=DataType.Float)
+            T156 = fd.ops.add(T7, T153)
+            T157 = fd.ops.cat([T156, T155], dim=-1, manual_padding=0)
+            T158 = fd.ops.permute(T136, dims=[0, 1, 3, 2])
+            T159 = fd.ops.permute(T157, dims=[0, 2, 1, 3])
+            fd.add_output(T159)
+            fd.add_output(T154)
+            fd.add_output(T158)
+
+        with FusionDefinition() as fd:
+            nvfuser_fusion_id1(fd)
+
+        inputs = [
+            torch.randn(3145727, dtype=torch.bfloat16, device="cuda:0").as_strided(
+                (1, 2048, 24, 32), (3145728, 1536, 64, 2)
+            ),
+            torch.randn(3145727, dtype=torch.bfloat16, device="cuda:0").as_strided(
+                (1, 2048, 24, 32), (3145728, 1536, 64, 2)
+            ),
+            torch.randn(3145727, dtype=torch.bfloat16, device="cuda:0").as_strided(
+                (1, 2048, 24, 32), (3145728, 1536, 64, 2)
+            ),
+            torch.testing.make_tensor(
+                (1, 2048, 4, 4608), dtype=torch.bfloat16, device="cuda:0"
+            ),
+            torch.randn(3145727, dtype=torch.bfloat16, device="cuda:0").as_strided(
+                (1, 2048, 24, 32), (3145728, 1536, 64, 2)
+            ),
+            torch.randn(131072, dtype=torch.float32, device="cuda:0").as_strided(
+                (1, 2048, 24, 64), (131072, 64, 0, 1)
+            ),
+            torch.testing.make_tensor(
+                (1, 2048, 24, 64), dtype=torch.float32, device="cuda:0"
+            ),
+            torch.testing.make_tensor(
+                (1, 2048, 24, 64), dtype=torch.float32, device="cuda:0"
+            ),
+        ]
+        fd.execute(inputs)


### PR DESCRIPTION
I decided to disable the cancellation of reshape in the resize scheduler. It was originally added in #3679. 

It results in about 10% perf regression in the RoPE benchmarks http://nv/eO-.

The optimization should be reenabled but rather than ad-hoc patching, I feel we should investigate fixing the root cause of the issue, which is cycles in the exact graph. Tracking issue: #4839 