### PR TITLE
Rename and simplify

### DIFF
--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -1398,9 +1398,9 @@ void CompiledKernel::compile(const LaunchParams& lparams) {
   // Basically setting high water mark as 1 when we don't provide args for
   // compilation, it will just generate a kernel that gets ditched at the
   // first run - not great. We should have better heuristics.
-  block_size_high_water_mark_ =
-      std::max<int64_t>(block_size, block_size_high_water_mark_);
-  maxrregcount_high_water_mark_ = compile_params_.maxrregcount;
+  block_size_high_watermark_ =
+      std::max<int64_t>(block_size, block_size_high_watermark_);
+  maxrregcount_high_watermark_ = compile_params_.maxrregcount;
   compiled_kernel_ = getCudaExecutable(
       kernel_code_,
       getStructuredCode(),
@@ -1557,14 +1557,14 @@ void CompiledKernel::deserialize(const serde::KernelExecutor* buffer) {
   c10::DeviceGuard dg(device_);
 
   // Initialize internal fields
-  maxrregcount_high_water_mark_ = buffer->maxrregcount_high_water_mark();
+  maxrregcount_high_watermark_ = buffer->maxrregcount_high_watermark();
   warp_size_ = buffer->warp_size();
   kernel_code_ = buffer->kernel_code()->str();
 
   // KernelDB query checks kernel_code string and compile_params before
   // copying cubin.
   compile_params_.index_type = serde::mapToNvfuserDtype(buffer->index_type());
-  compile_params_.maxrregcount = maxrregcount_high_water_mark_;
+  compile_params_.maxrregcount = maxrregcount_high_watermark_;
 
   // Replace integers that are tensor sizes by named scalars like "T0.size[0]"
   createKernelId();
@@ -1624,8 +1624,8 @@ void CompiledKernel::recompileKernel(
     const CompileParams& new_compile_params) {
   FUSER_PERF_SCOPE("CompiledKernel::runFusion::recompileKernel");
   const auto structured_code = getStructuredCode();
-  block_size_high_water_mark_ = new_launch_params.nThreads();
-  maxrregcount_high_water_mark_ = new_compile_params.maxrregcount;
+  block_size_high_watermark_ = new_launch_params.nThreads();
+  maxrregcount_high_watermark_ = new_compile_params.maxrregcount;
 
   // TODO: This should send in the right device!
   compiled_kernel_ = getCudaExecutable(
@@ -1634,7 +1634,7 @@ void CompiledKernel::recompileKernel(
       kernelName(),
       kernel_id_,
       new_compile_params,
-      block_size_high_water_mark_);
+      block_size_high_watermark_);
 
   if (kernel()->summary().has_cooperative_grid_reduction) {
     // We need to increase shared memory before kernel launch, but also before

--- a/csrc/runtime/compiled_kernel.h
+++ b/csrc/runtime/compiled_kernel.h
@@ -201,17 +201,11 @@ class CompiledKernel : public NonCopyable {
   const std::unique_ptr<GpuLower>& lowered() const {
     return lowered_;
   }
-  int64_t& blockSizeHighWaterMark() {
-    return block_size_high_water_mark_;
+  int64_t blockSizeHighWatermark() {
+    return block_size_high_watermark_;
   }
-  int64_t& maxrregcountHighWaterMark() {
-    return maxrregcount_high_water_mark_;
-  }
-  const int64_t& blockSizeHighWaterMark() const {
-    return block_size_high_water_mark_;
-  }
-  const int64_t& maxrregcountHighWaterMark() const {
-    return maxrregcount_high_water_mark_;
+  int64_t maxrregcountHighWatermark() {
+    return maxrregcount_high_watermark_;
   }
   bool launchParamCacheDisabled() const {
     return launch_param_cache_disabled_;
@@ -282,8 +276,8 @@ class CompiledKernel : public NonCopyable {
 
   // Track the block size this kernel was compiled with. If the block size
   // increases, recompile to adjust maxregister count.
-  int64_t block_size_high_water_mark_ = 1;
-  int64_t maxrregcount_high_water_mark_ = 255;
+  int64_t block_size_high_watermark_ = 1;
+  int64_t maxrregcount_high_watermark_ = 255;
 
   // Profiling support: disable caching of launch params and output allocation
   // output allocation is also disable when output sizes are dependent on

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -1063,9 +1063,9 @@ KernelArgumentHolder KernelExecutor::run(
   }
 
   if (!(executor_entry->launch_params.nThreads() <=
-            compiled_kernel_->blockSizeHighWaterMark() &&
+            compiled_kernel_->blockSizeHighWatermark() &&
         compile_params.maxrregcount ==
-            compiled_kernel_->maxrregcountHighWaterMark())) {
+            compiled_kernel_->maxrregcountHighWatermark())) {
     compiled_kernel_->recompileKernel(
         executor_entry->launch_params, compile_params);
   }
@@ -1327,8 +1327,8 @@ flatbuffers::Offset<serde::KernelExecutor> KernelExecutor::serialize(
   return serde::CreateKernelExecutorDirect(
       builder,
       device_smem_limit_,
-      compiledKernel()->blockSizeHighWaterMark(),
-      compiledKernel()->maxrregcountHighWaterMark(),
+      compiledKernel()->blockSizeHighWatermark(),
+      compiledKernel()->maxrregcountHighWatermark(),
       warp_size_,
       toUnderlying(compiledKernel()->schedulerType()),
       fusion_id_,

--- a/csrc/serde/fusion_cache.fbs
+++ b/csrc/serde/fusion_cache.fbs
@@ -395,8 +395,8 @@ table CudaKernel {
 // Each Fusion Executor maps to a lowered and compiled kernel.
 table KernelExecutor {
   device_smem_limit: long;
-  block_size_high_water_mark: long;
-  maxrregcount_high_water_mark: long;
+  block_size_high_watermark: long;
+  maxrregcount_high_watermark: long;
   warp_size: long;
   heuristic: long;
   fusion_id: long;


### PR DESCRIPTION
"watermark" is one word.

Returning an int& is unnecessary.