### PR TITLE
Add a top-level symbolic link to python/nvfuser_direct

### DIFF
--- a/nvfuser_direct
+++ b/nvfuser_direct
@@ -1,0 +1,1 @@
+python/nvfuser_direct


### PR DESCRIPTION
This helps IDEs like Cursor resolve symbols in nvfuser_direct without additional settings like #4978

This is an alternative to #4978. Let me know which you prefer. 