### PR TITLE
Properly handle zero-dimensional input for topk and argsort

### DIFF
--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1743,11 +1743,6 @@ WelfordResult::WelfordResult(
   NVF_ERROR(avg->definition()->sameAs(n->definition()));
 }
 
-TopKResult::TopKResult(TensorView* in_values, TensorView* in_indices)
-    : values(in_values), indices(in_indices) {
-  NVF_ERROR(values->definition()->sameAs(indices->definition()));
-}
-
 // COMPOUND OPERATIONS
 
 // add_alpha
@@ -2273,6 +2268,16 @@ TensorView* argsort(
     int64_t dim,
     bool descending,
     bool stable) {
+  const std::vector<IterDomain*> logical_dom =
+      TensorDomain::noReductions(inp->getLogicalDomain());
+
+  // Argsort of zero-dim tensor is allowed
+  if (logical_dom.empty()) {
+    return zeros({}, DataType::Int);
+  }
+
+  dim = wrapDim(dim, std::ssize(logical_dom));
+
   Val* out = ops::newValLike(inp, DataType::Int);
   IrBuilder::create<ArgsortOp>(out, inp, dim, descending, stable);
   return out->as<TensorView>();
@@ -2504,6 +2509,26 @@ TopKResult topk(
     bool sorted,
     bool maybe_symbolic) {
   auto inp_domain = TensorDomain::noReductions(inp->getLogicalDomain());
+
+  // When the input is a zero-dimensional tensor, dim must be either
+  // 0 or -1, and k must be 1.
+  if (inp_domain.empty()) {
+    NVF_ERROR(
+        dim == 0 || dim == -1,
+        "Invalid dimension to compute top-k of an zero-dimensinal tensor: ",
+        dim);
+
+    // Note that unless k is const, it is not possible to validate
+    // it's indeed 1. We need some way to register a condition to
+    // validate with actual fusion inputs like GpuLower::validate.
+    if (k->isConstScalar()) {
+      NVF_ERROR(k->isOneInt(), "Invalid k of topk: ", k->toString());
+    }
+    auto out_idx = zeros({}, DataType::Int);
+    auto out_val = set(inp);
+    return TopKResult(out_val, out_idx);
+  }
+
   dim = wrapDim(dim, std::ssize(inp_domain));
 
   NVF_CHECK(

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -147,10 +147,11 @@ struct WelfordResult {
 struct TopKResult {
  public:
   TensorView* values = nullptr; //!< The k largest/smallest values
-  TensorView* indices; //!< Indices of the values in the original tensor
+  TensorView* indices =
+      nullptr; //!< Indices of the values in the original tensor
 
-  //! Constructor ensuring both outputs come from the same TopK operation
-  explicit TopKResult(TensorView* in_values, TensorView* in_indices);
+  explicit TopKResult(TensorView* in_values, TensorView* in_indices)
+      : values(in_values), indices(in_indices) {}
 };
 
 //! Welford operator on specified axes. This is currently the only scan op with

--- a/tests/cpp/test_argsort.cpp
+++ b/tests/cpp/test_argsort.cpp
@@ -97,4 +97,23 @@ INSTANTIATE_TEST_SUITE_P(
       return std::string("Unknown");
     });
 
+TEST_F(ArgsortTest, ZeroDimensionalInput) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  auto tv0 = makeSymbolicTensor(0);
+  fusion.addInput(tv0);
+
+  auto tv2 = argsort(tv0, -1);
+  fusion.addOutput(tv2);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({}, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Currently, both argsort and topk don't reproduce the PyTorch behavior when the input is a zero-dimensional tensor.

It seems that:
- Argsort with a zero-dimensional input seems to return a zero-dimensional tensor with scalar 0.
- Topk with a zero-dimensional input also returns two zero-dimensional tensors. The value output is just a copy of the input, whereas the index tensor is a zero-dimensional tensor with scalar 0.

