### PR TITLE
Clean prepareRuntimeOrder

### DIFF
--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -5152,6 +5152,68 @@ void SegmentedFusion::annotateFP16IntermediateTensors() {
   }
 }
 
+RuntimeWorkSpace prepareRuntimeOrder(const SegmentedFusion& segmented_fusion) {
+  RuntimeWorkSpace runtime_workspace;
+
+  // Setup group run order:
+  std::unordered_set<Val*> available_input;
+
+  // setup the order tensor dimensions are bound
+  for (const size_t i : arange(segmented_fusion.inputs().size())) {
+    auto input_val = segmented_fusion.inputs()[i];
+    available_input.insert(input_val);
+
+    if (auto input_tv = dynamic_cast<TensorView*>(input_val)) {
+      auto logical_dom =
+          TensorDomain::noReductions(input_tv->getLogicalDomain());
+      for (const size_t dim : arange(logical_dom.size())) {
+        const auto extent = logical_dom[dim]->getMaybeExpandedExtent();
+        available_input.insert(extent);
+        runtime_workspace.group_extent_binding_order.push_back(extent);
+      }
+    }
+  }
+
+  // Keep track of groups that has run
+  std::vector<bool> group_ran(segmented_fusion.groups().size(), false);
+
+  while (!std::all_of(
+      group_ran.begin(), group_ran.end(), [](bool b) { return b; })) {
+    bool one_ran = false;
+
+    // Find the first segment with all inputs available to run
+    for (const size_t group_i : arange(segmented_fusion.groups().size())) {
+      auto& group = segmented_fusion.groups()[group_i];
+      if (group_ran[group_i]) {
+        continue;
+      }
+      const auto& group_inputs = group->inputs();
+      bool ready_to_run = std::all_of(
+          group_inputs.begin(),
+          group_inputs.end(),
+          [&available_input](Val* val) { return available_input.count(val); });
+
+      if (ready_to_run) {
+        runtime_workspace.group_run_order.push_back(group);
+        const auto& group_outputs = group->outputs();
+
+        // Insert graph segment output to tensor map
+        for (const size_t group_out_i : arange(group_outputs.size())) {
+          available_input.insert(group_outputs[group_out_i]);
+        }
+        group_ran[group_i] = true;
+        one_ran = true;
+      }
+    }
+    NVF_ERROR(
+        one_ran,
+        "Couldn't run all groups, something must have gone wrong in "
+        "segmentation.");
+  }
+
+  return runtime_workspace;
+}
+
 std::string toString(const SegmentCandidateFinderOptions& segment_options) {
   std::stringstream ss;
   ss << "segmentation phases {\n";

--- a/csrc/fusion_segmenter.h
+++ b/csrc/fusion_segmenter.h
@@ -467,6 +467,18 @@ std::ostream& operator<<(
     std::ostream& os,
     const SegmentedFusion* segmented_fusion);
 
+struct RuntimeWorkSpace {
+  //! Pre-determined order to run the segmented groups
+  std::vector<SegmentedGroup*> group_run_order;
+
+  //! Pre-determined order to bind tensor input meta data
+  std::vector<Val*> group_extent_binding_order;
+};
+
+// Perform a topological sort of different groups composiong the Segmented
+// Fusion
+RuntimeWorkSpace prepareRuntimeOrder(const SegmentedFusion& segmented_fusion);
+
 //! This is a base class for segmenter analysis
 //!  provides the minimal implementation on header so that
 //!  a unique_ptr can use this base class

--- a/csrc/host_ir/lower.cpp
+++ b/csrc/host_ir/lower.cpp
@@ -97,8 +97,7 @@ std::unique_ptr<hir::HostIrContainer> HostIrLower::lower(
           std::move(fusion), KernelArgumentHolder(), options, true);
   // Infer a topologically ordered traversal of the segmented fusion to
   // determine the order for launching the kernels/comms
-  RuntimeWorkSpace workspace;
-  prepareRuntimeOrder(staged_fusion.get(), workspace);
+  RuntimeWorkSpace workspace = prepareRuntimeOrder(*staged_fusion);
   // Create the HostIrContainer representing the host program. Each segment of
   // the segmented fusion will be translated to a HostIR
   auto hic = std::make_unique<hir::HostIrContainer>();

--- a/csrc/runtime/fusion_cache_utils.h
+++ b/csrc/runtime/fusion_cache_utils.h
@@ -7,41 +7,27 @@
 // clang-format on
 #pragma once
 
-#include <runtime/executor.h>
-#include <scheduler/heuristic.h>
-#include <serde/fusion_cache_generated.h>
-#include <utils.h>
-
-#include <c10/util/ArrayRef.h>
-
 #include <list>
 #include <mutex>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
-namespace nvfuser {
+#include <c10/util/ArrayRef.h>
 
-class SegmentedGroup;
-class SegmentedFusion;
+#include <fusion_segmenter.h>
+#include <runtime/executor.h>
+#include <scheduler/heuristic.h>
+#include <serde/fusion_cache_generated.h>
+#include <utils.h>
+
+namespace nvfuser {
 
 // Utilities for benchmarking and profiling
 struct ExecutorLog {
   std::unique_ptr<HeuristicParams> params = nullptr;
   ExecutorAbstract* fusion_executor = nullptr;
 };
-
-struct RuntimeWorkSpace {
-  //! Pre-determined order to run the segmented groups
-  std::vector<SegmentedGroup*> group_run_order;
-
-  //! Pre-determined order to bind tensor input meta data
-  std::vector<Val*> group_extent_binding_order;
-};
-
-// Perform a topological sort of different groups composiong the Segmented
-// Fusion
-void prepareRuntimeOrder(SegmentedFusion*, RuntimeWorkSpace&);
 
 //! Simple hasher for pair<T, const U*>. There is no default hasher for pairs,
 //! since there are a lot of options how to combine hashes. In a case where one

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -129,7 +129,7 @@ FusionKernelRuntime::FusionKernelRuntime(
 
   // Pre-compute the executor order so that the run time path
   //  would go directly to kernel launch.
-  prepareRuntimeOrder(segmented_fusion_.get(), runtime_workspace_);
+  runtime_workspace_ = prepareRuntimeOrder(*segmented_fusion_);
 
   executors_.resize(segmented_fusion_->groups().size());
 
@@ -634,7 +634,7 @@ std::optional<std::unique_ptr<HeuristicParamsList>> FusionKernelRuntime::
   // The runtime group run order is different from the segmented_fusion group
   // order. Instead of using HeuristicParamsList::emplaceBack, we initialize
   // HeuristicParamsList with the desired number of groups.
-  const int64_t num_groups = (int64_t)runtime_workspace_.group_run_order.size();
+  const int64_t num_groups = std::ssize(runtime_workspace_.group_run_order);
   std::unique_ptr<HeuristicParamsList> heuristics =
       std::make_unique<HeuristicParamsList>(num_groups);
 


### PR DESCRIPTION
Change the API to follow https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs

Reuse the toposort implementation from resetLevels. 

Move prepareRuntimeOrder to fusion_segmenter.h