### PR TITLE
Add DeviceMesh(devices: list[int]) for backward compatibility

### DIFF
--- a/python/python_direct/multidevice.cpp
+++ b/python/python_direct/multidevice.cpp
@@ -77,7 +77,15 @@ void bindDeviceMesh(py::module& nvfuser) {
       }),
       py::arg("devices"),
       R"(
-Create a new DeviceMesh.
+Create a new DeviceMesh from torch.Tensor.
+)");
+  device_mesh.def(
+      py::init([](const std::vector<int64_t>& devices) {
+        return new DeviceMesh(at::tensor(devices));
+      }),
+      py::arg("devices"),
+      R"(
+Create a new DeviceMesh from an integer list, for backward compatibility.
 )");
   device_mesh.def("__repr__", [](const DeviceMesh& self) {
     std::stringstream ss;


### PR DESCRIPTION
For https://github.com/Lightning-AI/lightning-thunder/pull/2423

I got the wrong impression that an integer list can be automatically converted to torch.Tensor. I was probably looking at a test with legacy bindings. 

cc @kshitij12345