### PR TITLE
Host IR LLVM Lowering Integration: add opt-in flag & patch tests

### DIFF
--- a/csrc/host_ir/executor.h
+++ b/csrc/host_ir/executor.h
@@ -11,9 +11,6 @@
 #include <expr_evaluator.h>
 #include <host_ir/container.h>
 #include <host_ir/host_ir.h>
-#ifdef NVFUSER_HOST_IR_JIT
-#include <host_ir/jit.h>
-#endif
 #include <multidevice/communicator.h>
 #include <multidevice/ipc_handle.h>
 #include <runtime/executor.h>

--- a/csrc/host_ir/jit.cpp
+++ b/csrc/host_ir/jit.cpp
@@ -1280,7 +1280,7 @@ void HostIrJitImpl::registerExternalFunctions() {
         }
         input_args.setDeviceIndex();
         container_ptr->getKernelExecutor(launch_kernel_ptr->groupId())
-            ->run(
+            .run(
                 input_args,
                 output_args,
                 launch_kernel_ptr->launchParams(),

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -472,8 +472,12 @@ void FusionKernelRuntime::compileFusionParallel(KernelArgumentHolder args) {
     }
     std::unique_ptr<hir::HostIrContainer> hic = lowerSegmentedFusionToHostIr(
         *segmented_fusion_, launch_params_per_segment, executors_);
+    #ifdef NVFUSER_HOST_IR_JIT
+    hij_ = std::make_unique<HostIrJit>(std::move(hic));
+    #else
     hie_ = std::make_unique<hir::HostIrEvaluator>(
         std::move(hic), &Communicator::getInstance());
+    #endif
   }
 
   if (isProfilerEnabled()) {

--- a/csrc/runtime/fusion_kernel_runtime.cpp
+++ b/csrc/runtime/fusion_kernel_runtime.cpp
@@ -157,7 +157,11 @@ void FusionKernelRuntime::evictCache(size_t input_id) {
 
 bool FusionKernelRuntime::isCompiled() const {
   if (isOptionEnabled(EnableOption::HostIrLowering)) {
+    #ifdef NVFUSER_HOST_IR_JIT
+    return hij_ != nullptr;
+    #else
     return hie_ != nullptr;
+    #endif
   } else {
     std::lock_guard<std::mutex> guard(mutex_);
     return std::all_of(
@@ -297,7 +301,12 @@ KernelArgumentHolder FusionKernelRuntime::runWithInputs(
               << std::endl;
     }
 
+    #ifdef NVFUSER_HOST_IR_JIT
+    auto outputs = hij_->runWithInputs(args); // TODO: add jit support
+    #else
     auto outputs = hie_->runWithInputs(args);
+    #endif
+
     if (isDebugDumpEnabled(DebugDumpOption::PerfDebugVerbose)) {
       debug() << "============= FINISHED RUNNING HOSTIR EVALUATOR ============"
               << std::endl;

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -142,9 +142,11 @@ class FusionKernelRuntime {
 
   const std::vector<std::unique_ptr<ExecutorAbstract>>& executors() const;
 
+  #ifndef NVFUSER_HOST_IR_JIT
   const hir::HostIrEvaluator& getHostIrEvaluator() const {
     return *hie_.get();
-  };
+  }
+  #endif
 
  private:
   //! Runs each fusion segment given arguments. The outputs for a fusion are
@@ -188,7 +190,7 @@ class FusionKernelRuntime {
 
   #ifdef NVFUSER_HOST_IR_JIT
   //! Host IR JIT
-  std::unique_ptr<hir::HostIrJit> hij_;
+  std::unique_ptr<HostIrJit> hij_;
   #else
   //! Host IR Evaluator
   std::unique_ptr<hir::HostIrEvaluator> hie_;

--- a/csrc/runtime/fusion_kernel_runtime.h
+++ b/csrc/runtime/fusion_kernel_runtime.h
@@ -11,6 +11,9 @@
 
 #include <fusion_segmenter.h>
 #include <host_ir/executor.h>
+#ifdef NVFUSER_HOST_IR_JIT  
+#include <host_ir/jit.h>
+#endif
 #include <polymorphic_value.h>
 #include <runtime/executor.h>
 #include <runtime/executor_kernel_arg.h>
@@ -183,8 +186,13 @@ class FusionKernelRuntime {
   //! Executors holding compiled kernels
   std::vector<std::unique_ptr<ExecutorAbstract>> executors_;
 
+  #ifdef NVFUSER_HOST_IR_JIT
+  //! Host IR JIT
+  std::unique_ptr<hir::HostIrJit> hij_;
+  #else
   //! Host IR Evaluator
   std::unique_ptr<hir::HostIrEvaluator> hie_;
+  #endif
 
   // A metadata copy of initial arguments used to contruct this
   // FusionKernelRuntime. Used during deserialization to schedule the fusion

--- a/tests/cpp/test_host_ir_integration.cpp
+++ b/tests/cpp/test_host_ir_integration.cpp
@@ -209,6 +209,7 @@ TEST_F(HostIrIntegrationTest, Deallocate) {
   EXPECT_EQ(memoryAllocated(device_index), 0);
 }
 
+#ifndef NVFUSER_HOST_IR_JIT
 TEST_F(HostIrIntegrationTest, InsertDeallocations) {
   c10::DeviceIndex device_index = 0;
   at::cuda::clearCublasWorkspaces();
@@ -285,7 +286,9 @@ TEST_F(HostIrIntegrationTest, InsertDeallocations) {
       << "Max memory allocated (" << max_memory_allocated
       << ") was higher than expected << (" << kExpectedPeakMemory << ")";
 }
+#endif
 
+#ifndef NVFUSER_HOST_IR_JIT
 TEST_F(HostIrIntegrationTest, ExcludeOutputsFromDeallocations) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
@@ -320,6 +323,7 @@ TEST_F(HostIrIntegrationTest, ExcludeOutputsFromDeallocations) {
         return v.as<at::Tensor>().defined();
       }));
 }
+#endif
 
 } // namespace hir
 

--- a/tests/cpp/test_host_ir_jit.cpp
+++ b/tests/cpp/test_host_ir_jit.cpp
@@ -23,7 +23,7 @@ namespace hir {
 using HostIrJitTest = NVFuserTest;
 // Build with: python setup.py install --build-with-host-ir-jit
 TEST_F(HostIrJitTest, Set) {
-  auto hic = std::make_unique<HostIrContainer>(1);
+  auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 
   auto hic_in = makeSymbolicTensor(2);
@@ -50,7 +50,7 @@ TEST_F(HostIrJitTest, Set) {
 }
 
 TEST_F(HostIrJitTest, HostIrContainer) {
-  auto hic = std::make_unique<HostIrContainer>(1);
+  auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 
   int num_inputs = std::rand() % 10 + 1;
@@ -275,7 +275,7 @@ TEST_F(HostIrJitTest, LaunchKernel) {
   ke->setGroupId(0);
   ke->compile(&fusion, {t0});
 
-  auto hic = std::make_unique<HostIrContainer>(1);
+  auto hic = std::make_unique<HostIrContainer>();
   FusionGuard::setCurFusion(hic.get());
 
   hic->addKernelExecutor(std::move(ke));

--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -16,7 +16,6 @@
 #include <tests/cpp/multidevice.h>
 #include <tests/cpp/validator.h>
 
-
 #ifndef NVFUSER_HOST_IR_JIT
 namespace nvfuser {
 

--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -16,6 +16,8 @@
 #include <tests/cpp/multidevice.h>
 #include <tests/cpp/validator.h>
 
+
+#ifndef NVFUSER_HOST_IR_JIT
 namespace nvfuser {
 
 using testing::Contains;
@@ -768,3 +770,5 @@ INSTANTIATE_TEST_SUITE_P(
     }));
 
 } // namespace nvfuser
+
+#endif


### PR DESCRIPTION
This PR targets to:
1. add opt-in flag
2. patch host ir jit tests as hostircontainer was changed.