### PR TITLE
Add var operation to direct bindings

### DIFF
--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -1711,6 +1711,38 @@ TensorView
     A new tensor containing the sum of elements along the specified dimensions.
 )")
   ops.def(
+      "var",
+      [](TensorView* arg,
+         const std::vector<int64_t>& dims,
+         int64_t correction,
+         bool keepdim) -> TensorView* {
+        return variance(arg, dims, correction, keepdim);
+      },
+      py::arg("arg"),
+      py::arg("dims"),
+      py::arg("correction") = 1,
+      py::arg("keepdim") = false,
+      R"(
+Reduce a tensor by computing the variance along specified dimensions.
+
+Parameters
+----------
+arg : TensorView
+    Input tensor to reduce.
+dims : list or tuple
+    Dimensions to reduce over.
+correction : int, optional
+    The correction factor to apply to the variance. Default is 1.
+keepdim : bool, optional
+    Whether to keep the reduced dimensions with size 1. Default is False.
+
+Returns
+-------
+TensorView
+    A tensor containing the variance along the specified dimensions.
+)",
+      py::return_value_policy::reference);
+  ops.def(
       "var_mean",
       [](TensorView* arg,
          const std::vector<int64_t>& dims,

--- a/python/python_direct/python_translate.cpp
+++ b/python/python_direct/python_translate.cpp
@@ -411,6 +411,7 @@ class PythonPrinter {
 //     with keepdim argument.
 //  3. Map Broadcast and Expand to `broadcast_in_dim`
 //  4. var_mean
+//  5. var
 class PythonTranslator : public OptInConstDispatch {
  public:
   // Returns a map from the values in the CPP fusion to its corresponding

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,7 +42,7 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 37 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 35 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 **Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
@@ -93,8 +93,6 @@ The following tests are complex and will be moved to tests/python/direct/test_hi
 
 **General tests to add with 50 Lines or Less:**
 The following tests will be added to tests/python/direct/test_python_frontend.py
-- `test_right_shift_logical` - Tests logical right shift; Missing bitwise_right_shift operation
-- `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size; Missing bitwise_right_shift operation
 - `test_var_correction` - Tests variance correction; Missing `var` operation
 
 ### Tests Only in Direct Frontend (Not in Main)
@@ -169,6 +167,8 @@ Both test files contain these 73 common tests:
 - `test_reshape_squeeze_concretization` - Tests reshape squeeze concretization
 - `test_returning_aliased_outputs` - Returning aliased outputs
 - `test_right_shift_arithmetic` - Tests arithmetic right shift
+- `test_right_shift_logical` - Tests logical right shift
+- `test_right_shift_logical_sizeof_dtype` - Tests logical right shift with dtype size
 - `test_scalar_only_inputs` - Scalar-only input operations
 - `test_scatter_output_intermediate` - Scatter output intermediate operations
 - `test_scatter_scalar_src` - Scatter scalar source operations
@@ -249,7 +249,7 @@ Contains direct frontend specific functionality tests:
 - **Direct Repro**: 31 tests in `tests/python/direct/test_repro.py`
 - **Direct Python**: 6 tests in `tests/python/direct/test_python_direct.py`
 - **Total Direct Tests**: 153 tests across 3 files
-- **Shared Tests**: 73 tests between legacy and direct frontend
+- **Shared Tests**: 75 tests between legacy and direct frontend
 - **Legacy-Only Tests**: 22 tests (not yet migrated)
 - **Direct-Only Tests**: 12 tests (new functionality)
 

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,7 +42,7 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 35 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 34 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 **Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
@@ -90,10 +90,6 @@ The following tests are complex and will be moved to tests/python/direct/test_hi
 - `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
 - `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
-
-**General tests to add with 50 Lines or Less:**
-The following tests will be added to tests/python/direct/test_python_frontend.py
-- `test_var_correction` - Tests variance correction; Missing `var` operation
 
 ### Tests Only in Direct Frontend (Not in Main)
 
@@ -186,6 +182,7 @@ Both test files contain these 73 common tests:
 - `test_tensor_size_both_args_bcast` - Tests tensor size with broadcast arguments
 - `test_triu` - Upper triangular operations
 - `test_uniform` - Uniform distribution generation
+- `test_var_correction` - Tests variance correction; Missing `var` operation
 - `test_var_mean_correction` - Tests variance mean correction
 - `test_welford` - Welford algorithm implementation
 - `test_where_dtypes` - Where operations with different data types

--- a/tests/python/direct/test_python_frontend.py
+++ b/tests/python/direct/test_python_frontend.py
@@ -2340,7 +2340,7 @@ def test_broadcast_and_stride_order(nvfuser_direct_test):
     nvfuser_direct_test.assertEqual(nvf_out[0].stride(), (1, 2, 2, 6))
 
 
-def test_right_shift_bitwise(nvfuser_direct_test):
+def test_right_shift_logical(nvfuser_direct_test):
     dtypes = [torch.int32, torch.int64]
     input = torch.tensor(
         [

--- a/tests/python/direct/test_python_frontend.py
+++ b/tests/python/direct/test_python_frontend.py
@@ -2422,6 +2422,10 @@ def test_right_shift_logical_sizeof_dtype(nvfuser_direct_test):
         num_bits = 32 if (dtype == torch.int32) else 64
 
         # expected_outputs given by jax.lax.shift_right_logical(inputs, sizeof(dtype))
+        # >>> jax.lax.shift_right_logical(input.to('cpu').numpy(), 32)
+        # Array([0, 0, 0, 0, 0, 0, 0, 0], dtype=int32)
+        # >>> jax.lax.shift_right_logical(input.to('cpu').numpy(), 64)
+        # Array([0, 0, 0, 0, 0, 0, 0, 0], dtype=int32)
         expected_output = torch.zeros_like(current_input)
 
         def fusion_func(fd: FusionDefinition):


### PR DESCRIPTION
This PR also adds `test_right_shift_logical` and `test_right_shift_logical_sizeof_dtype`, which didn't need any additional changes.