### PR TITLE
Check for a valid fusion before running execute in direct bindings.

### DIFF
--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -257,11 +257,7 @@ class FusionDefinition:
                 "Fusion does not exist! Use `with FusionDefinition() as fd: ...` to define a fusion.",
             )
 
-        if (
-            len(self._fusion.inputs()) == 0
-            or len(self._fusion.outputs()) == 0
-            or len(self._fusion.vals()) == 0
-        ):
+        if len(self._fusion.outputs()) == 0 or len(self._fusion.vals()) == 0:
             return False, "Fusion is empty!"
 
         return True, None

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -42,7 +42,7 @@ Each migrated test underwent the following adaptations:
 
 ### Tests Only in Main Frontend (Not in Direct)
 
-The following 33 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
+The following 32 tests exist in `tests/python/test_python_frontend.py` but are **NOT** present in `tests/python/direct/test_python_frontend.py`:
 
 **Note**: The legacy frontend uses class-based tests (`def test_*(self):`) while the direct frontend uses standalone functions (`def test_*(nvfuser_direct_test):`). Only actual pytest test methods (with `self` parameter) are counted here. `test_cat_qwen2_v2` is the only pytest outside of `TestNvFuserFrontend` in `tests/python/test_python_frontend.py`.
 
@@ -68,7 +68,6 @@ The following tests only exist in legacy frontend:
 
 **General Tests to add for basic functionality**
 The following functionality tests will be moved to tests/python/direct/test_python_direct.py.
-- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
 - `test_python_version_API` - Tests Python version API
 
 **General tests to add with more Than 50 Lines of Code:**
@@ -226,10 +225,11 @@ The following 13 tests are from the original `tests/python/test_repro.py`.
 - `test_ws_tma_normalization5` - Tests workspace TMA normalization 5
 - `test_ws_tma_normalization6` - Tests workspace TMA normalization 6
 
-#### test_python_direct.py (6 tests)
+#### test_python_direct.py
 Contains direct frontend specific functionality tests:
 - `test_fusion_not_defined` - Tests that `execute` raises exception when `Fusion` is not defined; Maps to legacy `test_no_definition`
 - `test_fusion_empty` - Tests that `execute` raise exception when `Fusion` is empty; Maps to legacy `test_no_definition`
+- `test_from_pytorch_fails_on_cpu_tensor` - Tests CPU tensor handling
 - `test_define_tensor` - Tests tensor definition
 - `test_enable_disable_options` - Tests enable/disable options
 - `test_execute_with_different_device` - Tests execution with different devices


### PR DESCRIPTION
This PR adds `test_fusion_not_defined`, `test_fusion_empty`, and `test_from_pytorch_fails_on_cpu_tensor` to check that a fusion is valid before running it.