### PR TITLE
Add remaining functions to enable `nvfuser_direct` in Thunder

### DIFF
--- a/csrc/options.h
+++ b/csrc/options.h
@@ -286,7 +286,7 @@ using EnableOptions = Options<EnableOption>;
 NVF_API std::optional<EnableOption> stringToEnableOption(
     const std::string& enable_option);
 
-NVF_API bool isOptionEnabled(EnableOption option);
+bool isOptionEnabled(EnableOption option);
 
 const std::vector<std::string>& getEnableOptionArguments(EnableOption option);
 

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -283,10 +283,10 @@ NVF_API std::unordered_map<EnableOption, std::vector<std::string>> Options<
 
 using EnableOptions = Options<EnableOption>;
 
-std::optional<EnableOption> stringToEnableOption(
+NVF_API std::optional<EnableOption> stringToEnableOption(
     const std::string& enable_option);
 
-bool isOptionEnabled(EnableOption option);
+NVF_API bool isOptionEnabled(EnableOption option);
 
 const std::vector<std::string>& getEnableOptionArguments(EnableOption option);
 
@@ -304,7 +304,7 @@ NVF_API std::unordered_map<DisableOption, std::vector<std::string>> Options<
 
 using DisableOptions = Options<DisableOption>;
 
-std::optional<DisableOption> stringToDisableOption(
+NVF_API std::optional<DisableOption> stringToDisableOption(
     const std::string& disable_option);
 
 NVF_API bool isOptionDisabled(DisableOption option);

--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -259,7 +259,7 @@ class FusionDefinition:
         device : torch.device, optional
             Device to execute the fusion on
         save_repro_inputs : bool, default=False
-            Whether to save the inputs for last_repro_script() to provide a provide a reproduction script.
+            Whether to save the inputs for last_repro_script() to provide a reproduction script.
         _enable_options : list of str, default=[]
             A list of enable options. An alternative to setting NVFUSER_ENABLE environment variable.
         _disable_options : list of str, default=[]

--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -291,7 +291,7 @@ class FusionDefinition:
 
     def last_repro_script(self) -> str:
         assert (
-            self.fake_inputs is not None
+            hasattr(self, "fake_inputs") and self.fake_inputs is not None
         ), "fd.last_repro_script() cannot provide a repro because fd.execute(inputs, save_repro_state=True) was not executed!"
         return self.repro_script_for(self.fake_inputs)
 

--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -50,7 +50,7 @@ def execute_with_dtensors(fd, in_dtensors: Iterable[DTensor]) -> list[DTensor]:
                 common_mesh_dim_names == mesh_dim_names
             ), f"All DTensor inputs must have the same mesh dim names. Got {common_mesh_dim_names} and {mesh_dim_names}"
 
-    out_tensors = fd.execute(in_tensors, auto_schedule=True)
+    out_tensors = fd.execute(in_tensors)
     out_shardings = fd.fec.get_output_shardings()
     assert len(out_tensors) == len(out_shardings)
 

--- a/python/python_direct/bindings.cpp
+++ b/python/python_direct/bindings.cpp
@@ -8,6 +8,7 @@
 
 #include <bindings.h>
 #include <multidevice/communicator.h>
+#include <python_common/python_utils.h>
 
 namespace nvfuser::python {
 
@@ -18,7 +19,19 @@ void initNvFuserPythonBindings(PyObject* module) {
   bindRuntime(nvfuser);
   bindOperations(nvfuser);
   bindMultiDevice(nvfuser);
-  nvfuser.def("translate_fusion", &translateFusion);
+  nvfuser.def(
+      "translate_fusion",
+      &translateFusion,
+      py::arg("fusion"),
+      R"(Translate a Fusion to a Python string.)");
+  nvfuser.def(
+      "compute_tensor_descriptor",
+      &computeTensorDescriptor,
+      py::arg("sizes"),
+      py::arg("strides"),
+      R"(
+    Compute the tensor descriptor for a given shape and stride.
+  )");
 #ifdef NVFUSER_ENABLE_CUTLASS
   bindCutlass(nvfuser);
 #endif

--- a/python/python_direct/runtime.cpp
+++ b/python/python_direct/runtime.cpp
@@ -266,8 +266,8 @@ Examples
           py::arg("inputs"),
           py::kw_only(),
           py::arg("device") = py::none(),
-          py::arg("_enable_options") = py::none(),
-          py::arg("_disable_options") = py::none(),
+          py::arg("_enable_options") = py::list(),
+          py::arg("_disable_options") = py::list(),
           R"(
 Execute the fusion with the given inputs.
 

--- a/python/python_direct/runtime.cpp
+++ b/python/python_direct/runtime.cpp
@@ -11,6 +11,7 @@
 #include <python_utils.h>
 
 #include <fusion.h>
+#include <options.h>
 #include <runtime/executor_kernel_arg.h>
 #include <runtime/fusion_executor_cache.h>
 #include <runtime/fusion_kernel_runtime.h>
@@ -230,15 +231,43 @@ Examples
           "execute",
           [](FusionExecutorCache& self,
              const py::iterable& iter,
-             std::optional<int64_t> device) {
+             std::optional<int64_t> device,
+             std::vector<std::string> _enable_options,
+             std::vector<std::string> _disable_options) {
             KernelArgumentHolder args = from_pyiterable(iter, device);
+
+            EnableOptionsGuard enable_opt_guard;
+            for (const auto& _enable_option : _enable_options) {
+              std::optional<EnableOption> opt =
+                  stringToEnableOption(_enable_option);
+              NVF_CHECK(
+                  opt.has_value(),
+                  "Unrecognized enable_option: ",
+                  _enable_option);
+              EnableOptionsGuard::getCurOptions().set(opt.value());
+            }
+
+            DisableOptionsGuard disable_opt_guard;
+            for (const auto& _disable_option : _disable_options) {
+              std::optional<DisableOption> opt =
+                  stringToDisableOption(_disable_option);
+              NVF_CHECK(
+                  opt.has_value(),
+                  "Unrecognized disable_option: ",
+                  _disable_option);
+              DisableOptionsGuard::getCurOptions().set(opt.value());
+            }
+
             KernelArgumentHolder outputs = self.runFusionWithInputs(
                 args, std::nullopt, args.getDeviceIndex());
+
             return to_tensor_vector(outputs);
           },
           py::arg("inputs"),
           py::kw_only(),
           py::arg("device") = py::none(),
+          py::arg("_enable_options") = py::none(),
+          py::arg("_disable_options") = py::none(),
           R"(
 Execute the fusion with the given inputs.
 
@@ -252,6 +281,12 @@ device : int, optional
     The device index to execute the fusion on.
     It must be a non-negative integer less than 256.
     If None, uses the device of the input tensors.
+    Default is None.
+_enable_options : list of str, optional
+    A list of enable options.
+    Default is None.
+_disable_options : list of str, optional
+    A list of disable options.
     Default is None.
 
 Returns

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -51,7 +51,6 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_arithmetic_ops` - Tests various arithmetic operations
 - `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes (79 lines)
 - `test_cat_symbolic` - Tests symbolic concatenation (86 lines)
-- `test_compute_tensor_descriptor` - Tests tensor descriptor computation
 - `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
 - `test_fusion_profiler` - Tests fusion profiling
 - `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
@@ -151,6 +150,7 @@ Both test files contain these common tests:
 - `test_basic_fp16` - Basic operations with FP16
 - `test_cast_double_to_half` - Casting double to half precision
 - `test_cast_fp8` - FP8 casting operations
+- `test_compute_tensor_descriptor` - Tests tensor descriptor computation
 - `test_promote_to_double` - Type promotion to double
 - `test_implicit_broadcast_input` - Implicit broadcast input handling
 - `test_explicit_broadcast_input` - Explicit broadcast input handling

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,25 +42,43 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 77 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 75 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 #### Advanced Operations & Features
+
+**Tests with More Than 50 Lines of Code:**
 - `test_all_dim_var_mean` - Tests variance and mean across all dimensions
+- `test_arithmetic_ops` - Tests various arithmetic operations
+- `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes (79 lines)
+- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model (201 lines)
+- `test_cat_symbolic` - Tests symbolic concatenation (86 lines)
+- `test_compute_tensor_descriptor` - Tests tensor descriptor computation
+- `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
+- `test_deterministic_random` - Tests deterministic random number generation
+- `test_fusion_profiler` - Tests fusion profiling
+- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
+- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
+- `test_mismatched_input_types` - Tests mismatched input type handling (50 lines)
+- `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
+- `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
+- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
+- `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
+- `test_random_distinct_values` - Tests random distinct value generation (100 lines)
+- `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
+- `test_repro_script_generation` - Tests reproduction script generation (130 lines)
+- `test_slice_error_checks` - Tests slice error checking (128 lines)
+- `test_stride_order_with_explicit_broadcast` - Tests stride order with explicit broadcast
+- `test_uniform_range` - Tests uniform range generation (230 lines)
+
+**Tests with 50 Lines or Less:**
 - `test_allocation_domain_concretization` - Tests allocation domain handling
 - `test_allocation_domain_index_select` - Tests index select with allocation domains
-- `test_arithmetic_ops` - Tests various arithmetic operations
-- `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes
-- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model
-- `test_cat_symbolic` - Tests symbolic concatenation
 - `test_complex_constants` - Tests complex number constants
 - `test_complex_rsqrt` - Tests complex reciprocal square root
 - `test_compute_contiguity` - Tests contiguity computation
-- `test_compute_tensor_descriptor` - Tests tensor descriptor computation
 - `test_constant_nans` - Tests constant NaN handling
-- `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation
 - `test_debug_output` - Tests debug output functionality
 - `test_def_op_in_schedule` - Tests operation definition in schedules
-- `test_deterministic_random` - Tests deterministic random number generation
 - `test_enable_disable_options` - Tests enable/disable options
 - `test_expand_to_zero` - Tests expansion to zero dimensions
 - `test_expanded_bcast_tensor` - Tests expanded broadcast tensors
@@ -68,9 +86,6 @@ The following 77 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_func_definition` - Tests function definition
 - `test_fusion_definition_error_cache` - Tests fusion definition error caching
 - `test_fusion_information` - Tests fusion information retrieval
-- `test_fusion_profiler` - Tests fusion profiling
-- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
-- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
 - `test_gcd` - Tests greatest common divisor
 - `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling
 - `test_inplace_update_on_non_contiguous_inputs` - Tests in-place updates
@@ -78,25 +93,17 @@ The following 77 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_integer_division` - Tests integer division
 - `test_mark_alias_pass` - Tests alias marking
 - `test_misaligned_add` - Tests misaligned addition
-- `test_mismatched_input_types` - Tests mismatched input type handling
-- `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
-- `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
 - `test_nextafter` - Tests nextafter function
 - `test_no_definition` - Tests undefined fusion behavior
 - `test_ops_broadcast` - Tests broadcast operations
 - `test_pad_cache` - Tests padding cache
 - `test_pad_expanded_empty` - Tests padding with expanded empty tensors
 - `test_pad_prior_cat` - Tests padding before concatenation
-- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass
-- `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass
 - `test_prod` - Tests product operations
 - `test_python_version_API` - Tests Python version API
-- `test_random_distinct_values` - Tests random distinct value generation
 - `test_real_imag` - Tests real and imaginary parts
 - `test_reduction_complex_number` - Tests complex number reduction
-- `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
 - `test_replaced_sizes_pr2714` - Tests size replacement
-- `test_repro_script_generation` - Tests reproduction script generation
 - `test_reshape_squeeze_concretization` - Tests reshape squeeze concretization
 - `test_right_shift_arithmetic` - Tests arithmetic right shift
 - `test_right_shift_logical` - Tests logical right shift
@@ -106,16 +113,13 @@ The following 77 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_selected_device` - Tests device selection
 - `test_signbit` - Tests sign bit operations
 - `test_slice_api` - Tests slice API
-- `test_slice_error_checks` - Tests slice error checking
 - `test_static_tensor_sizes` - Tests static tensor sizes
-- `test_stride_order_with_explicit_broadcast` - Tests stride order with explicit broadcast
 - `test_sum_sliced_reshape_to_broadcast` - Tests sum sliced reshape to broadcast
 - `test_tensor_shape` - Tests tensor shape operations
 - `test_tensor_shape_expand_bcast` - Tests tensor shape expansion broadcast
 - `test_tensor_shape_nobcast` - Tests tensor shape without broadcast
 - `test_tensor_shape_with_output_bcast` - Tests tensor shape with output broadcast
 - `test_tensor_size_both_args_bcast` - Tests tensor size with broadcast arguments
-- `test_uniform_range` - Tests uniform range generation
 - `test_var_correction` - Tests variance correction
 - `test_var_mean_correction` - Tests variance mean correction
 - `test_where_op` - Tests where operation

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -46,15 +46,17 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 
 #### Advanced Operations & Features
 
+**Disabled because of CUDA 13 incompatiblity**
+- `test_fusion_profiler` - Tests fusion profiling
+- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
+- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
+
 **Tests with More Than 50 Lines of Code:**
 - `test_all_dim_var_mean` - Tests variance and mean across all dimensions
 - `test_arithmetic_ops` - Tests various arithmetic operations
 - `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes (79 lines)
 - `test_cat_symbolic` - Tests symbolic concatenation (86 lines)
 - `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
-- `test_fusion_profiler` - Tests fusion profiling
-- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
-- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
 - `test_mismatched_input_types` - Tests mismatched input type handling (50 lines)
 - `test_random_distinct_values` - Tests random distinct value generation (100 lines)
 - `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
@@ -76,20 +78,19 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_fusion_information` - Tests fusion information retrieval
 - `test_repro_script_generation` - Tests reproduction script generation (130 lines)
 - `test_debug_output` - Tests debug output functionality
+- `test_compute_contiguity` - Tests contiguity computation
+- `test_static_tensor_sizes` - Tests static tensor sizes
 
 **General Tests -- To Add**
 - `test_no_definition` - Tests undefined fusion behavior
-- `test_enable_disable_options` - Tests enable/disable options
 - `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
 - `test_python_version_API` - Tests Python version API
-- `test_static_tensor_sizes` - Tests static tensor sizes
 
 **Tests with 50 Lines or Less:**
 - `test_allocation_domain_concretization` - Tests allocation domain handling
 - `test_allocation_domain_index_select` - Tests index select with allocation domains
 - `test_complex_constants` - Tests complex number constants
 - `test_complex_rsqrt` - Tests complex reciprocal square root
-- `test_compute_contiguity` - Tests contiguity computation
 - `test_constant_nans` - Tests constant NaN handling
 - `test_expand_to_zero` - Tests expansion to zero dimensions
 - `test_expanded_bcast_tensor` - Tests expanded broadcast tensors
@@ -147,6 +148,7 @@ The following 15 tests exist in `tests/python/direct/test_python_frontend.py` bu
 
 Both test files contain these common tests:
 - `test_basic` - Basic fusion operations
+- `test_enable_disable_options` - Tests enable/disable options
 - `test_basic_fp16` - Basic operations with FP16
 - `test_cast_double_to_half` - Casting double to half precision
 - `test_cast_fp8` - FP8 casting operations

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -50,25 +50,40 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_all_dim_var_mean` - Tests variance and mean across all dimensions
 - `test_arithmetic_ops` - Tests various arithmetic operations
 - `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes (79 lines)
-- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model (201 lines)
 - `test_cat_symbolic` - Tests symbolic concatenation (86 lines)
 - `test_compute_tensor_descriptor` - Tests tensor descriptor computation
 - `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
-- `test_deterministic_random` - Tests deterministic random number generation
 - `test_fusion_profiler` - Tests fusion profiling
 - `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
 - `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
 - `test_mismatched_input_types` - Tests mismatched input type handling (50 lines)
+- `test_random_distinct_values` - Tests random distinct value generation (100 lines)
+- `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
+- `test_slice_error_checks` - Tests slice error checking (128 lines)
+- `test_stride_order_with_explicit_broadcast` - Tests stride order with explicit broadcast
+- `test_deterministic_random` - Tests deterministic random number generation
+- `test_uniform_range` - Tests uniform range generation (230 lines)
+- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model (201 lines)
 - `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
 - `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
 - `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
-- `test_random_distinct_values` - Tests random distinct value generation (100 lines)
-- `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
+
+**General Tests -- Legacy-Only**
+- `test_def_op_in_schedule` - Tests operation definition in schedules
+- `test_func_definition` - Tests function definition
+- `test_fusion_definition_error_cache` - Tests fusion definition error caching
+- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling
+- `test_fusion_information` - Tests fusion information retrieval
 - `test_repro_script_generation` - Tests reproduction script generation (130 lines)
-- `test_slice_error_checks` - Tests slice error checking (128 lines)
-- `test_stride_order_with_explicit_broadcast` - Tests stride order with explicit broadcast
-- `test_uniform_range` - Tests uniform range generation (230 lines)
+- `test_debug_output` - Tests debug output functionality
+
+**General Tests -- To Add**
+- `test_no_definition` - Tests undefined fusion behavior
+- `test_enable_disable_options` - Tests enable/disable options
+- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
+- `test_python_version_API` - Tests Python version API
+- `test_static_tensor_sizes` - Tests static tensor sizes
 
 **Tests with 50 Lines or Less:**
 - `test_allocation_domain_concretization` - Tests allocation domain handling
@@ -77,30 +92,20 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_complex_rsqrt` - Tests complex reciprocal square root
 - `test_compute_contiguity` - Tests contiguity computation
 - `test_constant_nans` - Tests constant NaN handling
-- `test_debug_output` - Tests debug output functionality
-- `test_def_op_in_schedule` - Tests operation definition in schedules
-- `test_enable_disable_options` - Tests enable/disable options
 - `test_expand_to_zero` - Tests expansion to zero dimensions
 - `test_expanded_bcast_tensor` - Tests expanded broadcast tensors
-- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
-- `test_func_definition` - Tests function definition
-- `test_fusion_definition_error_cache` - Tests fusion definition error caching
-- `test_fusion_information` - Tests fusion information retrieval
 - `test_gcd` - Tests greatest common divisor
-- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling
 - `test_inplace_update_on_non_contiguous_inputs` - Tests in-place updates
 - `test_input_scalar` - Tests scalar input handling
 - `test_integer_division` - Tests integer division
 - `test_mark_alias_pass` - Tests alias marking
 - `test_misaligned_add` - Tests misaligned addition
 - `test_nextafter` - Tests nextafter function
-- `test_no_definition` - Tests undefined fusion behavior
 - `test_ops_broadcast` - Tests broadcast operations
 - `test_pad_cache` - Tests padding cache
 - `test_pad_expanded_empty` - Tests padding with expanded empty tensors
 - `test_pad_prior_cat` - Tests padding before concatenation
 - `test_prod` - Tests product operations
-- `test_python_version_API` - Tests Python version API
 - `test_real_imag` - Tests real and imaginary parts
 - `test_reduction_complex_number` - Tests complex number reduction
 - `test_replaced_sizes_pr2714` - Tests size replacement
@@ -110,10 +115,8 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size
 - `test_segment_set` - Tests segment set operations
 - `test_segmentation_reduction_pointwise_epilogue` - Tests segmented reduction
-- `test_selected_device` - Tests device selection
 - `test_signbit` - Tests sign bit operations
 - `test_slice_api` - Tests slice API
-- `test_static_tensor_sizes` - Tests static tensor sizes
 - `test_sum_sliced_reshape_to_broadcast` - Tests sum sliced reshape to broadcast
 - `test_tensor_shape` - Tests tensor shape operations
 - `test_tensor_shape_expand_bcast` - Tests tensor shape expansion broadcast
@@ -122,7 +125,6 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_tensor_size_both_args_bcast` - Tests tensor size with broadcast arguments
 - `test_var_correction` - Tests variance correction
 - `test_var_mean_correction` - Tests variance mean correction
-- `test_where_op` - Tests where operation
 - `test_zero_size_dim` - Tests zero size dimensions
 
 ### Tests Only in Direct Frontend (Not in Main)

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -71,15 +71,15 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
 
 **General Tests -- Legacy-Only**
-- `test_def_op_in_schedule` - Tests operation definition in schedules
-- `test_func_definition` - Tests function definition
-- `test_fusion_definition_error_cache` - Tests fusion definition error caching
-- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling
-- `test_fusion_information` - Tests fusion information retrieval
-- `test_repro_script_generation` - Tests reproduction script generation (130 lines)
-- `test_debug_output` - Tests debug output functionality
-- `test_compute_contiguity` - Tests contiguity computation
-- `test_static_tensor_sizes` - Tests static tensor sizes
+- `test_def_op_in_schedule` - Tests operation definition in schedules; scheduling and definition are not separate.
+- `test_func_definition` - Tests function definition; Redundant
+- `test_fusion_definition_error_cache` - Tests fusion definition error caching; No fusion cache
+- `test_fusion_information` - Tests fusion information retrieval; Not used in direct bindings
+- `test_debug_output` - Tests debug output functionality; Deprecated
+- `test_compute_contiguity` - Tests contiguity computation; Not used in Thunder
+- `test_static_tensor_sizes` - Tests static tensor sizes; Not used in Thunder
+- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling; An analogous test already exists
+- `test_repro_script_generation` - Tests reproduction script generation (130 lines); An analogous test already exists.
 
 **General Tests -- To Add**
 - `test_no_definition` - Tests undefined fusion behavior


### PR DESCRIPTION
This PR adds the remaining functions necessary to create a `nvfuser_direct` PR in Thunder.
- Add `compute_tensor_descriptor` along with `test_compute_tensor_descriptor`.
- Change `FusionDefinition.execute` to support `save_repro_inputs`, `_enable_options`, `_disable_options`.
- Adds `last_repro_script` for Thunder.

The following arguments are not ported to `nvfuser_direct`:
- `override_user_schedule` is irrelevant for `nvfuser_direct`.
- `capture_debug_output` isn't used by thunder.
- `print_repro` argument is redundant. You can call `fd.repro_script_for(inputs)` manually.
- `profile` doesn't work with CUDA 13, so skip it for now.