### PR TITLE
Add a default .pre-commit-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ python/nvfuser_direct/*.so
 *.log
 foo.bin
 
-# Config for https://pre-commit.com/
-.pre-commit-config.yaml
-
 *_generated.*
 
 # Mac OS internal file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lintrunner
+        name: Run lintrunner
+        # CLANGTIDY takes dozens of seconds to run and is therefore skipped
+        entry: lintrunner --skip CLANGTIDY -a
+        language: system


### PR DESCRIPTION
Running lintrunner pre commit reduces the time developers spend fixing lint errors in CI.

This was initially suggested by
https://github.com/NVIDIA/Fuser/pull/958#issuecomment-1738326868, but I had never got a chance to add it.

I don't think this config is highly environment-specific, but let me know if you prefer not checking in the config. As a reference, Thunder has .pre-commit-config.yaml checked in as well.