### PR TITLE
Reduce CI time by only running legacy opinfo tets not supported by direct bindings

### DIFF
--- a/tests/python/opinfo/test_legacy_ops.py
+++ b/tests/python/opinfo/test_legacy_ops.py
@@ -217,7 +217,11 @@ def serde_test_fn(op: OpInfo, dtype: torch.dtype):
 
 
 @atexit_serde_create_op_test(
-    tuple(op for op in opinfos if op.sample_input_generator is not None)
+    tuple(
+        op
+        for op in opinfos
+        if op.sample_input_generator is not None and not op.supports_direct_bindings
+    )
 )
 def test_correctness(op: OpInfo, dtype: torch.dtype):
     return serde_test_fn(op, dtype)


### PR DESCRIPTION
Only `test_correctness_index_put_accumulate` remains because it isn't used in Thunder.
All of the tests in `test_errors` and `test_definition_op_in_schedule_error`
The remaining 552 tests finish in in 9.33s.