### PR TITLE
may cache gather tv

### DIFF
--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -793,16 +793,11 @@ bool isIndexSelectIndicesTv(const TensorView* tv) {
   return false;
 }
 
-bool isGatherLookupTv(const Val* tv) {
-  for (auto expr : tv->uses()) {
-    if (expr->isA<GatherOp>()) {
-      auto idx_sel = expr->as<GatherOp>();
-      if (idx_sel->lookupTv() == tv) {
-        return true;
-      }
-    }
-  }
-  return false;
+bool isAndOnlyIsGatherLookupTv(const Val* tv) {
+  return !tv->uses().empty() &&
+      std::all_of(tv->uses().begin(), tv->uses().end(), [tv](Expr* expr) {
+        return expr->isA<GatherOp>() && expr->as<GatherOp>()->lookupTv() == tv;
+      });
 }
 
 std::string varName(const Val* val) {

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -440,7 +440,7 @@ bool isIndexSelectLookupTv(const TensorView* tv);
 // Check if the given tv is third argment of indexSelect(lookup, dim, indices)
 bool isIndexSelectIndicesTv(const TensorView* tv);
 
-bool isGatherLookupTv(const Val* tv);
+bool isAndOnlyIsGatherLookupTv(const Val* tv);
 
 std::string varName(const Val* val);
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1264,7 +1264,7 @@ std::vector<TensorView*> cacheInputs(Fusion* fusion, bool unroll) {
   // If we're going to unroll, make a cache of the inputs
   auto in_tvs = ir_utils::filterByType<TensorView>(fusion->inputs());
   for (auto tv : in_tvs) {
-    if (tv->uses().empty() || ir_utils::isGatherLookupTv(tv) ||
+    if (tv->uses().empty() || ir_utils::isAndOnlyIsGatherLookupTv(tv) ||
         ir_utils::isIndexSelectLookupTv(tv) ||
         ir_utils::isTvUsedByOpsOfType<SelectOp>(tv)) {
       // Right now, tensors that are input to the select, gather and
@@ -1282,7 +1282,7 @@ std::vector<TensorView*> cacheInputs(Fusion* fusion, bool unroll) {
     // caching load instructions.
     std::vector<Expr*> cached_uses;
     for (auto use : tv->uses()) {
-      if (!use->isOneOf<PadOp, SliceOp>()) {
+      if (!use->isOneOf<PadOp, SliceOp, GatherOp>()) {
         cached_uses.push_back(use);
       }
     }
@@ -1638,7 +1638,7 @@ std::vector<TensorView*> getInputsOutputsWithInnerDim(
        ir_utils::filterByType<TensorView>(reference_tv->fusion()->inputs())) {
     // for indexSelect(lookup_tv, dim, index_tv) op
     // ignore it's lookup_tv.
-    if (ir_utils::isGatherLookupTv(input_tv)) {
+    if (ir_utils::isAndOnlyIsGatherLookupTv(input_tv)) {
       continue;
     }
 

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1910,42 +1910,43 @@ TEST_F(PersistentBufferTest, BroadcastSyncInputsHasBcast) {
 
 // Should cache gather lookup tv if it is a persistent buffer
 TEST_F(PersistentBufferTest, BufferGatherLookupTv) {
-    DataType dtype = DataType::BFloat16;
-    int x = 2;
-    int y = 65 * 1024;
-    auto fusion_ptr = std::make_unique<Fusion>();
-    auto& fusion = *fusion_ptr;
-    FusionGuard fg(fusion_ptr.get());
-    auto tv0 = makeContigConcreteTensor({x, y}, dtype);
-    auto index_tv = makeContigConcreteTensor({x, 1}, DataType::Int);
-    fusion.addInput(tv0);
-    fusion.addInput(index_tv);
-    auto tv1 = maybeCastOp(DataType::Float, tv0);
-    auto tv2 = sum(tv1, {1});
-    auto tv3 = broadcast(tv2, {false, true});
-    auto tv4 = gather(tv0, 0, index_tv);
-    auto tv5 = maybeCastOp(DataType::BFloat16, tv4);
-    auto tv6 = add(tv3, tv5);
-    auto tv7 = add(tv1, tv6);
-    auto tv8 = maybeCastOp(DataType::BFloat16, tv7);
-    fusion.addOutput(tv8);
-    auto unscheduled_fusion_copy = fusion;
-  
-    auto options =
-        at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
-    auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
-    auto t0 = at::randn({x, y}, options).clamp(-2, 2);
-    auto t1 = at::randint(0, x, {x, 1}, options_i);
-    SchedulerRuntimeInfo runtime_info(fusion_ptr.get(), {t0, t1});
-    auto scheduler =
-        SchedulerEntry::makeSchedulerInstance(SchedulerType::InnerPersistent);
-    auto heuristic_params =
-        scheduler->computeHeuristics(fusion_ptr.get(), runtime_info);
-    scheduler->schedule(fusion_ptr.get(), heuristic_params.get());
-    KernelExecutor ke;
-    ke.compile(fusion_ptr.get(), {t0, t1});
-    auto outputs =
-        ke.run({t0, t1}, {}, heuristic_params->as<ReductionParams>()->lparams);
-    testValidate(&unscheduled_fusion_copy, outputs, {t0, t1});
-  }
+  DataType dtype = DataType::BFloat16;
+  int x = 2;
+  int y = 65 * 1024;
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto& fusion = *fusion_ptr;
+  FusionGuard fg(fusion_ptr.get());
+  auto tv0 = makeContigConcreteTensor({x, y}, dtype);
+  auto index_tv = makeContigConcreteTensor({x}, DataType::Int);
+  fusion.addInput(tv0);
+  fusion.addInput(index_tv);
+  auto tv1 = maybeCastOp(DataType::Float, tv0);
+  auto tv2 = sum(tv1, {1});
+  auto tv3 = broadcast(tv2, {false, true});
+  auto tv4 = broadcast(index_tv, {false, true});
+  auto tv5 = gather(tv0, 1, tv4);
+  auto tv6 = maybeCastOp(DataType::BFloat16, tv5);
+  auto tv7 = add(tv3, tv6);
+  auto tv8 = add(tv1, tv7);
+  auto tv9 = maybeCastOp(DataType::BFloat16, tv8);
+  fusion.addOutput(tv9);
+  auto unscheduled_fusion_copy = fusion;
+
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+  auto t0 = at::randn({x, y}, options).clamp(-2, 2);
+  auto t1 = at::randint(0, y, {x}, options_i);
+  SchedulerRuntimeInfo runtime_info(fusion_ptr.get(), {t0, t1});
+  auto scheduler =
+      SchedulerEntry::makeSchedulerInstance(SchedulerType::InnerPersistent);
+  auto heuristic_params =
+      scheduler->computeHeuristics(fusion_ptr.get(), runtime_info);
+  scheduler->schedule(fusion_ptr.get(), heuristic_params.get());
+  KernelExecutor ke;
+  ke.compile(fusion_ptr.get(), {t0, t1});
+  auto outputs =
+      ke.run({t0, t1}, {}, heuristic_params->as<ReductionParams>()->lparams);
+  testValidate(&unscheduled_fusion_copy, outputs, {t0, t1});
+}
 } // namespace nvfuser

--- a/tests/cpp/test_persistent_buffer.cpp
+++ b/tests/cpp/test_persistent_buffer.cpp
@@ -1907,4 +1907,45 @@ TEST_F(PersistentBufferTest, BroadcastSyncInputsHasBcast) {
       ke.run({t0, t1}, {}, heuristic_params->as<ReductionParams>()->lparams);
   testValidate(&unscheduled_fusion_copy, outputs, {t0, t1}, __LINE__, __FILE__);
 }
+
+// Should cache gather lookup tv if it is a persistent buffer
+TEST_F(PersistentBufferTest, BufferGatherLookupTv) {
+    DataType dtype = DataType::BFloat16;
+    int x = 2;
+    int y = 65 * 1024;
+    auto fusion_ptr = std::make_unique<Fusion>();
+    auto& fusion = *fusion_ptr;
+    FusionGuard fg(fusion_ptr.get());
+    auto tv0 = makeContigConcreteTensor({x, y}, dtype);
+    auto index_tv = makeContigConcreteTensor({x, 1}, DataType::Int);
+    fusion.addInput(tv0);
+    fusion.addInput(index_tv);
+    auto tv1 = maybeCastOp(DataType::Float, tv0);
+    auto tv2 = sum(tv1, {1});
+    auto tv3 = broadcast(tv2, {false, true});
+    auto tv4 = gather(tv0, 0, index_tv);
+    auto tv5 = maybeCastOp(DataType::BFloat16, tv4);
+    auto tv6 = add(tv3, tv5);
+    auto tv7 = add(tv1, tv6);
+    auto tv8 = maybeCastOp(DataType::BFloat16, tv7);
+    fusion.addOutput(tv8);
+    auto unscheduled_fusion_copy = fusion;
+  
+    auto options =
+        at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+    auto options_i = at::TensorOptions().dtype(at::kLong).device(at::kCUDA, 0);
+    auto t0 = at::randn({x, y}, options).clamp(-2, 2);
+    auto t1 = at::randint(0, x, {x, 1}, options_i);
+    SchedulerRuntimeInfo runtime_info(fusion_ptr.get(), {t0, t1});
+    auto scheduler =
+        SchedulerEntry::makeSchedulerInstance(SchedulerType::InnerPersistent);
+    auto heuristic_params =
+        scheduler->computeHeuristics(fusion_ptr.get(), runtime_info);
+    scheduler->schedule(fusion_ptr.get(), heuristic_params.get());
+    KernelExecutor ke;
+    ke.compile(fusion_ptr.get(), {t0, t1});
+    auto outputs =
+        ke.run({t0, t1}, {}, heuristic_params->as<ReductionParams>()->lparams);
+    testValidate(&unscheduled_fusion_copy, outputs, {t0, t1});
+  }
 } // namespace nvfuser


### PR DESCRIPTION
Fix https://github.com/NVIDIA/Fuser/issues/4985

The input tensor view is both a gather tensor view and a persistent buffer, so the current scheduler will not cache it. The shared memory persistent scheduler attempts to store this non-cached global input into shared memory since it is a persistent buffer, which causes an error.