### PR TITLE
Change the underlying storage of DeviceMesh to Tensor

### DIFF
--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -59,13 +59,13 @@ void lowerToScatter(
       receiver_mesh);
 
   // Find a common device between input and receiver meshes to be the root
+  std::vector<DeviceIdxType> input_devices = input_tv->getDeviceMesh().vector();
   auto it = std::ranges::find_if(
-      input_tv->getDeviceMesh().vector(),
-      [&receiver_mesh](DeviceIdxType device) {
+      input_devices, [&receiver_mesh](DeviceIdxType device) {
         return receiver_mesh.has(device);
       });
   NVF_ERROR(
-      it != input_tv->getDeviceMesh().vector().end(),
+      it != input_devices.end(),
       "No common device found between input and receiver meshes");
   DeviceIdxType root = *it;
 

--- a/csrc/multidevice/device_mesh.cpp
+++ b/csrc/multidevice/device_mesh.cpp
@@ -34,6 +34,13 @@ DeviceMesh::DeviceMesh(std::initializer_list<DeviceIdxType> devices) {
   validate();
 }
 
+DeviceMesh::DeviceMesh(
+    const std::vector<int64_t>& devices,
+    const std::vector<int64_t>& shape) {
+  devices_ = at::tensor(devices).view(shape);
+  validate();
+}
+
 void DeviceMesh::validate() const {
   NVF_ERROR_EQ(devices_.dtype(), at::kLong);
   NVF_ERROR_EQ(

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -38,6 +38,10 @@ class DeviceMesh final {
   DeviceMesh();
   explicit DeviceMesh(at::Tensor devices);
   DeviceMesh(std::initializer_list<DeviceIdxType> devices);
+  DeviceMesh(
+      const std::vector<int64_t>& devices,
+      const std::vector<int64_t>& shape);
+
   DeviceMesh(const DeviceMesh&) = default;
   DeviceMesh(DeviceMesh&&) = default;
   DeviceMesh& operator=(const DeviceMesh&) = default;

--- a/csrc/multidevice/device_mesh.h
+++ b/csrc/multidevice/device_mesh.h
@@ -88,7 +88,9 @@ class DeviceMesh final {
   int64_t idxOf(const DeviceIdxType device) const;
 
   // Returns the indices of a multi-dimensional mesh, or an empty vector
-  // if device is not present
+  // if device is not present.
+  //
+  // TODO(wujingyue): return a 1D tensor instead.
   std::vector<int64_t> getIndices(const DeviceIdxType device) const;
 
   // Returns the device at a particular index in the mesh
@@ -127,7 +129,10 @@ class DeviceMesh final {
   //      [3 4 5]]
   // getSlice(4, ParallelType::DIDx) = {3, 4, 5}
   // getSlice(4, ParallelType::DIDy) = {1, 4}
-  // TODO: these might be worth caching per TV
+  //
+  // These might be worth caching per TV.
+  //
+  // TODO(wujingyue): return a 1D tensor instead.
   std::vector<DeviceIdxType> getSlice(DeviceIdxType device, ParallelType ptype)
       const;
 

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -665,8 +665,8 @@ std::set<DeviceIdxType> involvedDevices(Expr* expr) {
         ir_utils::filterByType<TensorView>(expr->outputs())}) {
     for (auto* tv : tvs) {
       if (tv->hasDeviceMesh()) {
-        auto& mesh = tv->getDeviceMesh().vector();
-        std::copy(mesh.begin(), mesh.end(), std::inserter(ret, ret.end()));
+        const auto& mesh = tv->getDeviceMesh().vector();
+        ret.insert(mesh.begin(), mesh.end());
       } else {
         ret.insert(0);
       }

--- a/python/python_direct/multidevice.cpp
+++ b/python/python_direct/multidevice.cpp
@@ -73,7 +73,7 @@ void bindDeviceMesh(py::module& nvfuser) {
   py::class_<DeviceMesh>(nvfuser, "DeviceMesh", py::module_local())
       .def(
           py::init([](const std::vector<int64_t>& devices) {
-            return new DeviceMesh(devices);
+            return new DeviceMesh(at::tensor(devices));
           }),
           py::arg("devices"),
           R"(

--- a/python/python_frontend/multidevice_bindings.cpp
+++ b/python/python_frontend/multidevice_bindings.cpp
@@ -52,7 +52,9 @@ void bindCommunicator(py::module& nvfuser) {
 
 void bindDeviceMesh(py::module& nvfuser) {
   py::class_<DeviceMesh> device_mesh(nvfuser, "DeviceMesh", py::module_local());
-  device_mesh.def(py::init<at::Tensor>());
+  device_mesh.def(py::init([](const std::vector<int64_t>& devices) {
+    return new DeviceMesh(at::tensor(devices));
+  }));
   device_mesh.def("__repr__", [](const DeviceMesh& self) {
     std::stringstream ss;
     ss << self;

--- a/python/python_frontend/multidevice_bindings.cpp
+++ b/python/python_frontend/multidevice_bindings.cpp
@@ -52,7 +52,7 @@ void bindCommunicator(py::module& nvfuser) {
 
 void bindDeviceMesh(py::module& nvfuser) {
   py::class_<DeviceMesh> device_mesh(nvfuser, "DeviceMesh", py::module_local());
-  device_mesh.def(py::init<std::vector<int64_t>>());
+  device_mesh.def(py::init<at::Tensor>());
   device_mesh.def("__repr__", [](const DeviceMesh& self) {
     std::stringstream ss;
     ss << self;

--- a/tests/cpp/test_multidevice_host_ir_overlap.cpp
+++ b/tests/cpp/test_multidevice_host_ir_overlap.cpp
@@ -345,7 +345,7 @@ TEST_F(
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point
-  DeviceMesh full_mesh(all_devices_);
+  DeviceMesh full_mesh(at::tensor(all_devices_));
   tvc_j->setDeviceMesh(full_mesh);
   tvc_locally_reduced_j->setDeviceMesh(full_mesh);
 
@@ -838,7 +838,7 @@ TEST_F(AllgatherOverlapTest, AllgatherBasedPipeliningHostIrImplementation) {
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point
-  DeviceMesh full_mesh(all_devices_);
+  DeviceMesh full_mesh(at::tensor(all_devices_));
   tva_allgathered_j->setDeviceMesh(full_mesh);
   tva_j_unsqueezed->setDeviceMesh(full_mesh);
 
@@ -1172,7 +1172,7 @@ TEST_F(
 
   // Setting the DeviceMesh of the communication's I/O is artificial but
   // required at this point
-  DeviceMesh full_mesh(all_devices_);
+  DeviceMesh full_mesh(at::tensor(all_devices_));
   tva_j_curr_slice->setDeviceMesh(full_mesh);
   tva_j_next_slice->setDeviceMesh(full_mesh);
 

--- a/tests/cpp/test_multidevice_tutorial.cpp
+++ b/tests/cpp/test_multidevice_tutorial.cpp
@@ -900,12 +900,7 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
   // Before defining the communication (reduce-scatter) that produces tvd from
   // tvc, it is required to set tvd and tvc device mesh (this might be removed
   // in the future)
-  std::vector<int64_t> all_devices(communicator_->size());
-  std::iota(
-      all_devices.begin(),
-      all_devices.end(),
-      0); // all_devices = [0,1,..., communicator_->size()-1]
-  DeviceMesh mesh_full(all_devices);
+  auto mesh_full = DeviceMesh::createForNumDevices(communicator_->size());
   tvc->setDeviceMesh(mesh_full);
   tvd->setDeviceMesh(mesh_full);
 
@@ -913,7 +908,7 @@ TEST_F(MultiDeviceTutorial, HostIrGemmReduceScatter) {
       CommunicationType::ReduceScatter,
       /*out=*/tvd,
       /*in=*/tvc,
-      /*team=*/all_devices,
+      /*team=*/mesh_full.vector(),
       /*(unused)root=*/-1,
       RedOpType::SUM);
 

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -208,10 +208,8 @@ TEST_P(ShardingTest, ComputeIndex) {
 }
 
 TEST_F(ShardingTest, MultiDimDeviceMesh) {
-  DeviceMesh mesh(
-      at::tensor({3, 4, 1, 0, 8, 2}, at::dtype(at::kLong)).view({2, 3}));
-  EXPECT_ANY_THROW(
-      DeviceMesh(at::tensor({1, 2, 0, 2}, at::dtype(at::kLong)).view({2, 2})));
+  DeviceMesh mesh({3, 4, 1, 0, 8, 2}, {2, 3});
+  EXPECT_ANY_THROW(DeviceMesh({1, 2, 0, 2}, {2, 2}));
 
   std::vector<int64_t> local_indices_8 = {1, 1};
   std::vector<int64_t> local_indices_1 = {0, 2};

--- a/tests/cpp/test_sharding.cpp
+++ b/tests/cpp/test_sharding.cpp
@@ -208,11 +208,10 @@ TEST_P(ShardingTest, ComputeIndex) {
 }
 
 TEST_F(ShardingTest, MultiDimDeviceMesh) {
-  DeviceMesh mesh({3, 4, 1, 0, 8, 2}, {2, 3});
-  // Shape not consistent with number of devices
-  EXPECT_ANY_THROW(DeviceMesh({1, 2}, {2, 3}));
-  // Duplicates in DeviceMesh
-  EXPECT_ANY_THROW(DeviceMesh({1, 2, 0, 2}, {2, 3}));
+  DeviceMesh mesh(
+      at::tensor({3, 4, 1, 0, 8, 2}, at::dtype(at::kLong)).view({2, 3}));
+  EXPECT_ANY_THROW(
+      DeviceMesh(at::tensor({1, 2, 0, 2}, at::dtype(at::kLong)).view({2, 2})));
 
   std::vector<int64_t> local_indices_8 = {1, 1};
   std::vector<int64_t> local_indices_1 = {0, 2};


### PR DESCRIPTION
The benefits are:
1. We don't have to implement existing at::Tensor APIs, e.g., DeviceMesh::getSlice. 
2. `dist.DeviceMesh.mesh` is a torch.Tensor, which will seamlessly connect to `DeviceMesh::devices_`. This will lead to a better UX for the Thunder/DTensor integration.
3. Memory saving. at::Tensor contains a shared pointer of TensorImpl. Therefore, `DeviceMesh`es of the same content will more likely reuse the same storage. 

cc @kshitij12345