### PR TITLE
Fix clang-19 compiler detection issues in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           tools/apt-install-things.sh &
           tools/pip-install-things.sh &
-          source tools/setup-env.sh
           wait
+          source tools/setup-env.sh
           cd python
           python setup.py build --no-cutlass --cpp=23
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           tools/apt-install-things.sh &
           tools/pip-install-things.sh &
+          wait
           source tools/setup-env.sh
 
           # Install lintrunner
@@ -48,8 +49,6 @@ jobs:
 
           # Initialize lintrunner
           lintrunner init 2> /dev/null
-
-          wait
 
           # Go to python folder to build cmake files
           cd python

--- a/tools/apt-install-things.sh
+++ b/tools/apt-install-things.sh
@@ -15,6 +15,19 @@ sudo apt-get -y remove gcc-13 libstdc++-13-dev gcc-12 libstdc++-12-dev
 # Install the latest version of clang and gcc.
 sudo apt-get -y install --reinstall clang-19 gcc-14 nlohmann-json3-dev ninja-build
 
+# Ensure clang-19 and clang++-19 are available and properly linked
+# Create symlinks if they don't exist to handle runner environment variations
+if [ ! -x "/usr/bin/clang-19" ] && [ -x "/usr/bin/clang" ]; then
+    sudo ln -sf /usr/bin/clang /usr/bin/clang-19
+    sudo ln -sf /usr/bin/clang++ /usr/bin/clang++-19
+fi
+
+# Verify clang-19 installation
+if ! command -v clang-19 >/dev/null 2>&1; then
+    echo "Warning: clang-19 not found in PATH after installation"
+    ls -la /usr/bin/clang* || true
+fi
+
 # Install minimal cuda toolkit.
 sudo apt-get -y install cuda-compiler-12-8 cuda-command-line-tools-12-8 cuda-libraries-dev-12-8 libnccl-dev
 

--- a/tools/setup-env.sh
+++ b/tools/setup-env.sh
@@ -4,5 +4,19 @@ export CUDACXX=/usr/local/cuda/bin/nvcc
 export PATH=/usr/local/cuda/bin:${PATH}
 export CUDA_INSTALL_PATH=/usr/local/cuda
 export CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
-export CC=clang-19
-export CXX=clang++-19
+
+# Use absolute paths for clang compilers to avoid PATH issues
+# Try common locations where clang-19 might be installed
+if [ -x "/usr/bin/clang-19" ]; then
+    export CC=/usr/bin/clang-19
+    export CXX=/usr/bin/clang++-19
+elif [ -x "/usr/local/bin/clang-19" ]; then
+    export CC=/usr/local/bin/clang-19
+    export CXX=/usr/local/bin/clang++-19
+elif command -v clang-19 >/dev/null 2>&1; then
+    export CC=$(command -v clang-19)
+    export CXX=$(command -v clang++-19)
+else
+    echo "Error: clang-19 not found. Please ensure clang-19 is installed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Fixes clang build failures in GitHub Actions that started appearing since last night
- Addresses CMake errors: "Could not find compiler set in environment variable CC: clang-19"
- Makes compiler detection more robust against runner environment changes

## Root Cause
GitHub Actions Ubuntu 24.04 runners appear to have changed how clang-19 is installed or symlinked, causing CMake to fail when looking for compilers specified by relative names in environment variables.

## Changes Made

### `tools/setup-env.sh`
- Use absolute paths for `CC` and `CXX` environment variables instead of relative names
- Add fallback logic to check common installation locations (`/usr/bin`, `/usr/local/bin`)  
- Use `command -v` as final fallback to find clang-19 in PATH
- Add error handling with informative messages if clang-19 cannot be found

### `tools/apt-install-things.sh`
- Add verification that clang-19 is properly installed after apt-get
- Create symlinks as fallback if the expected binaries don't exist
- Add debugging output to help diagnose future issues

## Test Plan
- [x] Test that the scripts handle existing installations correctly
- [x] Verify error handling when clang-19 is not found
- [ ] Run CI to verify the fix works in GitHub Actions environment
- [ ] Verify both clang-tidy and clang-build jobs pass

## Fixes
- Resolves CMake configuration failures in clang-build-* CI jobs
- Should also help with clang-tidy detection issues

🤖 Generated with [Claude Code](https://claude.ai/code)