### PR TITLE
`nm -u` => `nm -uD`

### DIFF
--- a/tools/check_symbol_visibility.sh
+++ b/tools/check_symbol_visibility.sh
@@ -99,7 +99,7 @@ check_extension_symbols() {
 
     # Get undefined nvfuser symbols from this extension
     local undefined_file="$TEMP_DIR/${ext_name}_undefined_symbols.txt"
-    nm -u "$ext_file" | grep nvfuser | awk '{print $2}' | sort > "$undefined_file"
+    nm -uD "$ext_file" | grep nvfuser | awk '{print $2}' | sort > "$undefined_file"
     local undefined_count=$(wc -l < "$undefined_file")
     echo "Found $undefined_count undefined nvfuser symbols in $ext_name"
 


### PR DESCRIPTION
`nm -u` shows no symbols.
```
$ nm -u /opt/pytorch/nvfuser/python/nvfuser/_C.cpython-312-x86_64-linux-gnu.so
nm: /opt/pytorch/nvfuser/python/nvfuser/_C.cpython-312-x86_64-linux-gnu.so: no symbols
```

Is it because we removed the regular symbol table from the .so?

This PR allows the tool to capture the following wrong change:
```diff
diff --git a/csrc/host_ir/evaluator.h b/csrc/host_ir/evaluator.h
index 7394d9a2..5e0fec21 100644
--- a/csrc/host_ir/evaluator.h
+++ b/csrc/host_ir/evaluator.h
@@ -48,7 +48,7 @@ struct HostIrEvaluatorParams {
 //
 // Note: most of the implementation is copy pasted for MultiDeviceExecutor. This
 // duplication will be resolved in the future.
-class NVF_API HostIrEvaluator final : public OptOutDispatch {
+class HostIrEvaluator final : public OptOutDispatch {
  public:
   HostIrEvaluator(
       std::unique_ptr<HostIrContainer> container,
```