### PR TITLE
Handle remaining composite operations in opinfo tests

### DIFF
--- a/python/python_common/python_utils.cpp
+++ b/python/python_common/python_utils.cpp
@@ -249,6 +249,7 @@ std::vector<int64_t> getTensorViewBuilderSizes(
 }
 
 const char* dtypeToPyString(PrimDataType t) {
+  // Use Int64 for DataType::Index
   switch (t) {
     case DataType::Bool:
       return "DataType.Bool";
@@ -271,6 +272,7 @@ const char* dtypeToPyString(PrimDataType t) {
     case DataType::Float4_e2m1fn_x2:
       return "DataType.Float4_e2m1fn_x2";
     case DataType::Int:
+    case DataType::Index:
       return "DataType.Int";
     case DataType::Int32:
       return "DataType.Int32";

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -3165,6 +3165,10 @@ TensorView* random_dist_op_fn(
   NVF_CHECK(
       !((rng_seed == nullptr) ^ (rng_offset == nullptr)),
       "rng_seed and rng_offset must be provided together!");
+  NVF_CHECK(
+      isFloatingPointType(dtype),
+      "Random distributions only create floating point types! ",
+      dtype);
   std::vector<Val*> new_shape = SequenceAsVector(generic_new_shape);
   return RandomFuncWithSeed(
       new_shape,

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -2844,6 +2844,55 @@ TensorView
 )",
       py::return_value_policy::reference);
   ops.def(
+      "take_along_axis",
+      [](TensorView* arg, TensorView* index, int64_t dim) -> TensorView* {
+        NVF_CHECK(
+            arg->nDims() == index->nDims(),
+            "Tensor arguments have different dimensions ",
+            arg->nDims(),
+            " and ",
+            index->nDims());
+        auto num_dims = (int64_t)arg->nDims();
+        NVF_CHECK(
+            dim >= -num_dims && dim < num_dims,
+            "Tensor arguments have dimension ",
+            num_dims,
+            " so dim argument must satisfy ",
+            -num_dims,
+            " <= dim < ",
+            num_dims,
+            ", but received ",
+            dim);
+        return takeAlongAxis(arg, index, dim);
+      },
+      py::arg("arg"),
+      py::arg("index"),
+      py::arg("dim"),
+      R"(
+Index arg in dim at positions given by index.
+
+This operation is very similar to gather, but it enforces that all
+dimensions other than dim must be equal between arg and index.
+
+Parameters
+----------
+arg : TensorView
+    Tensor of shape `(Ni...,M,Nk...)` where `M` is the extent of `arg` in the
+    dimension `dim`.
+index : TensorView
+    Tensor of dtype `DataType::Int` of shape `(Ni...,J,Nk...)`.
+dim : int
+    Which position to index along.
+
+Returns
+-------
+TensorView
+    Tensor of same dtype as `arg` and of shape `(Ni...,J,Nk...)` where the
+    element at position `(i...,j,k...)` is equal to
+    `arg[i,...,index[i,...,j,k,...],k,...]`.
+      )",
+      py::return_value_policy::reference);
+  ops.def(
       "cat",
       [](std::vector<TensorView*> tensors,
          int64_t dim,

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -1886,6 +1886,33 @@ Val
       py::return_value_policy::reference);
 }
 
+void bindCompositeOps(py::module_& ops) {
+  ops.def(
+      "triu",
+      [](TensorView* arg, int64_t diagonal) -> TensorView* {
+        Val* diagonal_val =
+            IrBuilder::create<nvfuser::Val>(diagonal, DataType::Int);
+        return triu(arg, diagonal_val);
+      },
+      py::arg("arg"),
+      py::arg("diagonal") = 0,
+      R"(
+Get the upper triangular part of a tensor.
+
+Parameters
+----------
+arg : TensorView
+diagonal : int
+    Offset of the diagonal relative to the main diagonal.
+
+Returns
+-------
+TensorView
+    The upper triangular part of the tensor.
+)",
+      py::return_value_policy::reference);
+}
+
 void bindMatmulOps(py::module_& ops) {
   ops.def(
       "matmul",
@@ -3282,6 +3309,7 @@ void bindOperations(py::module& nvfuser) {
   bindReductionOps(nvf_ops);
   bindScanOps(nvf_ops);
   bindCastOps(nvf_ops);
+  bindCompositeOps(nvf_ops);
   bindMatmulOps(nvf_ops);
   bindMetadataOps(nvf_ops);
   bindTensorUtilityOps(nvf_ops);

--- a/python/python_direct/python_translate.cpp
+++ b/python/python_direct/python_translate.cpp
@@ -1473,7 +1473,7 @@ class PythonTranslator : public OptInConstDispatch {
     visited_vals_.insert(out_tv);
     static const std::vector<std::string> argument_names = {"dim"};
     printer_.generateKwargsOperation(
-        "fd.ops.gather",
+        (gop->exactSizes() ? "fd.ops.take_along_axis" : "fd.ops.gather"),
         std::make_tuple(gop->lookupTv(), gop->indexTv()),
         argument_names,
         std::make_tuple(gop->dim()),

--- a/tests/python/direct/test_python_frontend.py
+++ b/tests/python/direct/test_python_frontend.py
@@ -638,6 +638,31 @@ def test_select(nvfuser_direct_test):
     test_fn(1)
 
 
+def test_take_along_axis(nvfuser_direct_test):
+    inputs = [
+        torch.randn(8, 16, device="cuda"),
+        torch.randn(8, 16, device="cuda"),
+        torch.randint(0, 8, (8, 16), device="cuda").to(dtype=torch.long),
+    ]
+
+    def test_fn(dim):
+        def fusion_func(fd: FusionDefinition):
+            t0 = fd.from_pytorch(inputs[0])
+            t1 = fd.from_pytorch(inputs[1])
+            t2 = fd.from_pytorch(inputs[2])
+            t3 = fd.ops.add(t0, t1)
+            t4 = fd.ops.take_along_axis(t3, t2, dim)
+            fd.add_output(t4)
+
+        nvf_out, _ = nvfuser_direct_test.exec_nvfuser(fusion_func, inputs)
+
+        eager_out = torch.gather(inputs[0] + inputs[1], dim, inputs[2])
+        nvfuser_direct_test.assertEqual(eager_out, nvf_out[0])
+
+    test_fn(0)
+    test_fn(1)
+
+
 def test_cumsum(nvfuser_direct_test):
     inputs = [
         torch.randn(8, 16, device="cuda"),

--- a/tests/python/direct/test_python_frontend.py
+++ b/tests/python/direct/test_python_frontend.py
@@ -1335,3 +1335,18 @@ def test_output_stride_order_with_reduction(nvfuser_direct_test):
 
         out = fd.execute(inputs)[0]
         verify_stride_order(out.stride(), stride_order)
+
+
+def test_triu(nvfuser_direct_test):
+    inputs = [
+        torch.randn(4, 16, device="cuda", dtype=torch.float16),
+    ]
+
+    def fusion_func(fd: FusionDefinition) -> None:
+        t0 = fd.from_pytorch(inputs[0])
+        t1 = fd.ops.triu(t0, -1)
+        fd.add_output(t1)
+
+    nvf_out, _ = nvfuser_direct_test.exec_nvfuser(fusion_func, inputs)
+    eager_out0 = torch.triu(inputs[0], -1)
+    nvfuser_direct_test.assertEqual(eager_out0, nvf_out[0])

--- a/tests/python/opinfo/opinfos.py
+++ b/tests/python/opinfo/opinfos.py
@@ -1516,6 +1516,7 @@ triu_opinfo = OpInfo(
     error_input_generator=triu_error_generator,
     reference=torch.triu,
     symbolic_parameter_list=[ArgumentType.Symbolic, ArgumentType.Constant],
+    supports_direct_bindings=True,
 )
 
 tv_val_ops.append(triu_opinfo)

--- a/tests/python/opinfo/opinfos.py
+++ b/tests/python/opinfo/opinfos.py
@@ -1351,6 +1351,7 @@ uniform_opinfo = OpInfo(
         ArgumentType.ConstantScalar,
         ArgumentType.Constant,
     ),
+    supports_direct_bindings=True,
 )
 tensor_creation_ops.append(uniform_opinfo)
 
@@ -1367,6 +1368,7 @@ uniform_opinfo = OpInfo(
         ArgumentType.ConstantScalar,
         ArgumentType.Constant,
     ),
+    supports_direct_bindings=True,
 )
 tensor_creation_ops.append(uniform_opinfo)
 

--- a/tests/python/opinfo/opinfos.py
+++ b/tests/python/opinfo/opinfos.py
@@ -101,6 +101,9 @@ define_vector_constant_opinfo = OpInfo(
     "define_vector_constant",
     error_input_generator=define_vector_constant_error_generator,
     fd_error_input_fn=api_test_fd_fn,
+    # Direct bindings supports python lists and tuples of values.
+    # These python lists are directly indexable, so `define_vector_constant` is not needed.
+    supports_direct_bindings=False,
 )
 fusion_input_ops.append(define_vector_constant_opinfo)
 
@@ -977,6 +980,9 @@ vector_at_opinfo = OpInfo(
     error_input_generator=vector_at_error_generator,
     fd_correctness_fn=None,
     fd_error_input_fn=vector_api_test_fd_fn,
+    # Direct bindings supports python lists and tuples of values.
+    # These python lists are directly indexable, so `at` is not needed.
+    supports_direct_bindings=False,
 )
 dynamic_shapes_ops.append(vector_at_opinfo)
 
@@ -1198,6 +1204,8 @@ index_put_accumulate_opinfo = OpInfo(
         ArgumentType.Symbolic,
         ArgumentType.Symbolic,
     ),
+    # index_put_accumulate is not used in Thunder, so skip in direct bindings for now.
+    supports_direct_bindings=False,
 )
 shape_ops.append(index_put_accumulate_opinfo)
 

--- a/tests/python/opinfo/opinfos.py
+++ b/tests/python/opinfo/opinfos.py
@@ -1309,6 +1309,7 @@ take_along_axis_opinfo = OpInfo(
         ArgumentType.Symbolic,
         ArgumentType.Constant,
     ),
+    supports_direct_bindings=True,
 )
 shape_ops.append(take_along_axis_opinfo)
 


### PR DESCRIPTION
* Add support for `triu` and `take_along_axis`
* Explicitly skip `define_vector_constant`, `at`, and `index_put_accumulate` for direct bindings
* Ensure only floating point outputs are generated by `uniform` and `normal`