### PR TITLE
Remove expanded_extents from ExpandOp

### DIFF
--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1528,11 +1528,7 @@ class NVF_API ExpandOp : public Expr {
  public:
   using Expr::Expr;
 
-  ExpandOp(
-      IrBuilderPasskey,
-      TensorView* out,
-      TensorView* in,
-      std::vector<Val*> _expanded_extents);
+  ExpandOp(IrBuilderPasskey, TensorView* out, TensorView* in);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
@@ -1549,10 +1545,6 @@ class NVF_API ExpandOp : public Expr {
 
   TensorView* in() const {
     return input(0)->as<TensorView>();
-  }
-
-  std::vector<Val*> expanded_extents() const {
-    return {inputs().begin() + 1, inputs().end()};
   }
 
   std::vector<PolymorphicValue> evaluate(

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1528,7 +1528,11 @@ class NVF_API ExpandOp : public Expr {
  public:
   using Expr::Expr;
 
-  ExpandOp(IrBuilderPasskey, TensorView* out, TensorView* in);
+  ExpandOp(
+      IrBuilderPasskey,
+      TensorView* out,
+      TensorView* in,
+      const std::vector<Val*>& expanded_extents);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2163,29 +2163,16 @@ void MmaOp::setMacro(MmaMacro macro) {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)
 
-ExpandOp::ExpandOp(
-    IrBuilderPasskey passkey,
-    TensorView* out,
-    TensorView* in,
-    std::vector<Val*> _expanded_extents)
+ExpandOp::ExpandOp(IrBuilderPasskey passkey, TensorView* out, TensorView* in)
     : Expr(passkey) {
   addOutput(out);
   addInput(in);
-  for (auto expanded_extent : _expanded_extents) {
-    NVF_ERROR(expanded_extent != nullptr);
-    NVF_ERROR(
-        expanded_extent->dtype() == DataType::Index,
-        "Expanded extents must be of index type.");
-    addInput(expanded_extent);
-  }
 }
 
 std::string ExpandOp::toString(int indent_size) const {
   std::stringstream ss;
-  indent(ss, indent_size) << out()->toString() << " = expand( " << in()
-                          << ", {";
-  ss << toDelimitedString(expanded_extents());
-  ss << "} )\n";
+  indent(ss, indent_size) << out()->toString() << " = expand( " << in() << " )"
+                          << std::endl;
   return ss.str();
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2163,10 +2163,20 @@ void MmaOp::setMacro(MmaMacro macro) {
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(MmaOp)
 
-ExpandOp::ExpandOp(IrBuilderPasskey passkey, TensorView* out, TensorView* in)
+ExpandOp::ExpandOp(
+    IrBuilderPasskey passkey,
+    TensorView* out,
+    TensorView* in,
+    const std::vector<Val*>& expanded_extents)
     : Expr(passkey) {
   addOutput(out);
   addInput(in);
+  for (auto* expanded_extent : expanded_extents) {
+    NVF_ERROR(expanded_extent != nullptr);
+    NVF_ERROR_EQ(
+        expanded_extent->dtype(), DataType::Index, "Found ", expanded_extent);
+    addInput(expanded_extent);
+  }
 }
 
 std::string ExpandOp::toString(int indent_size) const {

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -1142,7 +1142,7 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
   if (!expanded) {
     IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, inp);
   } else {
-    IrBuilder::create<ExpandOp>(out, inp);
+    IrBuilder::create<ExpandOp>(out, inp, maybe_expanded_sizes);
   }
   return out;
 }
@@ -1203,7 +1203,7 @@ TensorView* expand_as(TensorView* inp, TensorView* other) {
   if (!expanded) {
     IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, inp);
   } else {
-    IrBuilder::create<ExpandOp>(out, inp);
+    IrBuilder::create<ExpandOp>(out, inp, maybe_expanded_sizes);
   }
   return out;
 }

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -1135,16 +1135,16 @@ TensorView* expand(TensorView* inp, const std::vector<Val*>& expanded_sizes) {
     out_domain.push_back(out_id_builder.build());
   }
 
-  TensorView* out_tensor = IrBuilder::create<TensorView>(
+  auto* out = IrBuilder::create<TensorView>(
       IrBuilder::create<TensorDomain>(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
   if (!expanded) {
-    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_tensor, inp);
+    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, inp);
   } else {
-    IrBuilder::create<ExpandOp>(out_tensor, inp, maybe_expanded_sizes);
+    IrBuilder::create<ExpandOp>(out, inp);
   }
-  return out_tensor;
+  return out;
 }
 
 TensorView* expand_as(TensorView* inp, TensorView* other) {
@@ -1196,16 +1196,16 @@ TensorView* expand_as(TensorView* inp, TensorView* other) {
     maybe_expanded_sizes.push_back(maybe_expanded_size);
   }
 
-  TensorView* out_tensor = IrBuilder::create<TensorView>(
+  auto* out = IrBuilder::create<TensorView>(
       IrBuilder::create<TensorDomain>(
           out_domain, TensorDomain::getContiguityFilledWith(out_domain, true)),
       inp->getDataType().value());
   if (!expanded) {
-    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out_tensor, inp);
+    IrBuilder::create<LoadStoreOp>(LoadStoreOpType::Set, out, inp);
   } else {
-    IrBuilder::create<ExpandOp>(out_tensor, inp, maybe_expanded_sizes);
+    IrBuilder::create<ExpandOp>(out, inp);
   }
-  return out_tensor;
+  return out;
 }
 
 TensorView* repeat(


### PR DESCRIPTION
The expanded_extents API is not used after #5005 and any potential uses could have been replaced with `out()`'s logical domain sizes.