### PR TITLE
Add scaled_mm and grouped_mm operations to direct bindings

### DIFF
--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -1831,6 +1831,242 @@ TensorView
     The result of the affine linear transformation.
 )",
       py::return_value_policy::reference);
+  ops.def(
+      "grouped_mm",
+      [](TensorView* mat1,
+         TensorView* mat2,
+         TensorView* offsets) -> TensorView* {
+        // Calculate output dimensions based on mat1 & mat2 rank
+        ScaledTensorView scaled_out = grouped_mm(mat1, mat2, offsets);
+        return scaled_out.tv;
+      },
+      py::arg("mat1"),
+      py::arg("mat2"),
+      py::arg("offsets"),
+      R"(
+Grouped matrix multiplication.
+
+Performs matrix multiplication on grouped sets of matrices using offsets
+to define variable-sized groups.
+
+Parameters
+----------
+mat1 : TensorView
+    First set of matrices
+mat2 : TensorView
+    Second set of matrices
+offsets : TensorView
+    Offsets tensor defining group boundaries
+
+Returns
+-------
+TensorView
+    Result of grouped matrix multiplication
+)",
+      py::return_value_policy::reference);
+  ops.def(
+      "grouped_mm",
+      [](TensorView* mat1,
+         TensorView* mat2,
+         TensorView* offsets,
+         TensorView* scale1,
+         TensorView* scale2,
+         TensorView* alpha,
+         TensorView* bias,
+         TensorView* beta,
+         PrimDataType dtype,
+         int64_t output_block_scale_size,
+         PrimDataType output_block_scale_dtype,
+         bool output_gamma)
+          -> std::tuple<
+              TensorView*,
+              std::optional<TensorView*>,
+              std::optional<TensorView*>> {
+        auto [output, block_scaling_factor, global_scaling_factor] = grouped_mm(
+            mat1,
+            mat2,
+            offsets,
+            scale1,
+            scale2,
+            alpha,
+            bias,
+            beta,
+            dtype,
+            output_block_scale_size,
+            output_block_scale_dtype,
+            output_gamma);
+
+        if (output_gamma) {
+          NVF_CHECK(
+              output_block_scale_size > 0,
+              "output_block_scale_size must be greater than 0 when "
+              "output_gamma is true");
+          return std::make_tuple(
+              output, block_scaling_factor, global_scaling_factor);
+        } else if (output_block_scale_size > 0) {
+          return std::make_tuple(output, block_scaling_factor, std::nullopt);
+        }
+        return std::make_tuple(output, std::nullopt, std::nullopt);
+      },
+      py::arg("mat1"),
+      py::arg("mat2"),
+      py::arg("offsets"),
+      py::arg("scale1"),
+      py::arg("scale2"),
+      py::arg("alpha").none(true) = py::none(),
+      py::arg("bias").none(true) = py::none(),
+      py::arg("beta").none(true) = py::none(),
+      py::arg("dtype") = DataType::BFloat16,
+      py::arg("output_block_scale_size") = 0,
+      py::arg("output_block_scale_dtype") = DataType::BFloat16,
+      py::arg("output_gamma") = false,
+      R"(
+Scaled Grouped matrix multiplication.
+
+Performs matrix multiplication on grouped sets of matrices using offsets
+to define variable-sized groups.
+
+The math operation is roughly two steps:
+    out = alpha * grouped_mm(dequant(mat1, scale1), dequant(mat2, scale2), offsets) + beta * bias
+
+    (out_mat, out_scale, out_gamma) = Quantization(
+        out,
+        dtype,
+        output_block_scale_size,
+        output_block_scale_dtype,
+        output_gamma)
+
+Note 1: The post quantization only applies when output_block_scale_size > 0,
+        which would produce out_scale tensor. Otherwise, None will be returned;
+Note 2: When output_gamma is set to True, it should produce global scaling factor out_gamma tensor.
+        Otherwise, None will be returned.
+
+Parameters
+----------
+mat1 : TensorView
+    First set of matrices
+mat2 : TensorView
+    Second set of matrices
+offsets : TensorView
+    Offsets tensor defining group boundaries
+scale1 : TensorView
+    Scale tensor for mat1
+scale2 : TensorView
+    Scale tensor for mat2
+alpha : TensorView, optional
+    Alpha tensor
+bias : TensorView, optional
+    Bias tensor
+beta : TensorView, optional
+    Beta tensor
+dtype : PrimDataType, optional
+    Output tensor type [default: DataType::BFloat16]
+output_block_scale_size : int, optional
+    Output block scale size
+output_block_scale_dtype : PrimDataType, optional
+    Output block scale dtype
+output_gamma : bool, optional
+    Output gamma [default: False]
+
+Returns
+-------
+tuple
+    A tuple containing the result of matrix multiplication, output block scale tensor, and output gamma tensor.
+)",
+      py::return_value_policy::reference);
+  ops.def(
+      "scaled_mm",
+      [](TensorView* mat1,
+         TensorView* mat2,
+         TensorView* scale1,
+         TensorView* scale2,
+         TensorView* alpha,
+         TensorView* bias,
+         TensorView* beta,
+         PrimDataType dtype,
+         int64_t output_block_scale_size,
+         PrimDataType output_block_scale_dtype,
+         bool output_gamma)
+          -> std::tuple<
+              TensorView*,
+              std::optional<TensorView*>,
+              std::optional<TensorView*>> {
+        /* Per https://pytorch.org/docs/stable/generated/torch.matmul.html */
+        auto [output, block_scaling_factor, global_scaling_factor] = scaled_mm(
+            mat1,
+            mat2,
+            scale1,
+            scale2,
+            alpha,
+            bias,
+            beta,
+            dtype,
+            output_block_scale_size,
+            output_block_scale_dtype,
+            output_gamma);
+
+        if (output_gamma) {
+          NVF_CHECK(
+              output_block_scale_size > 0,
+              "output_block_scale_size must be greater than 0 when "
+              "output_gamma is true");
+          return std::make_tuple(
+              output, block_scaling_factor, global_scaling_factor);
+        } else if (output_block_scale_size > 0) {
+          return std::make_tuple(output, block_scaling_factor, std::nullopt);
+        }
+        return std::make_tuple(output, std::nullopt, std::nullopt);
+      },
+      py::arg("mat1"),
+      py::arg("mat2"),
+      py::arg("scale1"),
+      py::arg("scale2"),
+      py::arg("alpha").none(true) = py::none(),
+      py::arg("bias").none(true) = py::none(),
+      py::arg("beta").none(true) = py::none(),
+      py::arg("dtype") = DataType::BFloat16,
+      py::arg("output_block_scale_size") = 0,
+      py::arg("output_block_scale_dtype") = DataType::BFloat16,
+      py::arg("output_gamma") = false,
+      R"(
+Scaled matrix multiplication.
+
+Note 1: The post quantization only applies when output_block_scale_size > 0,
+        which would produce out_scale tensor. Otherwise, None will be returned;
+Note 2: When output_gamma is set to True, it should produce global scaling factor out_gamma tensor.
+        Otherwise, None will be returned.
+
+Parameters
+----------
+mat1 : TensorView
+    First set of matrices
+mat2 : TensorView
+    Second set of matrices
+scale1 : TensorView
+    Scale tensor for mat1
+scale2 : TensorView
+    Scale tensor for mat2
+alpha : TensorView, optional
+    Alpha tensor
+bias : TensorView, optional
+    Bias tensor
+beta : TensorView, optional
+    Beta tensor
+dtype : PrimDataType, optional
+    Output tensor type [default: DataType::BFloat16]
+output_block_scale_size : int, optional
+    Output block scale size [default: 0]
+output_block_scale_dtype : PrimDataType, optional
+    Output block scale dtype
+output_gamma : bool, optional
+    Output gamma [default: False]
+
+Returns
+-------
+tuple
+    A tuple containing the result of matrix multiplication, output block scale tensor, and output gamma tensor.
+)",
+      py::return_value_policy::reference);
 }
 
 template <class ITERABLE>

--- a/tests/python/opinfo/opinfos.py
+++ b/tests/python/opinfo/opinfos.py
@@ -1395,6 +1395,7 @@ if LooseVersion(torch.__version__) >= LooseVersion("2.8.0"):
         dtypes=(torch.bfloat16,),
         sample_input_generator=grouped_mm_input_generator,
         reference=torch._grouped_mm,
+        supports_direct_bindings=True,
     )
 
     def scaled_grouped_mm_wrapper(
@@ -1440,6 +1441,7 @@ if LooseVersion(torch.__version__) >= LooseVersion("2.8.0"):
             ArgumentType.Constant,
             ArgumentType.Constant,
         ),
+        supports_direct_bindings=True,
     )
 
     def scaled_mm_wrapper(mat1, mat2, scale1, scale2, alpha, bias, beta, dtype):
@@ -1465,6 +1467,7 @@ if LooseVersion(torch.__version__) >= LooseVersion("2.8.0"):
             ArgumentType.Constant,
             ArgumentType.Constant,
         ),
+        supports_direct_bindings=True,
     )
 
     # only hopper is supported with torch._grouped_mm at this point.


### PR DESCRIPTION
* Create `generateOutputs` helper function to replace unused, optional outputs with `_` instead of incorrectly printing `None`.

## PR List
- #4907
- #4908
- #4909 
- #4910 
- #4911   **<< This PR.**
- #4912
- #4913
- #4914
- #4915