### PR TITLE
patch test_moe script to forward scatter to nvfuser

### DIFF
--- a/tests/python/test_moe.py
+++ b/tests/python/test_moe.py
@@ -188,7 +188,7 @@ def test_llama4_moe_thunderfx():
     assert expected.dtype == torch.bfloat16
     assert expected.is_cuda
 
-    tmodel = thunderfx(model, nv_enable_linear=True)
+    tmodel = thunderfx(model, nv_enable_linear=True, nv_enable_scatter=True)
 
     with torch.no_grad():
         actual = tmodel(inp)


### PR DESCRIPTION
Getting a single nvFusion region now.
```
def computation(l_hidden_states_, l_self_modules_shared_experts_modules_gate_proj_parameters_weight_, l_self_modules_shared_experts_modules_up_proj_parameters_weight_, l_self_modules_shared_experts_modules_down_proj_parameters_weight_, l_self_modules_gate_parameters_weight_, l_self_modules_routed_experts_modules_gat
e_proj_parameters_weight_, l_self_modules_routed_experts_modules_up_proj_parameters_weight_, l_self_modules_routed_experts_modules_down_proj_parameters_weight_):
  # l_hidden_states_: "cuda:0 bf16[1, 2048, 5120]"
  # l_self_modules_shared_experts_modules_gate_proj_parameters_weight_: "cuda:0 bf16[8192, 5120]"
  # l_self_modules_shared_experts_modules_up_proj_parameters_weight_: "cuda:0 bf16[8192, 5120]"
  # l_self_modules_shared_experts_modules_down_proj_parameters_weight_: "cuda:0 bf16[5120, 8192]"
  # l_self_modules_gate_parameters_weight_: "cuda:0 bf16[128, 5120]"
  # l_self_modules_routed_experts_modules_gate_proj_parameters_weight_: "cuda:0 bf16[128, 5120, 8192]"
  # l_self_modules_routed_experts_modules_up_proj_parameters_weight_: "cuda:0 bf16[128, 5120, 8192]"
  # l_self_modules_routed_experts_modules_down_proj_parameters_weight_: "cuda:0 bf16[128, 8192, 5120]"
  [add] = nvFusion0(l_hidden_states_, l_self_modules_shared_experts_modules_gate_proj_parameters_weight_, l_self_modules_shared_experts_modules_up_proj_parameters_weight_, l_self_modules_gate_parameters_weight_, l_self_modules_shared_experts_modules_down_proj_parameters_weight_, l_self_modules_routed_experts_modules
_gate_proj_parameters_weight_, l_self_modules_routed_experts_modules_up_proj_parameters_weight_, l_self_modules_routed_experts_modules_down_proj_parameters_weight_)
    # counts = prims.full((2048, 128), 0, device=devices.Device("cuda:0"), dtype=dtypes.int32)  # counts: "cuda:0 i32[2048, 128]"
    # hidden_states = prims.reshape(l_hidden_states_, (2048, 5120))  # hidden_states: "cuda:0 bf16[2048, 5120]"
    # linear = prims.linear(l_hidden_states_, l_self_modules_shared_experts_modules_gate_proj_parameters_weight_, None)  # linear: "cuda:0 bf16[1, 2048, 8192]"
    # linear_1 = prims.linear(l_hidden_states_, l_self_modules_shared_experts_modules_up_proj_parameters_weight_, None)  # linear_1: "cuda:0 bf16[1, 2048, 8192]"
    # router_logits = prims.linear(hidden_states, l_self_modules_gate_parameters_weight_, None)  # router_logits: "cuda:0 bf16[2048, 128]"
    # t1 = prims.convert_element_type(linear, dtypes.float32)  # t1: "cuda:0 f32[1, 2048, 8192]"
    # t2 = prims.neg(t1)  # t2: "cuda:0 f32[1, 2048, 8192]"
    # t3 = prims.exp(t2)  # t3: "cuda:0 f32[1, 2048, 8192]"
    # t4 = prims.add(1.0, t3)  # t4: "cuda:0 f32[1, 2048, 8192]"
    # t5 = prims.reciprocal(t4)  # t5: "cuda:0 f32[1, 2048, 8192]"
    # t9 = prims.mul(t1, t5)  # t9: "cuda:0 f32[1, 2048, 8192]"
    # (topk_weight, topk_ids) = prims.topk(router_logits, 1, 1, True, True)
    # t13 = prims.convert_element_type(linear_1, dtypes.float32)  # t13: "cuda:0 f32[1, 2048, 8192]"
    # t14 = prims.mul(t9, t13)  # t14: "cuda:0 f32[1, 2048, 8192]"
    # mul = prims.convert_element_type(t14, dtypes.bfloat16)  # mul: "cuda:0 bf16[1, 2048, 8192]"
    # t21 = prims.convert_element_type(topk_weight, dtypes.float32)  # t21: "cuda:0 f32[2048, 1]"
    # t22 = prims.neg(t21)  # t22: "cuda:0 f32[2048, 1]"
    # t23 = prims.exp(t22)  # t23: "cuda:0 f32[2048, 1]"
    # t24 = prims.add(1.0, t23)  # t24: "cuda:0 f32[2048, 1]"
    # t25 = prims.reciprocal(t24)  # t25: "cuda:0 f32[2048, 1]"
    # router_scores = prims.convert_element_type(t25, dtypes.bfloat16)  # router_scores: "cuda:0 bf16[2048, 1]"
    # counts_1 = prims.scatter(counts, topk_ids, 1, 1)  # counts_1: "cuda:0 i32[2048, 128]"
    # t35 = prims.convert_element_type(counts_1, dtypes.int64)  # t35: "cuda:0 i64[2048, 128]"
    # tokens_per_expert = prims.sum(t35, (0,))  # tokens_per_expert: "cuda:0 i64[128]"
    # view_1 = prims.reshape(topk_ids, (2048,))  # view_1: "cuda:0 i64[2048]"
    # linear_2 = prims.linear(mul, l_self_modules_shared_experts_modules_down_proj_parameters_weight_, None)  # linear_2: "cuda:0 bf16[1, 2048, 5120]"
    # t27 = prims.broadcast_in_dim(router_scores, (2048, 5120), (0, 1))  # t27: "cuda:0 bf16[2048, 5120]"
    # t28 = prims.convert_element_type(hidden_states, dtypes.float32)  # t28: "cuda:0 f32[2048, 5120]"
    # t29 = prims.convert_element_type(t27, dtypes.float32)  # t29: "cuda:0 f32[2048, 5120]"
    # t30 = prims.mul(t28, t29)  # t30: "cuda:0 f32[2048, 5120]"
    # hidden_states_1 = prims.convert_element_type(t30, dtypes.bfloat16)  # hidden_states_1: "cuda:0 bf16[2048, 5120]"
    # token_ids_sorted_by_expert_id = ltorch.argsort(view_1, -1, False, False)  # token_ids_sorted_by_expert_id: "cuda:0 i64[2048]"
    # offsets = ltorch.cumsum(tokens_per_expert, 0, dtype=torch.int32)  # offsets: "cuda:0 i32[128]"
    # t39 = prims.lt(token_ids_sorted_by_expert_id, 0)  # t39: "cuda:0 b8[2048]"
    # t40 = prims.where(t39, 2048, 0)  # t40: "cuda:0 i64[2048]"
    # t41 = prims.add(token_ids_sorted_by_expert_id, t40)  # t41: "cuda:0 i64[2048]"
    # tokens_sorted_by_expert_id = prims.take(hidden_states_1, t41, 0)  # tokens_sorted_by_expert_id: "cuda:0 bf16[2048, 5120]"
    # token_ids_sorted_by_expert_inverse_id = ltorch.argsort(token_ids_sorted_by_expert_id, -1, False, False)  # token_ids_sorted_by_expert_inverse_id: "cuda:0 i64[2048]"
    # _grouped_mm = prims._grouped_mm(tokens_sorted_by_expert_id, l_self_modules_routed_experts_modules_gate_proj_parameters_weight_, offsets)  # _grouped_mm: "cuda:0 bf16[2048, 8192]"
    # _grouped_mm_1 = prims._grouped_mm(tokens_sorted_by_expert_id, l_self_modules_routed_experts_modules_up_proj_parameters_weight_, offsets)  # _grouped_mm_1: "cuda:0 bf16[2048, 8192]"
    # t45 = prims.convert_element_type(_grouped_mm, dtypes.float32)  # t45: "cuda:0 f32[2048, 8192]"
    # t46 = prims.neg(t45)  # t46: "cuda:0 f32[2048, 8192]"
    # t47 = prims.exp(t46)  # t47: "cuda:0 f32[2048, 8192]"
    # t48 = prims.add(1.0, t47)  # t48: "cuda:0 f32[2048, 8192]"
    # t49 = prims.reciprocal(t48)  # t49: "cuda:0 f32[2048, 8192]"
    # t53 = prims.mul(t45, t49)  # t53: "cuda:0 f32[2048, 8192]"
    # t57 = prims.convert_element_type(_grouped_mm_1, dtypes.float32)  # t57: "cuda:0 f32[2048, 8192]"
    # t58 = prims.mul(t53, t57)  # t58: "cuda:0 f32[2048, 8192]"
    # mul_2 = prims.convert_element_type(t58, dtypes.bfloat16)  # mul_2: "cuda:0 bf16[2048, 8192]"
    # outs_sorted_by_expert_id = prims._grouped_mm(mul_2, l_self_modules_routed_experts_modules_down_proj_parameters_weight_, offsets)  # outs_sorted_by_expert_id: "cuda:0 bf16[2048, 5120]"
    # t62 = prims.lt(token_ids_sorted_by_expert_inverse_id, 0)  # t62: "cuda:0 b8[2048]"
    # t63 = prims.where(t62, 2048, 0)  # t63: "cuda:0 i64[2048]"
    # t64 = prims.add(token_ids_sorted_by_expert_inverse_id, t63)  # t64: "cuda:0 i64[2048]"
    # outs_sorted_by_token_id = prims.take(outs_sorted_by_expert_id, t64, 0)  # outs_sorted_by_token_id: "cuda:0 bf16[2048, 5120]"
    # t66 = prims.broadcast_in_dim(outs_sorted_by_token_id, (1, 2048, 5120), (1, 2))  # t66: "cuda:0 bf16[1, 2048, 5120]"
    # t67 = prims.convert_element_type(linear_2, dtypes.float32)  # t67: "cuda:0 f32[1, 2048, 5120]"
    # t68 = prims.convert_element_type(t66, dtypes.float32)  # t68: "cuda:0 f32[1, 2048, 5120]"
    # t69 = prims.add(t67, t68)  # t69: "cuda:0 f32[1, 2048, 5120]"
    # add = prims.convert_element_type(t69, dtypes.bfloat16)  # add: "cuda:0 bf16[1, 2048, 5120]"
  return (add,)]
```