### PR TITLE
add option to enable compile with `--use_fast_math`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -896,6 +896,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_gpu1.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu2.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu3.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_instructions.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_id_model.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_index_put.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_index_select.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -897,7 +897,6 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_gpu1.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu2.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_gpu3.cpp
-  ${NVFUSER_ROOT}/tests/cpp/test_instructions.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_id_model.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_index_put.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_index_select.cpp
@@ -911,6 +910,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_loop_domain_scheduling.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_loop_rotation.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_low_precision_recipe.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_math_opt.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_mbarrier.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_memory.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_move_pad.cpp

--- a/csrc/options.cpp
+++ b/csrc/options.cpp
@@ -173,6 +173,7 @@ const std::unordered_map<std::string, EnableOption>& getEnableOptions() {
           {"warn_register_spill", EnableOption::WarnRegisterSpill},
           {"ws_normalization", EnableOption::WarpSpecializedNormalization},
           {"host_ir_lowering", EnableOption::HostIrLowering},
+          {"fast_math", EnableOption::FastMath},
       };
   return available_options;
 }

--- a/csrc/options.h
+++ b/csrc/options.h
@@ -116,6 +116,7 @@ enum class EnableOption {
   WarnRegisterSpill, //! Enable warnings of register spill
   WarpSpecializedNormalization, //! Enable warp specialized persistent kernel
   HostIrLowering, //! Enable FusionKernelRuntime lowering to host IR
+  FastMath, //! Enable fast math optimizations (--use_fast_math)
   EndOfOption //! Placeholder for counting the number of elements
 };
 

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -546,6 +546,11 @@ void fillCompileOptions(
     nvrtc_compile_driver.setOption("--fmad=true");
   }
 
+  // Enable fast math optimizations if requested
+  if (isOptionEnabled(EnableOption::FastMath)) {
+    nvrtc_compile_driver.setOption("--use_fast_math");
+  }
+
   // Add line info to generated kernels
   if (isOptionEnabled(EnableOption::KernelLineInfo)) {
     nvrtc_compile_driver.setOption("-lineinfo");

--- a/tests/cpp/test_instructions.cpp
+++ b/tests/cpp/test_instructions.cpp
@@ -49,4 +49,35 @@ TEST_F(InstructionsTest, FmaxfGeneratesMaxInstruction) {
   testValidate(fusion.get(), output, {t0}, __LINE__, __FILE__);
 }
 
+TEST_F(InstructionsTest, FmaxfFastMath) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion->addInput(tv0);
+  auto tv1 = max(tv0, {1});
+  fusion->addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({4, 8}, options);
+
+  KernelExecutor ke;
+  {
+    DebugDumpOptionsGuard debug_dump_options_guard;
+    DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
+    EnableOptionsGuard enable_opt_guard;
+    EnableOptionsGuard::getCurOptions().set(EnableOption::FastMath);
+    ke.compile(fusion.get(), {t0});
+  }
+
+  // Verify PTX.
+  const executor_utils::CudaExecutable* compiled_kernel =
+      ke.compiledKernel()->cudaExecutable().get();
+  std::string ptx_string(
+      compiled_kernel->ptx.begin(), compiled_kernel->ptx.end());
+  EXPECT_TRUE(ptx_string.find("max.ftz.f32") != std::string::npos);
+
+  const auto output = ke.run({t0});
+  testValidate(fusion.get(), output, {t0}, __LINE__, __FILE__);
+}
 } // namespace nvfuser

--- a/tests/cpp/test_instructions.cpp
+++ b/tests/cpp/test_instructions.cpp
@@ -1,0 +1,52 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gtest/gtest.h>
+
+#include <fusion.h>
+#include <fusion_guard.h>
+#include <ops/all_ops.h>
+#include <runtime/executor.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+
+namespace nvfuser {
+
+using InstructionsTest = NVFuserTest;
+
+TEST_F(InstructionsTest, FmaxfGeneratesMaxInstruction) {
+  auto fusion = std::make_unique<Fusion>();
+  FusionGuard fg(fusion.get());
+
+  auto tv0 = makeSymbolicTensor(2);
+  fusion->addInput(tv0);
+  auto tv1 = max(tv0, {1});
+  fusion->addOutput(tv1);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({4, 8}, options);
+
+  KernelExecutor ke;
+  {
+    DebugDumpOptionsGuard debug_dump_options_guard;
+    DebugDumpOptionsGuard::getCurOptions().set(DebugDumpOption::Ptx);
+    ke.compile(fusion.get(), {t0});
+  }
+
+  // Verify PTX.
+  const executor_utils::CudaExecutable* compiled_kernel =
+      ke.compiledKernel()->cudaExecutable().get();
+  std::string ptx_string(
+      compiled_kernel->ptx.begin(), compiled_kernel->ptx.end());
+  EXPECT_TRUE(ptx_string.find("max.f32") != std::string::npos);
+
+  const auto output = ke.run({t0});
+  testValidate(fusion.get(), output, {t0}, __LINE__, __FILE__);
+}
+
+} // namespace nvfuser

--- a/tests/cpp/test_math_opt.cpp
+++ b/tests/cpp/test_math_opt.cpp
@@ -17,9 +17,9 @@
 
 namespace nvfuser {
 
-using InstructionsTest = NVFuserTest;
+using MathOptTest = NVFuserTest;
 
-TEST_F(InstructionsTest, FastMathTanh) {
+TEST_F(MathOptTest, FastMathTanh) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 


### PR DESCRIPTION
**How to enable**
If run with `NVFUSER_ENABLE=fast_math` will add `--use_fast_math` to compile option.

**Compiler-generated PTX:**
tanh --> `tanh.approx.f32 `
expf ---> `mul.ftz.f32 	%f3, %f2, 0f3FB8AA3B; ex2.approx.ftz.f32 	%f4, %f3;`

**Mainly influenced cases: Perf on GB200**

**Silu:** faster `exp`
<img width="1100" height="413" alt="image" src="https://github.com/user-attachments/assets/317dd412-be98-4169-9fa9-99c6d661bb06" />


**Gelu:** faster `tanh`
<img width="1097" height="427" alt="image" src="https://github.com/user-attachments/assets/6f154339-b3c3-43b9-bdda-1e4c8e723924" />


**Softmax:** faster `exp` (red markers) + fmaxf (blue markers, will be added in another PR)
<img width="1357" height="528" alt="image" src="https://github.com/user-attachments/assets/9e17396c-3a17-4fb8-ac59-e69dd40eddec" />



