### PR TITLE
Remove unnecessary `NVF_API`

### DIFF
--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -19,27 +19,27 @@
 namespace nvfuser {
 
 // Returns true iff nvFuser was compiled with distributed APIs enabled.
-NVF_API bool distributedEnabled();
+bool distributedEnabled();
 
 // Return true if the TensorView is contiguous. This function is more
 // permissive than torch.Tensor.is_contiguous because it allows expanded
 // broadcasts.
-NVF_API bool isTvContiguous(const TensorView* tv);
+bool isTvContiguous(const TensorView* tv);
 
 // Returns whether a TensorView has a non-reduction axis parallelized Didx
 // Checks that the other non-reduction axis are not parallelized on Didx
-NVF_API bool isSharded(const TensorView*);
+bool isSharded(const TensorView*);
 
 // Returns number of device dimensions in a TensorView's loop domain.
-NVF_API int64_t numDeviceDims(const TensorView*);
+int64_t numDeviceDims(const TensorView*);
 
-NVF_API std::unordered_set<IterDomain*> getInputsInTargetDomain(
+std::unordered_set<IterDomain*> getInputsInTargetDomain(
     const std::vector<IterDomain*>& loop_ids,
     const std::vector<IterDomain*>& target_domain);
 
 // Returns the subset of tvs which elements have the different multi-device
 // sharding as ref
-NVF_API std::unordered_set<TensorView*> getTvsWithDifferentSharding(
+std::unordered_set<TensorView*> getTvsWithDifferentSharding(
     TensorView* ref,
     const std::vector<TensorView*>& tvs);
 
@@ -48,22 +48,22 @@ NVF_API bool isResharding(const Expr* expr);
 
 // Returns whether two tensors have different shardings. Expect a
 // producer/consumer relationship between the arguments.
-NVF_API bool haveDifferentShardings(
+bool haveDifferentShardings(
     const TensorView* producer,
     const TensorView* consumer);
 
 // Returns a set that contains DIDs and Stream.
-NVF_API std::unordered_set<ParallelType> deviceAndStreamParallelTypes();
+std::unordered_set<ParallelType> deviceAndStreamParallelTypes();
 
 // Collect device and stream parallelized IterDomains in `domain` and return
 // them as a ParallelType-to-IterDomain map. Excludes reduction iterdomains.
-NVF_API std::unordered_map<ParallelType, IterDomain*>
-mapDeviceAndStreamParallelTypeToId(const std::vector<IterDomain*>& domain);
+std::unordered_map<ParallelType, IterDomain*> mapDeviceAndStreamParallelTypeToId(
+    const std::vector<IterDomain*>& domain);
 
 // Shards all tensors in tvs like reference.
 // Accepts a set of parallel types to shard on.
 // If empty, all DID parallel types are used.
-NVF_API void shardAllLike(
+void shardAllLike(
     TensorView* ref,
     const std::vector<TensorView*>& tvs,
     const std::unordered_set<ParallelType>& parallel_types);
@@ -76,27 +76,27 @@ NVF_API void shardAllLike(
 // propagation checks all TVs in the fusion are assigned a device mesh
 // regardless if they are reachable. To keep the checks simple, we require all
 // TVs are assigned a mesh if they exist in the fusion.
-NVF_API void shardBetween(
+void shardBetween(
     const std::vector<TensorView*>& from,
     const std::vector<TensorView*>& to,
     TensorView* ref);
 // Same as above but using the outputs of the from and to expressions
 // to form the from and to TVs.
-NVF_API void shardBetween(
+void shardBetween(
     const std::vector<Expr*>& from,
     const std::vector<Expr*>& to,
     TensorView* ref);
 
 // Returns the devices involved in an expr
-NVF_API std::set<DeviceIdxType> involvedDevices(Expr* expr);
+std::set<DeviceIdxType> involvedDevices(Expr* expr);
 
 // Returns the number of device indices present accross all
 // device meshes in the Fusion
-NVF_API int64_t requestedNumberOfDevices(Fusion*);
+int64_t requestedNumberOfDevices(Fusion*);
 
 // remove the multi-device scheduling annotations
-NVF_API void unshard(Fusion*);
-NVF_API void unshard(TensorView*);
+void unshard(Fusion*);
+void unshard(TensorView*);
 
 // Returns the index of the sharded logical axis that produces the allocation
 // IterDomain sharded on `parallel_type`. If `tv` isn't sharded on the parallel
@@ -107,13 +107,11 @@ NVF_API void unshard(TensorView*);
 // `tv->getLogicalDomain()` map one-to-one modulo reduction. However, a size in
 // `at::Tensor::sizes` is a factor of the corresponding logical IterDomain's
 // extent if that IterDomain is sharded.
-NVF_API int64_t
-getShardedLogicalAxis(const TensorView* tv, ParallelType parallel_type);
+int64_t getShardedLogicalAxis(const TensorView* tv, ParallelType parallel_type);
 
 // Returns the index of the loop axis that's parallelized on `parallel_type`.
 // If it's not found, returns -1.
-NVF_API int64_t
-getShardedLoopAxis(const TensorView* tv, ParallelType parallel_type);
+int64_t getShardedLoopAxis(const TensorView* tv, ParallelType parallel_type);
 
 // Shards the input tensor along `axis`. How the tensor gets sliced along `axis`
 // is determined by `mesh` and `device_id`. Returns the sharded tensor.
@@ -125,7 +123,7 @@ NVF_API at::Tensor shardTensor(
 
 // Reorders a TensorView so that the DID parallelized axis are in front.
 // Returns a map of the old index to the new index.
-NVF_API std::unordered_map<int64_t, int64_t> reorderDIDToFront(TensorView*);
+std::unordered_map<int64_t, int64_t> reorderDIDToFront(TensorView*);
 
 // Given a TensorView and the shape of a sharded tensor of which certain
 // dimensions are partially allocated, returns the global shape that'll be used
@@ -161,18 +159,18 @@ NVF_API std::unordered_map<int64_t, int64_t> reorderDIDToFront(TensorView*);
 // allocated (local) tensors for sharded TensorViews. The logical shapes would
 // have to be passed through FusionKernelRuntime, FusionExecutor,
 // ExpressionEvaluator, and so on, which is an API overhaul.
-NVF_API std::vector<int64_t> unshardedSizes(
+std::vector<int64_t> unshardedSizes(
     const TensorView* tv,
     c10::IntArrayRef sizes);
 
 // Validate the expression is a valid DID split: expr is an outer split with
 // device dim as the outer dimension.
-NVF_API void validateDeviceSplit(Expr* expr);
+void validateDeviceSplit(Expr* expr);
 
 // Find the producing logical id of the given allocation id traversing
 // through device splits. For unsharded allocation_id, logical_id is the same as
 // allocation_id.
-NVF_API IterDomain* projectShardedAllocationToLogical(
+IterDomain* projectShardedAllocationToLogical(
     TensorView* tv,
     IterDomain* allocation_id);
 
@@ -180,7 +178,7 @@ NVF_API IterDomain* projectShardedAllocationToLogical(
 // traversing through device splits. For e.g.: `i0` -> `DIDx(d), i0/d` will
 // return `i0/d`. For unsharded logical_id, allocation_id is the same as
 // logical_id.
-NVF_API IterDomain* projectLogicalToShardedAllocation(
+IterDomain* projectLogicalToShardedAllocation(
     TensorView* tv,
     IterDomain* logical_id);
 


### PR DESCRIPTION
Only `isResharding` and `shardTensor` are called from python bindings.
Verified using: `python -c 'import nvfuser' && python -c 'import nvfuser_direct'`