### PR TITLE
Extend lower_to_communication to handle SqueezeOp

### DIFF
--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -523,7 +523,7 @@ std::vector<Expr*> convertSingleOpToCommunication(
       "Resharding on an inner axis is not lowerable ",
       e->toString());
 
-  if (auto* load_store = dynamic_cast<LoadStoreOp*>(e)) {
+  if (e->isA<LoadStoreOp>()) {
     if (!is_input_sharded && is_output_sharded) {
       lowerToScatter(input_tv, output_tv, backend, comms);
     } else if (is_input_sharded && !is_output_sharded) {

--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -24,7 +24,7 @@ namespace {
 
 // TODO: handle `c10d::RedOpType::reduceOp::AVG` and
 // `c10d::RedOpType::reduceOp::PREMUL_SUM`
-inline c10d::ReduceOp::RedOpType getC10dReduceOpType(BinaryOpType op) {
+c10d::ReduceOp::RedOpType getC10dReduceOpType(BinaryOpType op) {
   switch (op) {
     case BinaryOpType::Add:
       return c10d::ReduceOp::RedOpType::SUM;
@@ -80,12 +80,10 @@ void lowerToScatter(
       backend));
 }
 
-/*
-Adds zero or multiple Gather communications to the vector 'comms'
-
-Note that since the root of a Gather collective is a destination, we possibly
-need multiple Gathers if the tensor is replicated in the receiver mesh.
-*/
+// Adds zero or multiple Gather communications to the vector 'comms'
+//
+// Note that since the root of a Gather collective is a destination, we possibly
+// need multiple Gathers if the tensor is replicated in the receiver mesh.
 void lowerToGather(
     TensorView* input_tv,
     TensorView* output_tv,
@@ -309,7 +307,7 @@ CommunicationInfo getCommunicationInfo(Expr* e) {
       e);
 
   NVF_ERROR(
-      e->isOneOf<LoadStoreOp, ReductionOp, SqueezeOp>(),
+      (e->isOneOf<LoadStoreOp, ReductionOp, SqueezeOp>()),
       "getCommunicationInfo should only be called when `e` is known to be a "
       "communication. Given: ",
       e);

--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -306,6 +306,7 @@ CommunicationInfo getCommunicationInfo(Expr* e) {
       "communication. So `e` should be resharding. Given: ",
       e);
 
+  // `sum` leads to a SqueezeOp when the reduction dimension is size-1.
   NVF_ERROR(
       (e->isOneOf<LoadStoreOp, ReductionOp, SqueezeOp>()),
       "getCommunicationInfo should only be called when `e` is known to be a "

--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -309,10 +309,9 @@ CommunicationInfo getCommunicationInfo(Expr* e) {
       e);
 
   NVF_ERROR(
-      e->isA<LoadStoreOp>() || e->isA<ReductionOp>() || e->isA<SqueezeOp>(),
+      e->isOneOf<LoadStoreOp, ReductionOp, SqueezeOp>(),
       "getCommunicationInfo should only be called when `e` is known to be a "
-      "communication. So `e` should be either a LoadStoreOp or a "
-      "ReductionOp. Given: ",
+      "communication. Given: ",
       e);
 
   auto* producer = e->inputs().at(0)->as<TensorView>();
@@ -541,9 +540,12 @@ std::vector<Expr*> convertSingleOpToCommunication(
       if (auto* reduce = dynamic_cast<ReductionOp*>(e)) {
         return reduce->getReductionOpType();
       }
+
+      NVF_ERROR(e != nullptr);
       if (e->isA<SqueezeOp>()) {
         return BinaryOpType::Add;
       }
+
       NVF_THROW("Expected a ReductionOp or a SqueezeOp, but got: ", e);
     }();
 

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -449,10 +449,9 @@ void IndexCompute::handle(Resize* resize) {
 }
 
 void IndexCompute::dispatch(Expr* e) {
-  auto is_expected_type =
-      e->isOneOf<Split, Merge, Swizzle, Swizzle2D, Resize>();
   NVF_ERROR(
-      is_expected_type, "Invalid expr type found in transform traversal.");
+      (e->isOneOf<Split, Merge, Swizzle, Swizzle2D, Resize>()),
+      "Invalid expr type found in transform traversal.");
   updateUnswitchedDomains(e);
   BackwardVisitor::dispatch(e);
 }

--- a/tests/python/multidevice/test_communication.py
+++ b/tests/python/multidevice/test_communication.py
@@ -73,14 +73,6 @@ def test_allreduce(multidevice_direct_test):
 def test_reduce_scatter(multidevice_direct_test):
     d = multidevice_direct_test.size
 
-    # The first dimension of the TensorView is the world size.
-    # When it is one, the axis becomes a broadcast iterDomain.
-    # The sum operations uses squeeze for size-1 broadcast domains.
-    # Squeeze is not supported by getCommunicationInfo.
-    # This test is skipped when the world size is 1.
-    if d == 1:
-        pytest.skip("This test requires > 1 MPI processes")
-
     mesh = nvfuser.multidevice.DeviceMesh(torch.arange(d))
 
     def _definition(fd: FusionDefinition):

--- a/tests/python/multidevice/test_communication.py
+++ b/tests/python/multidevice/test_communication.py
@@ -107,14 +107,6 @@ def test_reduce_scatter(multidevice_direct_test):
 def test_reduce_scatter_noncontiguous(multidevice_direct_test):
     d = multidevice_direct_test.size
 
-    # The first dimension of the TensorView is the world size.
-    # When it is one, the axis becomes a broadcast iterDomain.
-    # The sum operations uses squeeze for size-1 broadcast domains.
-    # Squeeze is not supported by getCommunicationInfo.
-    # This test is skipped when the world size is 1.
-    if d == 1:
-        pytest.skip("This test requires > 1 MPI processes")
-
     mesh = nvfuser.multidevice.DeviceMesh(torch.arange(d))
 
     def _definition(fd: FusionDefinition):


### PR DESCRIPTION
`sum` leads to a `SqueezeOp` when the reduction dimension is size-1. 

Tested with
```
mpirun -np 1 pytest tests/python/multidevice/test_communication.py --only-mpi
```
which I'll add to CI after this PR is merged. 