### PR TITLE
Check input IDs in ReductionScheduler::canScheduleCompileTime

### DIFF
--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -1687,7 +1687,7 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
   // this needs to be changed. see issue
   // https://github.com/NVIDIA/Fuser/issues/3811
   scheduler_tools::DomainMap domain_map(fusion);
-  if (!domain_map.isValidReference(reduction_tvs[0], /*check_inputs=*/false)) {
+  if (!domain_map.isValidReference(reduction_tvs[0], /*check_inputs=*/true)) {
     scheduler_debug_utils::canScheduleRejectReason(
         schedulerType(),
         "Output contains ID that's not scheduled by reference tv.");


### PR DESCRIPTION
This simply checks inputs when doing the `DomainMap` check on the reference tensor, which will disqualify some reference tensors.

Fixes #4840

cc @jjsjann123 who originally wrote this. Was there an important reason to not check inputs in this call?