### PR TITLE
Host IR LLVM Lowering Integration: `new` node insertion pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/host_ir/pass/convert_op_to_communication.cpp
   ${NVFUSER_SRCS_DIR}/host_ir/pass/stream_parallel_type.cpp
   ${NVFUSER_SRCS_DIR}/host_ir/pass/insert_deallocations.cpp
+  ${NVFUSER_SRCS_DIR}/host_ir/pass/insert_new.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/translate_repeat_to_expand.cpp
   ${NVFUSER_SRCS_DIR}/rng.cpp

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -167,7 +167,8 @@ class Val;
   f(EndCoalescing);                   \
   f(ShareMemHandles);                 \
   f(HirAliasSelect);                  \
-  f(Deallocate);
+  f(Deallocate);                      \
+  f(NewTensor);
 
 // Forward declarations for all Val and Expr types
 

--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -46,6 +46,10 @@ void HostIrContainer::insertExprAfter(int64_t index, Expr* expr) {
   top_level_exprs_.insert(top_level_exprs_.begin() + index + 1, expr);
 }
 
+void HostIrContainer::insertExprBefore(int64_t index, Expr* expr) {
+  top_level_exprs_.insert(top_level_exprs_.begin() + index, expr);
+}
+
 void HostIrContainer::pushBackTopLevelExprs(Expr* expr) {
   assertInContainer(expr, "Cannot add expr, ");
   top_level_exprs_.push_back(expr);

--- a/csrc/host_ir/container.h
+++ b/csrc/host_ir/container.h
@@ -47,6 +47,8 @@ class HostIrContainer final : public Fusion {
 
   void pushBackTopLevelExprs(Expr* expr);
 
+  void insertExprBefore(int64_t index, Expr* expr);
+
   void insertExprAfter(int64_t index, Expr* expr);
 
   void addKernelExecutor(std::unique_ptr<KernelExecutor> ke);

--- a/csrc/host_ir/executor.cpp
+++ b/csrc/host_ir/executor.cpp
@@ -847,6 +847,16 @@ void HostIrEvaluator::handle(Deallocate* deallocate) {
   expr_evaluator_.invalidate(tv);
 }
 
+void HostIrEvaluator::handle(NewTensor* new_tensor) {
+  auto* tv = new_tensor->buffer();
+  NVF_ERROR(
+      !expr_evaluator_.isKnown(tv),
+      "Tried to create a new tensor wrapper that is already created",
+      tv);
+  at::Tensor tensor = at::Tensor();
+  expr_evaluator_.bind(tv, tensor);
+}
+
 void HostIrEvaluator::unhandled(Statement* stmt) {
   NVF_ERROR(stmt->isA<Expr>(), stmt, " must be an Expr");
   auto* expr = stmt->as<Expr>();

--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -144,6 +144,7 @@ class HostIrEvaluator final : public OptOutDispatch {
   void handle(ShareMemHandles* share_mem_handles) override;
   void handle(HirAliasSelect* hir_alias_select) override;
   void handle(Deallocate* deallocate) override;
+  void handle(NewTensor* new_tensor) override;
   void unhandled(Statement* stmt) override;
 
   c10::cuda::CUDAStream getCUDAStream(Stream* stream);

--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -424,6 +424,30 @@ std::string HirAliasSelect::toInlineString(int indent_size) const {
   NVF_THROW("Cannot be printed inline");
 }
 
+NewTensor::NewTensor(IrBuilderPasskey passkey, TensorView* tv)
+    : Expr(passkey) {
+  addAttribute(tv);
+}
+
+NVFUSER_DEFINE_CLONE_AND_CREATE(NewTensor)
+
+TensorView* NewTensor::buffer() const {
+  return attributes_.at(0)->as<TensorView>();
+}
+
+std::string NewTensor::toString(int indent_size) const {
+  std::stringstream ss;
+  indent(ss, indent_size) << "NewTensor {" << std::endl;
+  ss << buffer()->toString(indent_size + 1) << std::endl;
+  indent(ss, indent_size) << "}" << std::endl;
+  return ss.str();
+}
+
+std::string NewTensor::toInlineString(int indent_size) const {
+  return std::string("NewTensor ") + buffer()->toInlineString();
+}
+
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -417,6 +417,27 @@ class HirAliasSelect : public Expr {
   }
 };
 
+class NewTensor : public Expr {
+  public:
+   using Expr::Expr;
+   NewTensor(IrBuilderPasskey passkey, TensorView* tv);
+ 
+   NewTensor(const NewTensor& other) = delete;
+   NewTensor& operator=(const NewTensor& other) = delete;
+   NewTensor(NewTensor&& other) = delete;
+   NewTensor& operator=(NewTensor&& other) = delete;
+ 
+   NVFUSER_DECLARE_CLONE_AND_CREATE
+ 
+   std::string toString(int indent_size = 0) const override;
+   std::string toInlineString(int indent_size = 0) const override;
+   const char* getOpString() const override {
+     return "hir::NewTensor";
+   }
+ 
+   TensorView* buffer() const;
+ };
+
 } // namespace hir
 
 } // namespace nvfuser

--- a/csrc/host_ir/pass/insert_new.cpp
+++ b/csrc/host_ir/pass/insert_new.cpp
@@ -1,0 +1,54 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <host_ir/pass/insert_new.h>
+
+namespace nvfuser::hir_pass {
+
+void InsertNewTensor::passImplementation(Fusion* fusion) {
+  FusionGuard fg(fusion);
+  hir::HostIrContainer* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
+  NVF_CHECK(hic, "Expected HostIrContainer");
+  std::unordered_set<TensorView*> allocated_tensors;
+
+  const std::vector<Expr*>& top_level_exprs = hic->topLevelExprs();
+  std::for_each(top_level_exprs.begin(), top_level_exprs.end(), [](Expr* expr) {
+    NVF_ERROR(
+        !expr->isA<hir::NewTensor>(),
+        "Expected hostir container to not have new tensor, but found one "
+        "anyways");
+  });
+
+  std::vector<std::pair<int64_t, TensorView*>> tensors_to_allocate;
+  for (auto&& [i, expr] : enumerate(top_level_exprs)) {
+    if (auto* allocated_tensor = dynamic_cast<kir::Allocate*>(expr)) {
+       allocated_tensors.insert(allocated_tensor->buffer());
+    }
+    else if (BinaryOp* binary_op = dynamic_cast<BinaryOp*>(expr)) {
+      for (auto* output : binary_op->outputs()) {
+        if (output->isA<TensorView>()) {
+          auto* tv = output->as<TensorView>();
+          if (!allocated_tensors.contains(tv)) {
+            tensors_to_allocate.emplace_back(i, tv);
+            allocated_tensors.insert(tv);
+          }
+        }
+      }
+    }
+  }
+
+  std::sort(tensors_to_allocate.begin(), tensors_to_allocate.end(), 
+            std::greater<std::pair<int64_t, TensorView*>>());
+
+  for (auto&& [i, tv] : tensors_to_allocate) {
+    auto* new_tensor = IrBuilder::create<hir::NewTensor>(tv);
+    hic->insertExprBefore(i, new_tensor);
+  }
+}
+
+} // namespace nvfuser::hir_pass

--- a/csrc/host_ir/pass/insert_new.cpp
+++ b/csrc/host_ir/pass/insert_new.cpp
@@ -27,7 +27,7 @@ void InsertNewTensor::passImplementation(Fusion* fusion) {
   std::vector<std::pair<int64_t, TensorView*>> tensors_to_allocate;
   for (auto&& [i, expr] : enumerate(top_level_exprs)) {
     if (auto* allocated_tensor = dynamic_cast<kir::Allocate*>(expr)) {
-       allocated_tensors.insert(allocated_tensor->buffer());
+       allocated_tensors.insert(allocated_tensor->buffer()->as<TensorView>());
     }
     else if (BinaryOp* binary_op = dynamic_cast<BinaryOp*>(expr)) {
       for (auto* output : binary_op->outputs()) {

--- a/csrc/host_ir/pass/insert_new.h
+++ b/csrc/host_ir/pass/insert_new.h
@@ -1,0 +1,27 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <host_ir/container.h>
+#include <host_ir/pass/optimization_pass.h>
+
+namespace nvfuser::hir_pass {
+
+/* For each input in every expression in the container, find the index of its
+ * last use and insert a new tensor directly after */
+class InsertNewTensor : public OptimizationPass<InsertNewTensor> {
+  friend class OptimizationPass<InsertNewTensor>;
+
+ protected:
+  void passImplementation(Fusion* fusion);
+  static constexpr std::string_view name() {
+    return "InsertNewTensor";
+  }
+};
+
+} // namespace nvfuser::hir_pass

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -13,6 +13,7 @@
 #include <host_ir/lower_to_communication.h>
 #include <host_ir/pass/convert_op_to_communication.h>
 #include <host_ir/pass/insert_deallocations.h>
+#include <host_ir/pass/insert_new.h>
 #include <instrumentation.h>
 #include <ir/base_nodes.h>
 #include <multidevice/communication.h>
@@ -559,6 +560,7 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
       hic->addOutput(ir_cloner.clone(out));
     }
 
+    hir_pass::InsertNewTensor().runPass(hic.get());
     hir_pass::InsertDeallocations().runPass(hic.get());
 
     hie_ = std::make_unique<hir::HostIrEvaluator>(


### PR DESCRIPTION
This PR targets to:
1. Create `newTensor` op in host ir
2. Add a pass to insert `newTensor` op before any ops with in wrapper output tensor allocation 