### PR TITLE
Copy the majority of the small unit tests to direct bindings

### DIFF
--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,7 +42,7 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 41 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 39 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 **Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
@@ -96,8 +96,6 @@ The following tests will be added to tests/python/direct/test_python_frontend.py
 - `test_right_shift_logical` - Tests logical right shift; Missing bitwise_right_shift operation
 - `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size; Missing bitwise_right_shift operation
 - `test_var_correction` - Tests variance correction; Missing `var` operation
-- `test_bcast_squeeze_replace_aliased_output` - Tests broadcast squeeze with aliased output replacement; Tests issue 3833 with reshape and set operations
-- `test_broadcast_and_stride_order` - Tests broadcast operations with specific stride order handling
 - `test_fix_2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations)
 - `test_remove_empty_issue_2545` - Tests fix for issue 2545 (empty tensor handling with concatenation operations)
 
@@ -120,9 +118,11 @@ The following 12 tests exist in `tests/python/direct/test_python_frontend.py` bu
 
 ### Shared Tests
 
-Both test files contain these 71 common tests:
+Both test files contain these 73 common tests:
 - `test_addcmul` - Addcmul operations
 - `test_alias_output_to_input` - Output aliasing to input
+- `test_bcast_squeeze_replace_aliased_output` - Tests broadcast squeeze with aliased output replacement; Tests issue 3833 with reshape and set operations
+- `test_broadcast_and_stride_order` - Tests broadcast operations with specific stride order handling
 - `test_allocation_domain_concretization` - Tests allocation domain handling
 - `test_allocation_domain_index_select` - Tests index select with allocation domains
 - `test_basic` - Basic fusion operations
@@ -247,12 +247,12 @@ Contains direct frontend specific functionality tests:
 **Important Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted for the legacy frontend.
 
 - **Legacy Frontend**: 133 actual pytest test methods in `tests/python/test_python_frontend.py` (6 additional functions start with `test_` but are not pytest methods)
-- **Direct Frontend**: 114 actual pytest test functions in `tests/python/direct/test_python_frontend.py`
+- **Direct Frontend**: 116 actual pytest test functions in `tests/python/direct/test_python_frontend.py`
 - **Direct Repro**: 31 tests in `tests/python/direct/test_repro.py`
 - **Direct Python**: 6 tests in `tests/python/direct/test_python_direct.py`
-- **Total Direct Tests**: 151 tests across 3 files
-- **Shared Tests**: 71 tests between legacy and direct frontend
-- **Legacy-Only Tests**: 14 tests (not yet migrated)
+- **Total Direct Tests**: 153 tests across 3 files
+- **Shared Tests**: 73 tests between legacy and direct frontend
+- **Legacy-Only Tests**: 24 tests (not yet migrated)
 - **Direct-Only Tests**: 12 tests (new functionality)
 
 ## Test Functions by File

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,21 +42,42 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 75 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 41 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+
+**Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
 #### Advanced Operations & Features
 
-**Disabled because of CUDA 13 incompatiblity**
-- `test_fusion_profiler` - Tests fusion profiling
-- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling
-- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels
+**General Tests -- Legacy-Only**
+The following tests only exist in legacy frontend:
+- `test_def_op_in_schedule` - Tests operation definition in schedules; scheduling and definition are not separate.
+- `test_func_definition` - Tests function definition; Redundant
+- `test_fusion_definition_error_cache` - Tests fusion definition error caching; No fusion cache
+- `test_fusion_information` - Tests fusion information retrieval; Not used in direct bindings
+- `test_debug_output` - Tests debug output functionality; Deprecated
+- `test_compute_contiguity` - Tests contiguity computation; Not used in Thunder
+- `test_static_tensor_sizes` - Tests static tensor sizes; Not used in Thunder
+- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling; An analogous test already exists
+- `test_repro_script_generation` - Tests reproduction script generation (130 lines); An analogous test already exists.
+- `test_pad_cache` - Tests padding cache; No fusion cache
+- `test_segmentation_reduction_pointwise_epilogue` - Tests segmented reduction; No segmentation support
+- `test_fusion_profiler` - Tests fusion profiling; Cuda 13 incompatibility
+- `test_fusion_profiler_user_schedule` - Tests user-defined fusion profiling; Cuda 13 incompatibility
+- `test_fusion_profiler_with_noncodegen_kernels` - Tests profiling with non-codegen kernels; Cuda 13 incompatibility
+- `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
 
-**Tests with More Than 50 Lines of Code:**
+**General Tests to add for basic functionality**
+The following functionality tests will be moved to tests/python/direct/test_python_direct.py.
+- `test_no_definition` - Tests undefined fusion behavior
+- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
+- `test_python_version_API` - Tests Python version API
+
+**General tests to add with more Than 50 Lines of Code:**
+The following tests are complex and will be moved to tests/python/direct/test_high_complexity.py.
 - `test_all_dim_var_mean` - Tests variance and mean across all dimensions
 - `test_arithmetic_ops` - Tests various arithmetic operations
 - `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes (79 lines)
 - `test_cat_symbolic` - Tests symbolic concatenation (86 lines)
-- `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
 - `test_mismatched_input_types` - Tests mismatched input type handling (50 lines)
 - `test_random_distinct_values` - Tests random distinct value generation (100 lines)
 - `test_reduction_transpose_sched_issue2317` - Tests reduction transpose scheduling
@@ -70,68 +91,21 @@ The following 75 tests exist in `tests/python/test_python_frontend.py` but are *
 - `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
 
-**General Tests -- Legacy-Only**
-- `test_def_op_in_schedule` - Tests operation definition in schedules; scheduling and definition are not separate.
-- `test_func_definition` - Tests function definition; Redundant
-- `test_fusion_definition_error_cache` - Tests fusion definition error caching; No fusion cache
-- `test_fusion_information` - Tests fusion information retrieval; Not used in direct bindings
-- `test_debug_output` - Tests debug output functionality; Deprecated
-- `test_compute_contiguity` - Tests contiguity computation; Not used in Thunder
-- `test_static_tensor_sizes` - Tests static tensor sizes; Not used in Thunder
-- `test_import_conflict_nvfuser_then_direct` - Tests import conflict handling; An analogous test already exists
-- `test_repro_script_generation` - Tests reproduction script generation (130 lines); An analogous test already exists.
-
-**General Tests -- To Add**
-- `test_no_definition` - Tests undefined fusion behavior
-- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
-- `test_python_version_API` - Tests Python version API
-
-**Tests with 50 Lines or Less:**
-- `test_allocation_domain_concretization` - Tests allocation domain handling
-- `test_allocation_domain_index_select` - Tests index select with allocation domains
-- `test_complex_constants` - Tests complex number constants
-- `test_complex_rsqrt` - Tests complex reciprocal square root
-- `test_constant_nans` - Tests constant NaN handling
-- `test_expand_to_zero` - Tests expansion to zero dimensions
-- `test_expanded_bcast_tensor` - Tests expanded broadcast tensors
-- `test_gcd` - Tests greatest common divisor
-- `test_inplace_update_on_non_contiguous_inputs` - Tests in-place updates
-- `test_input_scalar` - Tests scalar input handling
-- `test_integer_division` - Tests integer division
-- `test_mark_alias_pass` - Tests alias marking
-- `test_misaligned_add` - Tests misaligned addition
-- `test_nextafter` - Tests nextafter function
-- `test_ops_broadcast` - Tests broadcast operations
-- `test_pad_cache` - Tests padding cache
-- `test_pad_expanded_empty` - Tests padding with expanded empty tensors
-- `test_pad_prior_cat` - Tests padding before concatenation
-- `test_prod` - Tests product operations
-- `test_real_imag` - Tests real and imaginary parts
-- `test_reduction_complex_number` - Tests complex number reduction
-- `test_replaced_sizes_pr2714` - Tests size replacement
-- `test_reshape_squeeze_concretization` - Tests reshape squeeze concretization
-- `test_right_shift_arithmetic` - Tests arithmetic right shift
-- `test_right_shift_logical` - Tests logical right shift
-- `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size
-- `test_segment_set` - Tests segment set operations
-- `test_segmentation_reduction_pointwise_epilogue` - Tests segmented reduction
-- `test_signbit` - Tests sign bit operations
-- `test_slice_api` - Tests slice API
-- `test_sum_sliced_reshape_to_broadcast` - Tests sum sliced reshape to broadcast
-- `test_tensor_shape` - Tests tensor shape operations
-- `test_tensor_shape_expand_bcast` - Tests tensor shape expansion broadcast
-- `test_tensor_shape_nobcast` - Tests tensor shape without broadcast
-- `test_tensor_shape_with_output_bcast` - Tests tensor shape with output broadcast
-- `test_tensor_size_both_args_bcast` - Tests tensor size with broadcast arguments
-- `test_var_correction` - Tests variance correction
-- `test_var_mean_correction` - Tests variance mean correction
-- `test_zero_size_dim` - Tests zero size dimensions
+**General tests to add with 50 Lines or Less:**
+The following tests will be added to tests/python/direct/test_python_frontend.py
+- `test_right_shift_logical` - Tests logical right shift; Missing bitwise_right_shift operation
+- `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size; Missing bitwise_right_shift operation
+- `test_var_correction` - Tests variance correction; Missing `var` operation
+- `test_bcast_squeeze_replace_aliased_output` - Tests broadcast squeeze with aliased output replacement; Tests issue 3833 with reshape and set operations
+- `test_broadcast_and_stride_order` - Tests broadcast operations with specific stride order handling
+- `test_fix_2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations)
+- `test_remove_empty_issue_2545` - Tests fix for issue 2545 (empty tensor handling with concatenation operations)
 
 ### Tests Only in Direct Frontend (Not in Main)
 
-The following 15 tests exist in `tests/python/direct/test_python_frontend.py` but are **NOT** present in `tests/python/test_python_frontend.py`:
+The following 12 tests exist in `tests/python/direct/test_python_frontend.py` but are **NOT** present in `tests/python/test_python_frontend.py`:
 
-- `test_broadcast` - Tests basic broadcasting functionality
+- `test_broadcast` - Tests basic broadcasting functionality; Maps to legacy `test_ops_broadcast`.
 - `test_cast_scalar` - Tests scalar casting operations
 - `test_cummax` - Tests cumulative maximum operations
 - `test_cummin` - Tests cumulative minimum operations
@@ -141,53 +115,87 @@ The following 15 tests exist in `tests/python/direct/test_python_frontend.py` bu
 - `test_linear_with_bias` - Tests linear layers with bias
 - `test_linear_without_bias` - Tests linear layers without bias
 - `test_matmul` - Tests matrix multiplication
-- `test_slice` - Tests tensor slicing operations
-- `test_where` - Tests where operations
+- `test_slice` - Tests tensor slicing operations; Maps to legacy `test_slice_api`
+- `test_where` - Tests where operations; Maps to legacy `test_where_op`
 
 ### Shared Tests
 
-Both test files contain these common tests:
+Both test files contain these 71 common tests:
+- `test_addcmul` - Addcmul operations
+- `test_alias_output_to_input` - Output aliasing to input
+- `test_allocation_domain_concretization` - Tests allocation domain handling
+- `test_allocation_domain_index_select` - Tests index select with allocation domains
 - `test_basic` - Basic fusion operations
-- `test_enable_disable_options` - Tests enable/disable options
 - `test_basic_fp16` - Basic operations with FP16
+- `test_broadcast_mixing` - Broadcast mixing operations
 - `test_cast_double_to_half` - Casting double to half precision
 - `test_cast_fp8` - FP8 casting operations
+- `test_cat` - Concatenation operations
+- `test_complex_constants` - Tests complex number constants
+- `test_complex_rsqrt` - Tests complex reciprocal square root
 - `test_compute_tensor_descriptor` - Tests tensor descriptor computation
-- `test_promote_to_double` - Type promotion to double
-- `test_implicit_broadcast_input` - Implicit broadcast input handling
-- `test_explicit_broadcast_input` - Explicit broadcast input handling
-- `test_broadcast_mixing` - Broadcast mixing operations
-- `test_tensor_ndim` - Tensor dimensionality
-- `test_execute_with_tuple_and_list` - Execution with tuple and list inputs
+- `test_constant_nans` - Tests constant NaN handling
 - `test_dynamic_reshape` - Dynamic reshape operations
-- `test_reshape_dynamic` - Dynamic reshape functionality
 - `test_empty_reshape` - Empty tensor reshape
-- `test_squeeze` - Tensor squeezing operations
-- `test_expanded_reduction` - Expanded reduction operations
+- `test_execute_with_tuple_and_list` - Execution with tuple and list inputs
 - `test_expand` - Tensor expansion operations
+- `test_expand_to_zero` - Tests expansion to zero dimensions
+- `test_expanded_bcast_tensor` - Tests expanded broadcast tensors
+- `test_expanded_reduction` - Expanded reduction operations
+- `test_explicit_broadcast_input` - Explicit broadcast input handling
+- `test_gather` - Gather operations
+- `test_gcd` - Tests greatest common divisor
+- `test_implicit_broadcast_input` - Implicit broadcast input handling
 - `test_index_select` - Index selection operations
 - `test_index_select_scalar_indices` - Index selection with scalar indices
-- `test_select` - Tensor selection operations
-- `test_take_along_axis` - Take along axis operations
-- `test_where_dtypes` - Where operations with different data types
-- `test_addcmul` - Addcmul operations
+- `test_inplace_update_on_non_contiguous_inputs` - Tests in-place updates
+- `test_input_scalar` - Tests scalar input handling
+- `test_integer_division` - Tests integer division
 - `test_iota` - Iota tensor generation
-- `test_scalar_only_inputs` - Scalar-only input operations
-- `test_alias_output_to_input` - Output aliasing to input
-- `test_returning_aliased_outputs` - Returning aliased outputs
-- `test_welford` - Welford algorithm implementation
-- `test_gather` - Gather operations
-- `test_pad` - Padding operations
-- `test_pad_dynamic` - Dynamic padding operations
-- `test_cat` - Concatenation operations
+- `test_mark_alias_pass` - Tests alias marking
+- `test_misaligned_add` - Tests misaligned addition
+- `test_nextafter` - Tests nextafter function
 - `test_normal` - Normal distribution generation
-- `test_uniform` - Uniform distribution generation
 - `test_output_stride_order` - Output stride order handling
 - `test_output_stride_order_with_reduction` - Output stride order with reduction
+- `test_pad` - Padding operations
+- `test_pad_dynamic` - Dynamic padding operations
+- `test_pad_expanded_empty` - Tests padding with expanded empty tensors
+- `test_pad_prior_cat` - Tests padding before concatenation
+- `test_prod` - Tests product operations
+- `test_promote_to_double` - Type promotion to double
+- `test_real_imag` - Tests real and imaginary parts
+- `test_reduction_complex_number` - Tests complex number reduction
+- `test_replaced_sizes_pr2714` - Tests size replacement
+- `test_reshape_dynamic` - Dynamic reshape functionality
+- `test_reshape_squeeze_concretization` - Tests reshape squeeze concretization
+- `test_returning_aliased_outputs` - Returning aliased outputs
+- `test_right_shift_arithmetic` - Tests arithmetic right shift
+- `test_scalar_only_inputs` - Scalar-only input operations
+- `test_scatter_output_intermediate` - Scatter output intermediate operations
+- `test_scatter_scalar_src` - Scatter scalar source operations
+- `test_segment_set` - Tests segment set operations
+- `test_select` - Tensor selection operations
+- `test_signbit` - Tests sign bit operations
+- `test_squeeze` - Tensor squeezing operations
+- `test_sum_sliced_reshape_to_broadcast` - Tests sum sliced reshape to broadcast
+- `test_take_along_axis` - Take along axis operations
+- `test_tensor_ndim` - Tensor dimensionality
+- `test_tensor_shape` - Tests tensor shape operations
+- `test_tensor_shape_expand_bcast` - Tests tensor shape expansion broadcast
+- `test_tensor_shape_nobcast` - Tests tensor shape without broadcast
+- `test_tensor_shape_with_output_bcast` - Tests tensor shape with output broadcast
+- `test_tensor_size_both_args_bcast` - Tests tensor size with broadcast arguments
 - `test_triu` - Upper triangular operations
+- `test_uniform` - Uniform distribution generation
+- `test_var_mean_correction` - Tests variance mean correction
+- `test_welford` - Welford algorithm implementation
+- `test_where_dtypes` - Where operations with different data types
+- `test_zero_size_dim` - Tests zero size dimensions
 
-### Migrated Issue-Specific Tests
+### Additional Direct Frontend Test Files
 
+#### test_repro.py (31 tests)
 The following 18 issue-specific tests have been migrated from the main frontend to the direct frontend and are now available in `tests/python/direct/test_repro.py`:
 
 - `test_issue1129` - Tests fix for issue 1129 (reshape and index_select with strided tensors)
@@ -202,14 +210,50 @@ The following 18 issue-specific tests have been migrated from the main frontend 
 - `test_issue1706` - Tests fix for issue 1706 (complex operations derived from Llama2 network)
 - `test_issue1872` - Tests fix for issue 1872 (full tensor creation with slice operations and casting)
 - `test_issue1953` - Tests fix for issue 1953 (complex operations with strided tensors and multiple data types)
-- `test_issue2275_repro1` - Tests fix for issue 2275 (unpadded concatenation operations with complex tensor manipulations)
-- `test_issue2275_repro2` - Tests fix for issue 2275 (unpadded concatenation operations with trigonometric functions)
+- `test_issue2275_repro1` - Tests fix for issue 2275 (unpadded concatenation operations with complex tensor manipulations); Maps to legacy `test_unpadded_catop_issue2275_repro1`
+- `test_issue2275_repro2` - Tests fix for issue 2275 (unpadded concatenation operations with trigonometric functions); Maps to legacy `test_unpadded_catop_issue2275_repro2`
 - `test_issue2545` - Tests fix for issue 2545 (complex operations with empty tensors and concatenation)
 - `test_issue2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations)
 - `test_issue2755` - Tests fix for issue 2755 (slice operations with negation)
 - `test_issue3292` - Tests fix for issue 3292 (complex tensor operations with manual normalization and padding)
 
-These tests have been adapted to use the `nvfuser_direct` API and the `nvfuser_direct_test` pytest fixture, ensuring compatibility with the direct frontend while maintaining the same functionality as the original tests.
+The following 13 tests are from the original `tests/python/test_repro.py`.
+- `test_domain_map_hang` - Tests domain mapping hang issue
+- `test_issue4444` - Tests fix for issue 4444
+- `test_issue4459` - Tests fix for issue 4459
+- `test_issue4670` - Tests fix for issue 4670
+- `test_loop_promotion_cyclic_war` - Tests loop promotion cyclic WAR
+- `test_reduction_reference_missing_input_ids` - Tests reduction reference missing input IDs
+- `test_reshape_cancellation` - Tests reshape cancellation
+- `test_ws_tma_normalization1` - Tests workspace TMA normalization 1
+- `test_ws_tma_normalization2` - Tests workspace TMA normalization 2
+- `test_ws_tma_normalization3` - Tests workspace TMA normalization 3
+- `test_ws_tma_normalization4` - Tests workspace TMA normalization 4
+- `test_ws_tma_normalization5` - Tests workspace TMA normalization 5
+- `test_ws_tma_normalization6` - Tests workspace TMA normalization 6
+
+#### test_python_direct.py (6 tests)
+Contains direct frontend specific functionality tests:
+- `test_define_tensor` - Tests tensor definition
+- `test_enable_disable_options` - Tests enable/disable options
+- `test_execute_with_different_device` - Tests execution with different devices
+- `test_fusion_definition_print` - Tests fusion definition printing
+- `test_fusion_execution_cache` - Tests fusion execution caching; Maps to legacy `test_selected_device`
+- `test_repro_script_for` - Tests reproduction script generation; Maps to legacy `test_repro_script_generation`
+- `test_enable_disable_options` - Tests enable/disable options for scheduler selection; Tests matmul scheduler vs expr_eval scheduler options
+
+### Test Count Summary
+
+**Important Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted for the legacy frontend.
+
+- **Legacy Frontend**: 133 actual pytest test methods in `tests/python/test_python_frontend.py` (6 additional functions start with `test_` but are not pytest methods)
+- **Direct Frontend**: 114 actual pytest test functions in `tests/python/direct/test_python_frontend.py`
+- **Direct Repro**: 31 tests in `tests/python/direct/test_repro.py`
+- **Direct Python**: 6 tests in `tests/python/direct/test_python_direct.py`
+- **Total Direct Tests**: 151 tests across 3 files
+- **Shared Tests**: 71 tests between legacy and direct frontend
+- **Legacy-Only Tests**: 14 tests (not yet migrated)
+- **Direct-Only Tests**: 12 tests (new functionality)
 
 ## Test Functions by File
 

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,7 +42,7 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 39 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 37 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 **Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
@@ -96,8 +96,6 @@ The following tests will be added to tests/python/direct/test_python_frontend.py
 - `test_right_shift_logical` - Tests logical right shift; Missing bitwise_right_shift operation
 - `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size; Missing bitwise_right_shift operation
 - `test_var_correction` - Tests variance correction; Missing `var` operation
-- `test_fix_2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations)
-- `test_remove_empty_issue_2545` - Tests fix for issue 2545 (empty tensor handling with concatenation operations)
 
 ### Tests Only in Direct Frontend (Not in Main)
 
@@ -212,8 +210,8 @@ The following 18 issue-specific tests have been migrated from the main frontend 
 - `test_issue1953` - Tests fix for issue 1953 (complex operations with strided tensors and multiple data types)
 - `test_issue2275_repro1` - Tests fix for issue 2275 (unpadded concatenation operations with complex tensor manipulations); Maps to legacy `test_unpadded_catop_issue2275_repro1`
 - `test_issue2275_repro2` - Tests fix for issue 2275 (unpadded concatenation operations with trigonometric functions); Maps to legacy `test_unpadded_catop_issue2275_repro2`
-- `test_issue2545` - Tests fix for issue 2545 (complex operations with empty tensors and concatenation)
-- `test_issue2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations)
+- `test_issue2545` - Tests fix for issue 2545 (complex operations with empty tensors and concatenation); Maps to legacy `test_remove_empty_issue_2545`
+- `test_issue2549` - Tests fix for issue 2549 (broadcast_in_dim and division operations); Maps to `test_fix_2549`
 - `test_issue2755` - Tests fix for issue 2755 (slice operations with negation)
 - `test_issue3292` - Tests fix for issue 3292 (complex tensor operations with manual normalization and padding)
 
@@ -252,7 +250,7 @@ Contains direct frontend specific functionality tests:
 - **Direct Python**: 6 tests in `tests/python/direct/test_python_direct.py`
 - **Total Direct Tests**: 153 tests across 3 files
 - **Shared Tests**: 73 tests between legacy and direct frontend
-- **Legacy-Only Tests**: 24 tests (not yet migrated)
+- **Legacy-Only Tests**: 22 tests (not yet migrated)
 - **Direct-Only Tests**: 12 tests (new functionality)
 
 ## Test Functions by File

--- a/tests/python/direct/test_repro.py
+++ b/tests/python/direct/test_repro.py
@@ -1198,14 +1198,11 @@ def test_issue2275_repro2(nvfuser_direct_test):
 
 def test_issue2545(nvfuser_direct_test):
     """
-    Test for issue 2545 - tests complex operations with empty tensors and concatenation.
+    Test for issue 2545 - tests empty tensor handling with concatenation operations.
 
-    This test verifies that complex operations work correctly with:
-    - Empty tensors (zero-sized dimensions)
-    - Multiple concatenation operations
-    - Conditional operations (where, lt)
-    - Arithmetic operations with scalars
-    - Proper handling of empty tensor removal during optimization
+    This test verifies that operations with empty tensors work correctly,
+    particularly when concatenating tensors where one or more inputs
+    are empty tensors.
     """
     inputs = [
         torch.randint(0, 10, (2,), dtype=torch.int64, device="cuda:0").as_strided(
@@ -1258,11 +1255,9 @@ def test_issue2549(nvfuser_direct_test):
     """
     Test for issue 2549 - tests broadcast_in_dim and division operations.
 
-    This test verifies that broadcast_in_dim and division operations work correctly:
-    - Broadcasting a tensor to a specific shape with explicit broadcast dimensions
-    - Division operations with broadcasted tensors
-    - Proper handling of tensor shapes and strides
-    - Correct computation of division with broadcasted operands
+    This test verifies that broadcast_in_dim operations work correctly
+    with division operations, particularly when broadcasting tensors
+    with different shapes.
     """
     a = torch.ones(4, 1, dtype=torch.double, device="cuda")
     b = torch.ones(4, 4, dtype=torch.double, device="cuda")


### PR DESCRIPTION
This PR copies majority the small unit tests (<50 LoC) from `tests/python/test_python_frontend.py` to `tests/python/direct/test_python_frontend.py`. 

* Tests `test_right_shift_logical`, `test_right_shift_logical_sizeof_dtype`, and `test_var_correction` are skipped because `bitwise_right_shift` and `var` are not yet supported in the direct bindings.
* Corrected `tests/python/direct/README.md` to track remaining tests.

<details>

<summary> The tests added to direct bindings </summary>

1. test_allocation_domain_concretization - Tests allocation domain handling
2. test_allocation_domain_index_select - Tests index select with allocation domains
3. test_bcast_squeeze_replace_aliased_output - Tests broadcast squeeze with aliased output replacement; Tests issue 3833 with reshape and set operations
4. test_broadcast_and_stride_order - Tests broadcast operations with specific stride order handling
5. test_complex_constants - Tests complex number constants
6. test_complex_rsqrt - Tests complex reciprocal square root
7. test_constant_nans - Tests constant NaN handling
8. test_expand_to_zero - Tests expansion to zero dimensions
9. test_expanded_bcast_tensor - Tests expanded broadcast tensors
10. test_gcd - Tests greatest common divisor
11. test_inplace_update_on_non_contiguous_inputs - Tests in-place updates
12. test_input_scalar - Tests scalar input handling
13. test_integer_division - Tests integer division
14. test_mark_alias_pass - Tests alias marking
15. test_misaligned_add - Tests misaligned addition
16. test_nextafter - Tests nextafter function
17. test_ops_broadcast - Tests broadcast operations
18. test_pad_cache - Tests padding cache
19. test_pad_expanded_empty - Tests padding with expanded empty tensors
20. test_pad_prior_cat - Tests padding before concatenation
21. test_prod - Tests product operations
22. test_real_imag - Tests real and imaginary parts
23. test_reduction_complex_number - Tests complex number reduction
24. test_replaced_sizes_pr2714 - Tests size replacement
25. test_reshape_squeeze_concretization - Tests reshape squeeze concretization
26. test_right_shift_arithmetic - Tests arithmetic right shift
27. test_right_shift_logical - Tests logical right shift
28. test_right_shift_logical_sizeof_dtype - Tests logical right shift with dtype size
29. test_segment_set - Tests segment set operations
30. test_segmentation_reduction_pointwise_epilogue - Tests segmented reduction
31. test_signbit - Tests sign bit operations
32. test_slice_api - Tests slice API
33. test_sum_sliced_reshape_to_broadcast - Tests sum sliced reshape to broadcast
34. test_tensor_shape - Tests tensor shape operations
35. test_tensor_shape_expand_bcast - Tests tensor shape expansion broadcast
36. test_tensor_shape_nobcast - Tests tensor shape without broadcast
37. test_tensor_shape_with_output_bcast - Tests tensor shape with output broadcast
38. test_tensor_size_both_args_bcast - Tests tensor size with broadcast arguments
39. test_var_correction - Tests variance correction
40. test_var_mean_correction - Tests variance mean correction
41. test_zero_size_dim - Tests zero size dimension

</details>