### PR TITLE
Fix transfer_size calculation in pointwise scheduler

### DIFF
--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -409,17 +409,16 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
             broadcast_bit_multiples[break_point_i].rhs_multiple;
 
         // Estimate transfer cost with this break point
-        int64_t cur_transfer_size_bit = 1;
-        int64_t right_transfer_size_bit = 1;
+        int64_t cur_transfer_size_bit = lhs_bit_multiple;
+        int64_t right_transfer_size_bit = rhs_bit_multiple;
 
         for (const auto left_i : arange(break_point_i)) {
-          cur_transfer_size_bit =
-              cur_transfer_size_bit * elem_counts[left_i] * lhs_bit_multiple;
+          cur_transfer_size_bit = cur_transfer_size_bit * elem_counts[left_i];
         }
 
         for (const auto right_i : arange(break_point_i, ref_loop.size())) {
           right_transfer_size_bit =
-              right_transfer_size_bit * elem_counts[right_i] * rhs_bit_multiple;
+              right_transfer_size_bit * elem_counts[right_i];
         }
         cur_transfer_size_bit *= right_transfer_size_bit;
 


### PR DESCRIPTION
Resolves https://github.com/NVIDIA/Fuser/issues/4773 which tracks a wrong calculation in the pointwise scheduler noticed by @zasdfgbnm:
> The unit of cur_transfer_size and right_transfer_size were in the unit of byte ^ N, where N is the number of dimensions on the left/right of the break point...  Later in code, we are comparing the transfer sizes with L2 cache. This makes no sense. We can not compare a quantity with unit byte ^ N with a quantity with unit byte.

Fixing it shows a perf improvement in test_nvfuser:
```
./bin/test_nvfuser --gtest_filter=PointwiseTest.*

- Before PR: 30 tests from PointwiseTest (7252 ms total)
- After PR:  30 tests from PointwiseTest (7500 ms total)
```

TODO: test benchmarks