### PR TITLE
Search modules in folder `python`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ python/nvfuser_direct/*.so
 *.swp
 *~
 .~lock.*
-.vscode
 
 # debugging temporaries
 *.log

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cursorpyright.analysis.extraPaths": [
+        "python"
+    ]
+}


### PR DESCRIPTION
When nvFuser is installed in development mode (aka `--editable`), Cursor has problems find nvFuser's Python source code. Therefore, we add `python` as an extra path to help Cursor resolve imports.