### PR TITLE
Add document code snippet check functionality

### DIFF
--- a/csrc/serde/Serde.md
+++ b/csrc/serde/Serde.md
@@ -120,13 +120,13 @@ def fusion(fd: FusionDefinition):
 
 # Corresponding FusionCache Trie Structure
 
-1. StartRecord
-2. TensorRecord --- t0
-3. ScalarRecord --- c0
-3. FullOpRecord --- t1
-4. OpRecord<TensorView*, TensorView*, TensorView*> --- t2
-4. OutputRecord
-5. EndRecord
+# 1. StartRecord
+# 2. TensorRecord --- t0
+# 3. ScalarRecord --- c0
+# 4. FullOpRecord --- t1
+# 5. OpRecord<TensorView*, TensorView*, TensorView*> --- t2
+# 6. OutputRecord
+# 7. EndRecord
 ```
 # Serialization Overview
 

--- a/doc/dev/host_ir_jit.md
+++ b/doc/dev/host_ir_jit.md
@@ -104,11 +104,11 @@ Otherwise the default runtime is Host IR Evaluator. In the future, when llvm is 
 to get rid of this opt-in flag and rather use `enableOption` to control backend switching after build is done.
 
 Sample build
-```python
+```bash
 NVFUSER_HOST_IR_JIT=1 pip install --no-build-isolation -e python -v
 ```
 or
-```python
+```bash
 NVFUSER_HOST_IR_JIT=1 _bn
 ```
 ## Future Integration plan

--- a/doc/dev/tmem.md
+++ b/doc/dev/tmem.md
@@ -300,6 +300,7 @@ right are for the column.
 In the above example, the allocation domain, contiguity, and stride of the
 tensor could be:
 
+<!-- CI IGNORE -->
 ```python
 allocation domain: [ BIDx,  4, 16, | , BIDy, 8 ]
        contiguity: [    ?,  F,  T, | ,    ?, T ]
@@ -362,6 +363,7 @@ TEST_F(TMemTutorialC, TooManyLanes) {
 ```
 
 In the above example, the fusion is scheduled as:
+<!-- CI IGNORE -->
 ```python
 [BIDx{2}, TIDx{3}, 5, (CA), BIDy{7}, TIDy{11}, 13, (DimSep), 17]
 ```
@@ -411,6 +413,7 @@ TEST_F(TMemTutorialC, TooManyCols) {
 ```
 
 In the above example, the fusion is scheduled as:
+<!-- CI IGNORE -->
 ```python
 [TIDx{32}, (DimSep), BIDx{3}, TIDy{5}, 7, (CA), BIDy{11}, TIDz{13}, 17]
 ```

--- a/doc/reading/divisibility-of-split.md
+++ b/doc/reading/divisibility-of-split.md
@@ -292,6 +292,7 @@ We can see this from a simple example where there is a tensor `T[I1, I2]`,
 For transformation 1, after schedule, the extents of the loop domain `[I4, I5]` will be `[2*2, 4]`.
 We will be iterating the tensor as the following Listing 1:
 
+<!-- CI IGNORE -->
 ```python
 T[0, 0], T[0, 1], T[0, 2] , T[0, 3]
 T[0, 4], T[0, 5], T[0, 6] , T[0, 7]
@@ -302,6 +303,7 @@ T[1, 4], T[1, 5], T[1, 6] , T[1, 7]
 For transformation 2, after schedule, the extents of the loop domain `[I4, I5]` will be `[3, 4]`.
 We will be iterating the tensor as as the following Listing 2:
 
+<!-- CI IGNORE -->
 ```python
 T[0, 0], T[0, 1], T[0, 2] , T[0, 3]
 T[0, 4], T[1, 0], T[1, 1] , T[1, 2]

--- a/python/nvfuser/README.md
+++ b/python/nvfuser/README.md
@@ -37,6 +37,7 @@ nvf_out = fd.execute([input1, input2])[0]
 
 ## Example 2 - Lookup and Execute a `FusionDefinition` Based on Id
 
+<!-- CI IGNORE -->
 ```python
 fid = 0
 fd = FusionDefinition(fid)
@@ -100,6 +101,7 @@ c0 = fd.define_scalar(3.0)
 ```
 
 **Note**: you cannot use Python literals directly:
+<!-- CI IGNORE -->
 ```python
 # Correct - define scalar constant first
 scalar_const = fd.define_scalar(2.0)
@@ -112,23 +114,29 @@ result = fd.ops.mul(tensor, 2.0)  # ERROR!
 #### Defining Operations
 
 Operators are added with the following notation:
+<!-- CI IGNORE -->
 ```python
 output = fd.ops.foo(arg1, ... )
 ```
 
 
 You can see a supported list of operations with the following query:
-```python
+```bash
 python -c "from nvfuser import FusionDefinition; help(FusionDefinition.Operators)"
 ```
+
 #### Notating Outputs
 
-The `FusionDefinition` `add_output` method is used to indicate an intermediate is an output to the fusion.
+The `FusionDefinition` `add_output` method is used to indicate an intermediate is an output to the fusion. Output can be a tensor or a scalar.
 
 ```python
-add_output(output: Tensor)
-# or
-add_output(output: Scalar)
+t0 = fd.define_tensor(sizes=[2, 4, 6], strides=[24, 6, 1], dtype=DataType.Half)
+fd.add_output(t0)
+```
+or
+<!-- CI IGNORE -->
+```python
+fd.add_output(output: Scalar)
 ```
 
 # Complete Working Example
@@ -181,11 +189,12 @@ if __name__ == "__main__":
 
 # Debug Information
 **Query a list of supported operations:**
-```python
+```bash
 python -c "from nvfuser import FusionDefinition; help(FusionDefinition.Operators)"
 ```
 
 **Get debug information after execution:**
+<!-- CI IGNORE -->
 ```python
 # These methods require the fusion to be executed first
 print(f"Fusion ID: {fd.id()}")
@@ -194,7 +203,7 @@ print(f"Generated CUDA code:\n{fd.last_cuda_code()}")
 ```
 
 **View the fusion definitions that are executed by setting an environment variable:**
-```python
+```bash
 export NVFUSER_DUMP=python_definition
 ```
 Example Output:

--- a/tools/check_markdown_code.py
+++ b/tools/check_markdown_code.py
@@ -5,13 +5,15 @@ and executes them to ensure no errors are thrown.
 
 This script:
 1. Finds all *.md files while respecting .gitignore and excluding third_party/
-2. Extracts code blocks marked with ``` or ```python
-3. Executes Python code blocks and reports any errors
+2. Extracts code blocks marked with ```python
+3. Skips blocks preceded by <!-- CI IGNORE --> comments
+4. Uses AST analysis to detect 'fd' variable usage and auto-wraps with FusionDefinition context manager
+5. Sets __name__ = '__main__' to allow execution of main blocks
+6. Automatically imports common nvfuser modules (torch, nvfuser, FusionDefinition, DataType)
+7. Executes Python code blocks and reports any errors
 """
 
 import ast
-import os
-import re
 import sys
 import subprocess
 from pathlib import Path
@@ -25,7 +27,7 @@ def is_git_ignored(file_path: Path, repo_root: Path) -> bool:
             ["git", "check-ignore", str(file_path)],
             cwd=repo_root,
             capture_output=True,
-            text=True
+            text=True,
         )
         return result.returncode == 0
     except (subprocess.SubprocessError, FileNotFoundError):
@@ -35,118 +37,118 @@ def is_git_ignored(file_path: Path, repo_root: Path) -> bool:
 def find_markdown_files(repo_root: Path) -> List[Path]:
     """Find all *.md files recursively, excluding git-ignored and third_party/ files."""
     md_files = []
-    
+
     for md_file in repo_root.rglob("*.md"):
         # Skip third_party directory
         if "third_party" in md_file.parts:
             continue
-            
+
         # Skip git-ignored files
         if is_git_ignored(md_file, repo_root):
             continue
-            
+
         md_files.append(md_file)
-    
+
     return sorted(md_files)
 
 
 def extract_code_blocks(content: str) -> List[Tuple[str, int, str, bool]]:
     """
     Extract code blocks from markdown content.
-    
+
     Returns:
         List of tuples: (code, line_number, language, should_ignore)
     """
     code_blocks = []
-    lines = content.split('\n')
+    lines = content.split("\n")
     i = 0
-    
+
     while i < len(lines):
         line = lines[i].strip()
-        
+
         # Look for code block start
-        if line.startswith('```'):
+        if line.startswith("```"):
             start_line = i + 1
             language = line[3:].strip() if len(line) > 3 else ""
-            
+
             # Check if the previous line contains CI IGNORE comment
             should_ignore = False
             if i > 0:
                 prev_line = lines[i - 1].strip()
                 if prev_line == "<!-- CI IGNORE -->":
                     should_ignore = True
-            
+
             # Find end of code block
             i += 1
             code_lines = []
-            while i < len(lines) and not lines[i].strip().startswith('```'):
+            while i < len(lines) and not lines[i].strip().startswith("```"):
                 code_lines.append(lines[i])
                 i += 1
-            
+
             if code_lines:
-                code = '\n'.join(code_lines)
+                code = "\n".join(code_lines)
                 code_blocks.append((code, start_line, language, should_ignore))
-        
+
         i += 1
-    
+
     return code_blocks
-
-
 
 
 def analyze_code_for_fd_usage(code: str) -> bool:
     """
     Use AST to check if code uses 'fd' variable but doesn't define it.
-    
+
     Returns:
         True if code uses 'fd' but doesn't define it (needs context manager)
     """
     try:
         tree = ast.parse(code)
-        
+
         # Track if 'fd' is defined (assigned to)
         fd_defined = False
         # Track if 'fd' is used (accessed)
         fd_used = False
-        
+
         class FdAnalyzer(ast.NodeVisitor):
             def visit_Assign(self, node):
                 # Check if 'fd' is being assigned to
                 for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == 'fd':
+                    if isinstance(target, ast.Name) and target.id == "fd":
                         nonlocal fd_defined
                         fd_defined = True
                 self.generic_visit(node)
-            
+
             def visit_Name(self, node):
                 # Check if 'fd' is being accessed
-                if node.id == 'fd' and isinstance(node.ctx, ast.Load):
+                if node.id == "fd" and isinstance(node.ctx, ast.Load):
                     nonlocal fd_used
                     fd_used = True
                 self.generic_visit(node)
-            
+
             def visit_Attribute(self, node):
                 # Check for fd.something usage
-                if isinstance(node.value, ast.Name) and node.value.id == 'fd':
+                if isinstance(node.value, ast.Name) and node.value.id == "fd":
                     nonlocal fd_used
                     fd_used = True
                 self.generic_visit(node)
-        
+
         analyzer = FdAnalyzer()
         analyzer.visit(tree)
-        
+
         # Return True if fd is used but not defined
         return fd_used and not fd_defined
-        
+
     except SyntaxError:
         # If code has syntax errors, don't try to wrap it
         return False
 
 
-def execute_python_code(code: str, file_path: Path, line_number: int) -> Tuple[bool, str]:
+def execute_python_code(
+    code: str, file_path: Path, line_number: int
+) -> Tuple[bool, str]:
     """
     Execute Python code and return success status and error message.
-    
+
     Returns:
         Tuple of (success, error_message)
     """
@@ -159,29 +161,29 @@ import nvfuser
 from nvfuser import FusionDefinition, DataType
 __name__ = '__main__'
 """
-        
+
         # Check if we need to wrap with FusionDefinition context manager
         if analyze_code_for_fd_usage(code):
             # Indent the code and wrap with context manager
-            indented_code = '\n'.join('    ' + line for line in code.split('\n'))
+            indented_code = "\n".join("    " + line for line in code.split("\n"))
             full_code = imports + "\nwith FusionDefinition() as fd:\n" + indented_code
         else:
             # Just prepend imports
             full_code = imports + "\n" + code
-        
+
         # Execute the code using python -c
         result = subprocess.run(
             [sys.executable, "-c", full_code],
             capture_output=True,
             text=True,
-            timeout=30  # 30 second timeout
+            timeout=30,  # 30 second timeout
         )
-        
+
         if result.returncode == 0:
             return True, ""
         else:
             return False, result.stderr.strip()
-            
+
     except subprocess.TimeoutExpired:
         return False, "Code execution timed out (30s)"
     except Exception as e:
@@ -191,65 +193,67 @@ __name__ = '__main__'
 def main():
     """Main function to run the markdown code check."""
     repo_root = Path(__file__).parent.parent  # Assume script is in tools/
-    
+
     print("🔍 Finding markdown files...")
     md_files = find_markdown_files(repo_root)
     print(f"Found {len(md_files)} markdown files to check")
-    
+
     total_code_blocks = 0
     total_python_blocks = 0
     failed_blocks = 0
     errors: List[Dict] = []
-    
+
     for md_file in md_files:
         print(f"📄 Checking {md_file.relative_to(repo_root)}")
-        
+
         try:
-            content = md_file.read_text(encoding='utf-8')
+            content = md_file.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             print(f"⚠️  Skipping {md_file} - encoding error")
             continue
-        
+
         code_blocks = extract_code_blocks(content)
         total_code_blocks += len(code_blocks)
-        
+
         for code, line_number, language, should_ignore in code_blocks:
             if language == "python":
                 if should_ignore:
-                    print(f"  ⏭️ Skipping Python code at line {line_number} (CI IGNORE)")
+                    print(
+                        f"  ⏭️ Skipping Python code at line {line_number} (CI IGNORE)"
+                    )
                     continue
-                    
+
                 total_python_blocks += 1
                 print(f"  🐍 Executing Python code at line {line_number}")
-                
+
                 success, error_msg = execute_python_code(code, md_file, line_number)
-                
+
                 if not success:
                     failed_blocks += 1
                     error_info = {
-                        'file': md_file,
-                        'line': line_number,
-                        'error': error_msg,
-                        'code': code[:200] + '...' if len(code) > 200 else code
+                        "file": md_file,
+                        "line": line_number,
+                        "error": error_msg,
+                        "code": code[:200] + "..." if len(code) > 200 else code,
                     }
                     errors.append(error_info)
                     print(f"    ❌ Error: {error_msg}")
                 else:
-                    print(f"    ✅ OK")
-    
+                    print("    ✅ OK")
+
     # Print summary
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("📊 SUMMARY")
-    print("="*60)
+    print("=" * 60)
     print(f"Markdown files checked: {len(md_files)}")
     print(f"Total code blocks found: {total_code_blocks}")
     print(f"Python code blocks executed: {total_python_blocks}")
     print(f"Failed executions: {failed_blocks}")
-    
+
     if errors:
         return 1
     else:
-        print(f"\n✅ All Python code blocks executed successfully!")
+        print("\n✅ All Python code blocks executed successfully!")
         return 0
 
 

--- a/tools/check_markdown_code.py
+++ b/tools/check_markdown_code.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""
+CI check script that reads all *.md files recursively, extracts Python code blocks,
+and executes them to ensure no errors are thrown.
+
+This script:
+1. Finds all *.md files while respecting .gitignore and excluding third_party/
+2. Extracts code blocks marked with ``` or ```python
+3. Executes Python code blocks and reports any errors
+"""
+
+import ast
+import os
+import re
+import sys
+import subprocess
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+
+def is_git_ignored(file_path: Path, repo_root: Path) -> bool:
+    """Check if a file is git-ignored using git check-ignore."""
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", str(file_path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+
+
+def find_markdown_files(repo_root: Path) -> List[Path]:
+    """Find all *.md files recursively, excluding git-ignored and third_party/ files."""
+    md_files = []
+    
+    for md_file in repo_root.rglob("*.md"):
+        # Skip third_party directory
+        if "third_party" in md_file.parts:
+            continue
+            
+        # Skip git-ignored files
+        if is_git_ignored(md_file, repo_root):
+            continue
+            
+        md_files.append(md_file)
+    
+    return sorted(md_files)
+
+
+def extract_code_blocks(content: str) -> List[Tuple[str, int, str, bool]]:
+    """
+    Extract code blocks from markdown content.
+    
+    Returns:
+        List of tuples: (code, line_number, language, should_ignore)
+    """
+    code_blocks = []
+    lines = content.split('\n')
+    i = 0
+    
+    while i < len(lines):
+        line = lines[i].strip()
+        
+        # Look for code block start
+        if line.startswith('```'):
+            start_line = i + 1
+            language = line[3:].strip() if len(line) > 3 else ""
+            
+            # Check if the previous line contains CI IGNORE comment
+            should_ignore = False
+            if i > 0:
+                prev_line = lines[i - 1].strip()
+                if prev_line == "<!-- CI IGNORE -->":
+                    should_ignore = True
+            
+            # Find end of code block
+            i += 1
+            code_lines = []
+            while i < len(lines) and not lines[i].strip().startswith('```'):
+                code_lines.append(lines[i])
+                i += 1
+            
+            if code_lines:
+                code = '\n'.join(code_lines)
+                code_blocks.append((code, start_line, language, should_ignore))
+        
+        i += 1
+    
+    return code_blocks
+
+
+
+
+def analyze_code_for_fd_usage(code: str) -> bool:
+    """
+    Use AST to check if code uses 'fd' variable but doesn't define it.
+    
+    Returns:
+        True if code uses 'fd' but doesn't define it (needs context manager)
+    """
+    try:
+        tree = ast.parse(code)
+        
+        # Track if 'fd' is defined (assigned to)
+        fd_defined = False
+        # Track if 'fd' is used (accessed)
+        fd_used = False
+        
+        class FdAnalyzer(ast.NodeVisitor):
+            def visit_Assign(self, node):
+                # Check if 'fd' is being assigned to
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == 'fd':
+                        nonlocal fd_defined
+                        fd_defined = True
+                self.generic_visit(node)
+            
+            def visit_Name(self, node):
+                # Check if 'fd' is being accessed
+                if node.id == 'fd' and isinstance(node.ctx, ast.Load):
+                    nonlocal fd_used
+                    fd_used = True
+                self.generic_visit(node)
+            
+            def visit_Attribute(self, node):
+                # Check for fd.something usage
+                if isinstance(node.value, ast.Name) and node.value.id == 'fd':
+                    nonlocal fd_used
+                    fd_used = True
+                self.generic_visit(node)
+        
+        analyzer = FdAnalyzer()
+        analyzer.visit(tree)
+        
+        # Return True if fd is used but not defined
+        return fd_used and not fd_defined
+        
+    except SyntaxError:
+        # If code has syntax errors, don't try to wrap it
+        return False
+
+
+def execute_python_code(code: str, file_path: Path, line_number: int) -> Tuple[bool, str]:
+    """
+    Execute Python code and return success status and error message.
+    
+    Returns:
+        Tuple of (success, error_message)
+    """
+    try:
+        # Prepend common imports for nvfuser code
+        imports = """
+from typing import Callable
+import torch
+import nvfuser
+from nvfuser import FusionDefinition, DataType
+__name__ = '__main__'
+"""
+        
+        # Check if we need to wrap with FusionDefinition context manager
+        if analyze_code_for_fd_usage(code):
+            # Indent the code and wrap with context manager
+            indented_code = '\n'.join('    ' + line for line in code.split('\n'))
+            full_code = imports + "\nwith FusionDefinition() as fd:\n" + indented_code
+        else:
+            # Just prepend imports
+            full_code = imports + "\n" + code
+        
+        # Execute the code using python -c
+        result = subprocess.run(
+            [sys.executable, "-c", full_code],
+            capture_output=True,
+            text=True,
+            timeout=30  # 30 second timeout
+        )
+        
+        if result.returncode == 0:
+            return True, ""
+        else:
+            return False, result.stderr.strip()
+            
+    except subprocess.TimeoutExpired:
+        return False, "Code execution timed out (30s)"
+    except Exception as e:
+        return False, f"Execution error: {str(e)}"
+
+
+def main():
+    """Main function to run the markdown code check."""
+    repo_root = Path(__file__).parent.parent  # Assume script is in tools/
+    
+    print("🔍 Finding markdown files...")
+    md_files = find_markdown_files(repo_root)
+    print(f"Found {len(md_files)} markdown files to check")
+    
+    total_code_blocks = 0
+    total_python_blocks = 0
+    failed_blocks = 0
+    errors: List[Dict] = []
+    
+    for md_file in md_files:
+        print(f"📄 Checking {md_file.relative_to(repo_root)}")
+        
+        try:
+            content = md_file.read_text(encoding='utf-8')
+        except UnicodeDecodeError:
+            print(f"⚠️  Skipping {md_file} - encoding error")
+            continue
+        
+        code_blocks = extract_code_blocks(content)
+        total_code_blocks += len(code_blocks)
+        
+        for code, line_number, language, should_ignore in code_blocks:
+            if language == "python":
+                if should_ignore:
+                    print(f"  ⏭️ Skipping Python code at line {line_number} (CI IGNORE)")
+                    continue
+                    
+                total_python_blocks += 1
+                print(f"  🐍 Executing Python code at line {line_number}")
+                
+                success, error_msg = execute_python_code(code, md_file, line_number)
+                
+                if not success:
+                    failed_blocks += 1
+                    error_info = {
+                        'file': md_file,
+                        'line': line_number,
+                        'error': error_msg,
+                        'code': code[:200] + '...' if len(code) > 200 else code
+                    }
+                    errors.append(error_info)
+                    print(f"    ❌ Error: {error_msg}")
+                else:
+                    print(f"    ✅ OK")
+    
+    # Print summary
+    print("\n" + "="*60)
+    print("📊 SUMMARY")
+    print("="*60)
+    print(f"Markdown files checked: {len(md_files)}")
+    print(f"Total code blocks found: {total_code_blocks}")
+    print(f"Python code blocks executed: {total_python_blocks}")
+    print(f"Failed executions: {failed_blocks}")
+    
+    if errors:
+        return 1
+    else:
+        print(f"\n✅ All Python code blocks executed successfully!")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/linter/adapters/README.md
+++ b/tools/linter/adapters/README.md
@@ -22,6 +22,7 @@ is_formatter = true
 It must accept two arguments.
 * `{{DRYRUN}}` - A bool flag that prints an explanation of what the linter would do.
 
+<!-- CI IGNORE -->
 ```python
 parser.add_argument(
     "--dry-run", help="do not install anything, just print what would be done."
@@ -30,6 +31,7 @@ parser.add_argument(
 
 * `{{PATHSFILE}}` - a variadic argument for all files passed to the linter.
 
+<!-- CI IGNORE -->
 ```python
 parser.add_argument(
     "filenames",


### PR DESCRIPTION
Added a CI check script that reads all *.md files recursively, extracts Python code blocks, and executes them to ensure no errors are thrown.

This script:

1. Finds all *.md files while respecting .gitignore and excluding third_party/
2. Extracts code blocks marked with ```python
3. Skips blocks preceded by <!-- CI IGNORE --> comments
4. Uses AST analysis to detect 'fd' variable usage and auto-wraps with FusionDefinition context manager
5. Sets \_\_name\_\_ = '\_\_main\_\_' to allow execution of main blocks
6. Automatically imports common nvfuser modules (torch, nvfuser, FusionDefinition, DataType)
7. Executes Python code blocks and reports any errors