### PR TITLE
Patch old broadcast python api

### DIFF
--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -2866,7 +2866,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         NVF_CHECK(
             self.validUse(), "Attempting to add to a completed definition!");
         FusionDefinition* fd = self.fusion_definition;
-        Tensor output = fd->defineTensor(arg.dims);
+        Tensor output = fd->defineTensor(is_broadcast_dim.size());
         fd->defineRecord(new BroadcastOpRecord(
             {fd->recordingState(arg())},
             {fd->recordingState(output())},

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -5017,8 +5017,8 @@ fd.execute(inputs)
          
         nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
 
-        self.assertEqual(nvf_out[0], inputs[0].expand(2, 1, 3, 4))
-        self.assertEqual(nvf_out[0].stride(), (1, 2, 2, 6)
+        self.assertEqual(nvf_out[0], inputs[0].unsqueeze(1))
+        self.assertEqual(nvf_out[0].stride(), (1, 2, 2, 6))
         
 
 @pytest.mark.skip("https://github.com/NVIDIA/Fuser/issues/3740")

--- a/tests/python/test_python_frontend.py
+++ b/tests/python/test_python_frontend.py
@@ -5005,6 +5005,22 @@ fd.execute(inputs)
             )
 
 
+    def test_broadcast_and_stride_order(self):
+        inputs = [
+            torch.randn(2, 3, 4, dtype=torch.float32, device='cuda:0'),
+        ]
+
+        def fusion_func(fd : FusionDefinition) -> None :
+            T0 = fd.from_pytorch(inputs[0])
+            T1 = fd.ops.broadcast(T0, is_broadcast_dim=[False, True, False, False])
+            fd.add_output(T1, stride_order=[0, 1, 2, 3])
+         
+        nvf_out, _ = self.exec_nvfuser(fusion_func, inputs)
+
+        self.assertEqual(nvf_out[0], inputs[0].expand(2, 1, 3, 4))
+        self.assertEqual(nvf_out[0].stride(), (1, 2, 2, 6)
+        
+
 @pytest.mark.skip("https://github.com/NVIDIA/Fuser/issues/3740")
 def test_cat_qwen2_v2():
     def qwen2_cat_fusion_2(fd: FusionDefinition) -> None:


### PR DESCRIPTION
Fixes #4984 

Output tensor from boadcast should have the rank of broadcast vector instead of input tensor.