### PR TITLE
Simplify topological sorting in `ExprSegmentationSorter::resetLevels`.

### DIFF
--- a/benchmarks/python/host/test_many_pointwise_ops_host.py
+++ b/benchmarks/python/host/test_many_pointwise_ops_host.py
@@ -30,7 +30,7 @@ def pointwise_ops_fusion(fd: FusionDefinition, dtype: DataType, num_iters: int):
 
 
 # NOTE: num_iters restricted due to issue #1234.
-@pytest.mark.parametrize("num_iters", [2, 4, 8, 16])
+@pytest.mark.parametrize("num_iters", [2, 8, 32, 128])
 @pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
 def test_pointwise_ops_benchmark(
     benchmark,


### PR DESCRIPTION
Closes #1234.
Benchmark results for compile (first-time) host latency for `test_many_pointwise_ops.py` benchmark.

Before:
```
Name (time in ms)                                                                Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]        173.8155 (1.0)        173.8224 (1.0)        173.8190 (1.0)       0.0049 (1.0)        173.8190 (1.0)       0.0069 (1.0)           0;0  5.7531 (1.0)           2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]        240.5683 (1.38)       255.9930 (1.47)       248.2806 (1.43)     10.9070 (>1000.0)    248.2806 (1.43)     15.4248 (>1000.0)       0;0  4.0277 (0.70)          2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]        386.3396 (2.22)       410.7824 (2.36)       398.5610 (2.29)     17.2837 (>1000.0)    398.5610 (2.29)     24.4428 (>1000.0)       0;0  2.5090 (0.44)          2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]     1,225.5503 (7.05)     1,234.8559 (7.10)     1,230.2031 (7.08)      6.5801 (>1000.0)  1,230.2031 (7.08)      9.3056 (>1000.0)       0;0  0.8129 (0.14)          2           1

```
With this PR:
```
Name (time in ms)                                                                Min                   Max                  Mean             StdDev                Median                IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=2]         170.7435 (1.0)        171.0568 (1.0)        170.9001 (1.0)       0.2215 (1.0)        170.9001 (1.0)       0.3133 (1.0)           0;0  5.8514 (1.0)           2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=4]         247.9076 (1.45)       251.9501 (1.47)       249.9288 (1.46)      2.8584 (12.90)      249.9288 (1.46)      4.0424 (12.90)         0;0  4.0011 (0.68)          2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=8]         372.1686 (2.18)       383.2379 (2.24)       377.7033 (2.21)      7.8272 (35.33)      377.7033 (2.21)     11.0693 (35.33)         0;0  2.6476 (0.45)          2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=16]        657.3172 (3.85)       664.2111 (3.88)       660.7641 (3.87)      4.8747 (22.00)      660.7641 (3.87)      6.8939 (22.00)         0;0  1.5134 (0.26)          2           1
```

The changes allow us to execute larger iterations such as 32, 64, 128 .. which would previously cause OOM. 32 iterations was projected to take ~30 min.

```
-------------------------------------------------------------------------------------------------------- benchmark: 3 tests --------------------------------------------------------------------------------------------------------
Name (time in s)                                                             Min               Max              Mean            StdDev            Median               IQR            Outliers     OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=32]      1.3191 (1.0)      1.3218 (1.0)      1.3204 (1.0)      0.0019 (48.57)    1.3204 (1.0)      0.0027 (48.57)         0;0  0.7573 (1.0)           2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=64]      2.9338 (2.22)     2.9515 (2.23)     2.9426 (2.23)     0.0125 (317.62)   2.9426 (2.23)     0.0177 (317.62)        0;0  0.3398 (0.45)          2           1
test_pointwise_ops_benchmark[host_bench_mode='compile'-num_iters=128]     7.3684 (5.59)     7.3685 (5.57)     7.3685 (5.58)     0.0000 (1.0)      7.3685 (5.58)     0.0001 (1.0)           0;0  0.1357 (0.18)          2           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```