### PR TITLE
Allow skipping JAX test to avoid flaky test failures

### DIFF
--- a/tests/python/opinfo/opinfo_utils.py
+++ b/tests/python/opinfo/opinfo_utils.py
@@ -22,15 +22,22 @@ except ImportError as e:
 def requiresJAX(fn):
     @wraps(fn)
     def _fn(*args, **kwargs):
+        import pytest
+
         if not JAX_AVAILABLE:
             pytest.xfail("Requires JAX")
         if torch.cuda.is_available():
             import os
+
             device_prop = torch.cuda.get_device_properties(torch.cuda.current_device())
             total_gpu_memory_gb = device_prop.total_memory / 1024**3
-            if total_gpu_memory_gb < int(os.getenv("NVFUSER_JAX_TEST_REQUIRE_MINIMUM_GPU_MEMORY_GB", -1)):   # default to -1 means no minimum requirement
-                pytest.xfail("JAX initialization requires enough GPU memory. Skipping this test to avoid flaky JAX initialization error. " \
-                "See http://nv/eRj for more details.")
+            if total_gpu_memory_gb < int(
+                os.getenv("NVFUSER_JAX_TEST_REQUIRE_MINIMUM_GPU_MEMORY_GB", -1)
+            ):  # default to -1 means no minimum requirement
+                pytest.xfail(
+                    "JAX initialization requires enough GPU memory. Skipping this test to avoid flaky JAX initialization error. "
+                    "See http://nv/eRj for more details."
+                )
         return fn(*args, **kwargs)
 
     return _fn

--- a/tests/python/opinfo/opinfo_utils.py
+++ b/tests/python/opinfo/opinfo_utils.py
@@ -24,6 +24,13 @@ def requiresJAX(fn):
     def _fn(*args, **kwargs):
         if not JAX_AVAILABLE:
             pytest.xfail("Requires JAX")
+        if torch.cuda.is_available():
+            import os
+            device_prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+            total_gpu_memory_gb = device_prop.total_memory / 1024**3
+            if total_gpu_memory_gb < os.getenv("NVFUSER_JAX_TEST_REQUIRE_MINIMUM_GPU_MEMORY_GB", -1):   # default to -1 means no minimum requirement
+                pytest.xfail("JAX initialization requires enough GPU memory. Skipping this test to avoid flaky JAX initialization error. " \
+                "See http://nv/eRj for more details.")
         return fn(*args, **kwargs)
 
     return _fn

--- a/tests/python/opinfo/opinfo_utils.py
+++ b/tests/python/opinfo/opinfo_utils.py
@@ -28,7 +28,7 @@ def requiresJAX(fn):
             import os
             device_prop = torch.cuda.get_device_properties(torch.cuda.current_device())
             total_gpu_memory_gb = device_prop.total_memory / 1024**3
-            if total_gpu_memory_gb < os.getenv("NVFUSER_JAX_TEST_REQUIRE_MINIMUM_GPU_MEMORY_GB", -1):   # default to -1 means no minimum requirement
+            if total_gpu_memory_gb < int(os.getenv("NVFUSER_JAX_TEST_REQUIRE_MINIMUM_GPU_MEMORY_GB", -1)):   # default to -1 means no minimum requirement
                 pytest.xfail("JAX initialization requires enough GPU memory. Skipping this test to avoid flaky JAX initialization error. " \
                 "See http://nv/eRj for more details.")
         return fn(*args, **kwargs)


### PR DESCRIPTION
Jax init requires enough GPU memory to work. When there isn't enough, it may fail with error message, e.g. 

```
jaxlib._jax.XlaRuntimeError: FAILED_PRECONDITION: DNN library initialization failed. Look at the errors above for more details.
```

This PR adds a switch to allow skipping JAX tests based on GPU max available memory. The default value won't affect anyone. The switch is reserved for CI tuning.