### PR TITLE
Create nvfp4 `scaled_mm` with fused blockscale quantization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(BUILD_CUTLASS)
     set(NVFUSER_CUTLASS_SRCS)
     list(APPEND NVFUSER_CUTLASS_SRCS
         ${NVFUSER_CUTLASS}/nvfp4_scaled_mm.cu
+        ${NVFUSER_CUTLASS}/nvfp4_scaled_mm_blockscale.cu
         ${NVFUSER_CUTLASS}/nvfp4_scaled_group_mm.cu
         ${NVFUSER_CUTLASS}/nvf_cutlass.cpp
         ${NVFUSER_CUTLASS}/cutlass_utils.cpp

--- a/cutlass/nvf_cutlass.h
+++ b/cutlass/nvf_cutlass.h
@@ -13,9 +13,14 @@
 
 namespace nvfuser::cutlass_kernels {
 
+// Helper function to compute ceil(x / y)
+inline int64_t ceilDiv(int64_t x, int64_t y) {
+  return (x + y - 1) / y;
+}
+
 // Helper function to round up to the nearest multiple of y
-inline int64_t roundUp(int64_t x, int64_t y = 1) {
-  return (x + y - 1) / y * y;
+inline int64_t roundUp(int64_t x, int64_t y) {
+  return ceilDiv(x, y) * y;
 }
 
 // Validates all input parameters and tensor properties for NVFP4 scaled matrix
@@ -44,7 +49,7 @@ NVF_API std::tuple<int64_t, int64_t, int64_t> validateInputsNvfp4ScaledMm(
     const torch::Tensor& alpha,
     bool skip_checks = false);
 
-// Performs scaled matrix multiplication using NVFP4 format
+// Performs scaled matrix multiplication using NVFP4 format.
 //
 // This function implements a scaled matrix multiplication C = alpha * (A @ B)
 // where A and B are matrices in NVFP4 format with per-block scaling factors.
@@ -69,7 +74,8 @@ NVF_API torch::Tensor nvfp4_scaled_mm(
     at::ScalarType out_dtype,
     bool skip_checks = false);
 
-// Performs scaled matrix multiplication using NVFP4 format
+// Performs scaled matrix multiplication using NVFP4 format with fused epilogue
+// blockscale quantization.
 //
 // This function implements a scaled matrix multiplication C = alpha * (A @ B)
 // where A and B are matrices in NVFP4 format with per-block scaling factors.

--- a/cutlass/nvf_cutlass.h
+++ b/cutlass/nvf_cutlass.h
@@ -14,7 +14,7 @@
 namespace nvfuser::cutlass_kernels {
 
 // Helper function to round up to the nearest multiple of y
-inline int64_t roundUp(int64_t x, int64_t y) {
+inline int64_t roundUp(int64_t x, int64_t y = 1) {
   return (x + y - 1) / y * y;
 }
 
@@ -56,7 +56,7 @@ NVF_API std::tuple<int64_t, int64_t, int64_t> validateInputsNvfp4ScaledMm(
 //   b: Input matrix B in Float4_e2m1fn_x2 format (N x K/2)
 //   scales_a: Per-block scaling factors for matrix A in FP8_E4M3 format
 //   scales_b: Per-block scaling factors for matrix B in FP8_E4M3 format
-//   alpha: Global scaling factor in FP32 format
+//   alpha: Combined global scaling factor for operands A and B in FP32 format
 //   out_dtype: Output data type (Half, BFloat16, or Float)
 //
 // Returns: Matrix C = alpha * (A @ B) in the specified output dtype
@@ -69,13 +69,31 @@ NVF_API torch::Tensor nvfp4_scaled_mm(
     at::ScalarType out_dtype,
     bool skip_checks = false);
 
-NVF_API std::pair<torch::Tensor, torch::Tensor> nvfp4_scaled_mm_epilogue(
+// Performs scaled matrix multiplication using NVFP4 format
+//
+// This function implements a scaled matrix multiplication C = alpha * (A @ B)
+// where A and B are matrices in NVFP4 format with per-block scaling factors.
+// The function uses CUTLASS kernels optimized for NVIDIA GPUs with SM100+
+// architecture.
+//
+// Parameters:
+//   a: Input matrix A in Float4_e2m1fn_x2 format (M x K/2)
+//   b: Input matrix B in Float4_e2m1fn_x2 format (N x K/2)
+//   scales_a: Per-block scaling factors for matrix A in FP8_E4M3 format
+//   scales_b: Per-block scaling factors for matrix B in FP8_E4M3 format
+//   alpha: Combined global scaling factor for operands A and B in FP32 format
+//   global_normconst: Global scaling factor for output matrix C in FP32 format
+//
+// Returns: A tuple of nvfp4 output matrix and blockscale factor.
+//  * Matrix C = alpha * (A @ B) in Float4_e2m1fn_x2 format (M x N/2)
+//  * Blockscale factor for Matrix C in Float8_e4m3fn format
+NVF_API std::pair<torch::Tensor, torch::Tensor> nvfp4_scaled_mm_blockscale(
     const torch::Tensor& a,
     const torch::Tensor& b,
     const torch::Tensor& scales_a,
     const torch::Tensor& scales_b,
     const torch::Tensor& alpha,
-    at::ScalarType out_dtype,
+    const torch::Tensor& global_normconst,
     bool skip_checks = false);
 
 void nvfp4_scaled_grouped_mm(

--- a/cutlass/nvfp4_scaled_mm_blockscale.cu
+++ b/cutlass/nvfp4_scaled_mm_blockscale.cu
@@ -345,7 +345,7 @@ std::pair<torch::Tensor, torch::Tensor> nvfp4_scaled_mm_blockscale(
                             .dtype(at::ScalarType::Float4_e2m1fn_x2)
                             .device(at::kCUDA, a.get_device());
   // Only half the number of elements in inner-most dimension for packed format.
-  torch::Tensor output = at::empty({m, roundUp(n / 2)}, output_options);
+  torch::Tensor output = at::empty({m, ceilDiv(n, 2)}, output_options);
 
   auto blockscale_options = at::TensorOptions()
                                 .dtype(at::ScalarType::Float8_e4m3fn)

--- a/cutlass/nvfp4_scaled_mm_blockscale.cu
+++ b/cutlass/nvfp4_scaled_mm_blockscale.cu
@@ -1,0 +1,372 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <cutlass_utils.h>
+#include <exceptions.h>
+#include <nvf_cutlass.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/torch.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/kernel/tile_scheduler_params.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/packed_stride.hpp"
+
+namespace nvfuser::cutlass_kernels {
+
+namespace {
+
+using namespace cute;
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+// Kernel configuration traits for different output data types
+// Defines tile shapes and cluster configurations.
+template <typename T>
+struct KernelTraits;
+
+// Kernel traits for NVFP4 output
+template <>
+struct KernelTraits<cutlass::float_e2m1_t> {
+  using MmaTileShape = Shape<_128, _128, _256>;
+  using ClusterShape = Shape<_1, _1, _1>;
+};
+
+// Main GEMM configuration for NVFP4 scaled matrix multiplication on SM100+
+// Defines all the types, layouts, and configurations needed for the CUTLASS
+// kernel
+template <typename T>
+struct Fp4GemmSm100 {
+  // A matrix configuration
+  using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+  using LayoutATag = cutlass::layout::RowMajor;
+  static constexpr int AlignmentA = 32;
+
+  // B matrix configuration
+  using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
+  using LayoutBTag = cutlass::layout::ColumnMajor;
+  static constexpr int AlignmentB = 32;
+
+  // C/D matrix configuration
+  using ElementD = cutlass::float_e2m1_t;
+  using ElementC = cutlass::float_e2m1_t;
+  using ElementSFD = cutlass::float_e4m3_t;
+  using LayoutCTag = cutlass::layout::RowMajor;
+  using LayoutDTag = cutlass::layout::RowMajor;
+  using LayoutSFDTag = LayoutDTag;
+
+  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+
+  // Kernel functional config
+  using ElementAccumulator = float;
+  using ElementCompute = float;
+  using ArchTag = cutlass::arch::Sm100;
+  using OperatorClass = cutlass::arch::OpClassBlockScaledTensorOp;
+
+  // Kernel Perf config
+  using MmaTileShape = typename KernelTraits<T>::MmaTileShape;
+  using ClusterShape = typename KernelTraits<T>::ClusterShape;
+
+  static constexpr int InputSFVectorSize = 16;
+  static constexpr int OutputSFVectorSize = InputSFVectorSize;
+
+  // D = alpha * acc + beta * C
+  // With BlockScaleFactor generation.
+  using FusionOperation = cutlass::epilogue::fusion::LinCombBlockScaleFactor<
+      OutputSFVectorSize,
+      ElementD,
+      ElementCompute,
+      ElementSFD,
+      LayoutSFDTag,
+      ElementC>;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAccumulator,
+          ElementAccumulator,
+          ElementC,
+          LayoutCTag,
+          AlignmentC,
+          ElementD,
+          LayoutDTag,
+          AlignmentD,
+          cutlass::epilogue::collective::EpilogueScheduleAuto,
+          FusionOperation>::CollectiveOp;
+
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          ArchTag,
+          OperatorClass,
+          ElementA,
+          LayoutATag,
+          AlignmentA,
+          ElementB,
+          LayoutBTag,
+          AlignmentB,
+          ElementAccumulator,
+          MmaTileShape,
+          ClusterShape,
+          cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+              sizeof(typename CollectiveEpilogue::SharedStorage))>,
+          cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int, int, int, int>,
+      CollectiveMainloop,
+      CollectiveEpilogue,
+      void>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  // Reference device GEMM implementation type
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using LayoutA = decltype(cute::make_layout(make_shape(0, 0, 0), StrideA{}));
+  using LayoutSFA = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using LayoutB = decltype(cute::make_layout(make_shape(0, 0, 0), StrideB{}));
+  using LayoutSFB = typename Gemm::GemmKernel::CollectiveMainloop::LayoutSFB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using LayoutC = decltype(cute::make_layout(make_shape(0, 0, 0), StrideC{}));
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+  using LayoutD = decltype(cute::make_layout(make_shape(0, 0, 0), StrideD{}));
+
+  using FusionOp = typename Gemm::EpilogueOutputOp;
+  static constexpr bool IsBlockScaleSupported = FusionOp::IsBlockScaleSupported;
+  using SfdOutputCfg =
+      cutlass::detail::Sm1xxBlockScaledOutputConfig<OutputSFVectorSize>;
+  using LayoutSFD = typename SfdOutputCfg::LayoutSF;
+};
+
+// Constructs CUTLASS GEMM arguments from PyTorch tensors and dimensions
+//
+// This function converts PyTorch tensor data and metadata into the format
+// expected by CUTLASS GEMM kernels, including proper stride calculations
+// and layout configurations for the scaled matrix multiplication.
+//
+// Parameters:
+//   output: Output tensor for storing matmul results
+//   output_blockscale: Output tensor to store nvfp4 blockscale factor
+//   a: Input matrix A in NVFP4 format
+//   b: Input matrix B in NVFP4 format
+//   scales_a: Per-block scaling factors for matrix A
+//   scales_b: Per-block scaling factors for matrix B
+//   alpha: Global scaling factor for operands A and B
+//   global_normconst: Global scaling factor for output blockscaling
+//   M, N, K: Matrix dimensions
+//
+// Returns: CUTLASS GEMM arguments structure ready for kernel execution
+template <typename T>
+typename T::Gemm::Arguments args_from_options(
+    at::Tensor& output,
+    at::Tensor& output_blockscale,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& scales_a,
+    const at::Tensor& scales_b,
+    const at::Tensor& alpha,
+    const at::Tensor& global_normconst,
+    int64_t M,
+    int64_t N,
+    int64_t K) {
+  using ElementA = typename T::Gemm::ElementA;
+  using ElementB = typename T::Gemm::ElementB;
+  using ElementSFA = cutlass::float_ue4m3_t;
+  using ElementSFB = cutlass::float_ue4m3_t;
+  using ElementD = typename T::Gemm::ElementD;
+  using ElementSFD = cutlass::float_e4m3_t;
+  using ElementCompute = float;
+  using StrideA = typename T::StrideA;
+  using StrideB = typename T::StrideB;
+  using StrideD = typename T::StrideD;
+  using Sm1xxBlkScaledConfig =
+      typename T::Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+
+  int m = static_cast<int>(M);
+  int n = static_cast<int>(N);
+  int k = static_cast<int>(K);
+  auto stride_A = cutlass::make_cute_packed_stride(StrideA{}, {m, k, 1});
+  auto stride_B = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
+  auto stride_D = cutlass::make_cute_packed_stride(StrideD{}, {m, n, 1});
+
+  auto layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(
+      cute::make_shape(m, n, k, 1));
+  auto layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(
+      cute::make_shape(m, n, k, 1));
+
+  typename T::Gemm::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      {m, n, k, 1},
+      {// Mainloop arguments
+       static_cast<ElementA const*>(a.data_ptr()),
+       stride_A,
+       static_cast<ElementB const*>(b.data_ptr()),
+       stride_B,
+       static_cast<ElementSFA const*>(scales_a.data_ptr()),
+       layout_SFA,
+       static_cast<ElementSFB const*>(scales_b.data_ptr()),
+       layout_SFB},
+      {// Epilogue arguments
+       {}, // epilogue.thread
+       static_cast<ElementD const*>(output.data_ptr()),
+       stride_D,
+       static_cast<ElementD*>(output.data_ptr()),
+       stride_D}};
+  auto& fusion_args = arguments.epilogue.thread;
+  fusion_args.alpha_ptr = static_cast<ElementCompute const*>(alpha.data_ptr());
+
+  if constexpr (T::IsBlockScaleSupported) {
+    arguments.epilogue.thread.block_scale_factor_ptr =
+        static_cast<ElementSFD*>(output_blockscale.data_ptr());
+    // Matrix-wide normalization constant
+    arguments.epilogue.thread.norm_constant_ptr =
+        static_cast<ElementCompute const*>(global_normconst.data_ptr());
+  }
+  return arguments;
+}
+
+// Executes the FP4 scaled matrix multiplication using CUTLASS kernels
+//
+// This function orchestrates the GEMM operation by setting up the kernel,
+// allocating workspace memory, and running the computation on the GPU.
+// It handles the complete lifecycle from kernel initialization to execution.
+//
+// Parameters:
+//   output: Output tensor to store the matmul result
+//   output_blockscale: Output tensor to store nvfp4 blockscale factor
+//   a, b: Input matrices in FP4 format
+//   scales_a, scales_b: Per-block scaling factors
+//   alpha: Global scaling factor
+//   global_normconst: Global scaling factor for output blockscaling
+//   m, n, k: Matrix dimensions
+//   stream: CUDA stream for asynchronous execution
+template <typename T>
+void runGemm(
+    at::Tensor& output,
+    at::Tensor& output_blockscale,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& scales_a,
+    const at::Tensor& scales_b,
+    const at::Tensor& alpha,
+    const at::Tensor& global_normconst,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    cudaStream_t stream) {
+  typename Fp4GemmSm100<T>::Gemm gemm;
+
+  auto arguments = args_from_options<Fp4GemmSm100<T>>(
+      output,
+      output_blockscale,
+      a,
+      b,
+      scales_a,
+      scales_b,
+      alpha,
+      global_normconst,
+      m,
+      n,
+      k);
+
+  size_t workspace_size = Fp4GemmSm100<T>::Gemm::get_workspace_size(arguments);
+  auto const workspace_options =
+      torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+  auto workspace = torch::empty(workspace_size, workspace_options);
+
+  auto can_implement_status = gemm.can_implement(arguments);
+  NVF_CHECK(
+      can_implement_status == cutlass::Status::kSuccess,
+      "Failed to implement GEMM");
+
+  auto status = gemm.initialize(arguments, workspace.data_ptr(), stream);
+  NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
+
+  status = gemm.run(arguments, workspace.data_ptr(), stream);
+  NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
+}
+#else
+// Fallback implementation for unsupported CUTLASS versions
+// Throws an error when SM100+ CUTLASS support is not available
+template <typename T>
+void runGemm(
+    at::Tensor& output,
+    at::Tensor& output_blockscale,
+    at::Tensor const& a,
+    at::Tensor const& b,
+    at::Tensor const& scales_a,
+    at::Tensor const& scales_b,
+    at::Tensor const& alpha,
+    at::Tensor const& global_normconst,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    cudaStream_t stream) {
+  NVF_THROW("Unsupported CUTLASS version.");
+}
+#endif // defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+} // namespace
+
+std::pair<torch::Tensor, torch::Tensor> nvfp4_scaled_mm_blockscale(
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& scales_a,
+    const torch::Tensor& scales_b,
+    const torch::Tensor& alpha,
+    const torch::Tensor& global_normconst,
+    bool skip_checks) {
+  // Validate all inputs and get matrix dimensions
+  auto [m, n, k] =
+      validateInputsNvfp4ScaledMm(a, b, scales_a, scales_b, alpha, skip_checks);
+
+  at::cuda::CUDAGuard device_guard{(int8_t)a.get_device()};
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  auto output_options = at::TensorOptions()
+                            .dtype(at::ScalarType::Float4_e2m1fn_x2)
+                            .device(at::kCUDA, a.get_device());
+  // Only half the number of elements in inner-most dimension for packed format.
+  torch::Tensor output = at::empty({m, roundUp(n / 2)}, output_options);
+
+  auto blockscale_options = at::TensorOptions()
+                                .dtype(at::ScalarType::Float8_e4m3fn)
+                                .device(at::kCUDA, a.get_device());
+  torch::Tensor output_blockscale =
+      at::empty({m, roundUp(n / 16, 4)}, blockscale_options);
+
+  runGemm<cutlass::float_e2m1_t>(
+      output,
+      output_blockscale,
+      a,
+      b,
+      scales_a,
+      scales_b,
+      alpha,
+      global_normconst,
+      m,
+      n,
+      k,
+      stream);
+  return std::make_pair(output, output_blockscale);
+}
+
+} // namespace nvfuser::cutlass_kernels

--- a/python/python_direct/cutlass.cpp
+++ b/python/python_direct/cutlass.cpp
@@ -26,7 +26,8 @@ void bindGemm(py::module_& cutlass) {
         return cutlass_kernels::nvfp4_scaled_mm(
             a, b, scales_a, scales_b, alpha, out_dtype);
       },
-      R"(nvfp4_scaled_mm(Tensor a,
+      R"(Computes nvfp4 matmul and returns bf16, fp16, or fp32 output tensor.
+         nvfp4_scaled_mm(Tensor a,
                          Tensor b,
                          Tensor scales_a,
                          Tensor scales_b,
@@ -47,7 +48,9 @@ void bindGemm(py::module_& cutlass) {
                 a_nvfp4, b_nvfp4, scales_a, scales_b, alpha, global_normconst);
         return py::make_tuple(output.first, output.second);
       },
-      R"(nvfp4_scaled_mm_blockscale(Tensor a_nvfp4,
+      R"(Computes nvfp4 matmul and blockscale quantization. It returns nvfp4
+         output tensor and its blockscale factor.
+         nvfp4_scaled_mm_blockscale(Tensor a_nvfp4,
                                     Tensor b_nvfp4,
                                     Tensor scales_a,
                                     Tensor scales_b,

--- a/tests/python/direct/test_cutlass_nvfp4_gemm.py
+++ b/tests/python/direct/test_cutlass_nvfp4_gemm.py
@@ -19,6 +19,7 @@ from python.utils import (
     dequantize_to_dtype,
     linear_to_swizzled_128_4,
     pytorch_nvfp4_quantize,
+    unpack_fp4_bytes,
 )
 
 
@@ -93,3 +94,78 @@ def test_nvfp4_gemm(
     )
 
     torch.testing.assert_close(out, expected_out.to(dtype=dtype), atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "shape", [(128, 128, 64), (128, 128, 128), (256, 128, 64), (128, 256, 128)]
+)
+@torch.inference_mode()
+def test_nvfp4_gemm_epilogue(
+    dtype: torch.dtype,
+    shape: tuple[int, int, int],
+) -> None:
+    m, n, packed_k = shape
+    k = packed_k * 2
+    block_size = 16
+    a_dtype = torch.randn((m, k), dtype=dtype, device="cuda")
+    b_dtype = torch.randn((n, k), dtype=dtype, device="cuda")
+
+    a_global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(a_dtype.flatten(), dim=-1)
+    ).to(torch.float32)
+    b_global_scale = (
+        (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.amax(b_dtype.flatten(), dim=-1)
+    ).to(torch.float32)
+    alpha = 1.0 / (a_global_scale * b_global_scale)
+    global_normconst = torch.tensor(2, dtype=torch.float, device="cuda")
+
+    a_fp4, a_scale_linear = pytorch_nvfp4_quantize(a_dtype, a_global_scale)
+    b_fp4, b_scale_linear = pytorch_nvfp4_quantize(b_dtype, b_global_scale)
+    a_scale_interleaved = linear_to_swizzled_128_4(a_scale_linear)
+    b_scale_interleaved = linear_to_swizzled_128_4(b_scale_linear)
+
+    expected_out = get_ref_results(
+        a_fp4,
+        b_fp4,
+        a_scale_interleaved,
+        b_scale_interleaved,
+        a_global_scale,
+        b_global_scale,
+        m,
+        n,
+        dtype,
+        block_size,
+        "cuda",
+    )
+
+    expected_out_fp4, expected_out_scale_linear = pytorch_nvfp4_quantize(
+        expected_out, global_normconst
+    )
+    expected_out_scale_interleaved = linear_to_swizzled_128_4(expected_out_scale_linear)
+
+    out_fp4, out_scale_interleaved = nvf_cutlass.nvfp4_scaled_mm_blockscale(
+        a_fp4, b_fp4, a_scale_interleaved, b_scale_interleaved, alpha, global_normconst
+    )
+
+    # Convert to unpacked fp32 to check nvfp4 tensors.
+    expected_out_fp32 = unpack_fp4_bytes(expected_out_fp4, torch.float32)
+    out_fp32 = unpack_fp4_bytes(out_fp4, torch.float32)
+
+    # The absolute max difference is 2.0.
+    abs_diff = torch.abs(expected_out_fp32 - out_fp32)
+    assert torch.max(abs_diff) <= 2.0
+
+    # The percentage of mismatched values is 1%.
+    nonzero = torch.count_nonzero(torch.ne(abs_diff, 0.0))
+    assert (nonzero / abs_diff.numel()) < 0.01
+
+    # Compare scale factors
+    # rtol = epsilon = 2**(-3) for fp8_m4e3
+    # atol = 2**(num_exponent_bits + smallest_exponent_value)
+    torch.testing.assert_close(
+        out_scale_interleaved.to(torch.float),
+        expected_out_scale_interleaved.to(torch.float),
+        atol=2e-3,
+        rtol=0.125,
+    )


### PR DESCRIPTION
This PR creates a nvfp4 `scaled_mm` with blockscale quantization fused in the epilogue. The kernel returns an `nvfp4` output along with the `fp8` blockscale factor.

The epilogue builder uses `cutlass::epilogue::fusion::LinCombBlockScaleFactor`, which implements `D = alpha * acc + beta * C with BlockScaleFactor generation`.