### PR TITLE
Fix Host IR Insert_deallocation

### DIFF
--- a/csrc/host_ir/pass/insert_deallocations.cpp
+++ b/csrc/host_ir/pass/insert_deallocations.cpp
@@ -32,6 +32,11 @@ void InsertDeallocations::passImplementation(Fusion* fusion) {
       last_use[tv] = i;
     }
   }
+  
+  // Remove outputs from last_use, they should not be deallocated
+  for (auto* out : ir_utils::filterByType<TensorView>(hic->outputs())) {
+    last_use.erase(out);
+  }
 
   std::vector<std::pair<int64_t, TensorView*>> last_use_by_index;
   last_use_by_index.reserve(last_use.size());


### PR DESCRIPTION
This PR targets to fix:
```
  TensorView* t0 = add(in, in);
  TensorView* t1 = matmul(t0, t0);
  fusion->addOutput(t0);
  fusion->addOutput(t1);
```

current insert_deallocation pass treats t0 as an intermediate tensor, and t0 will be deallocated, causing invalid output.