### PR TITLE
Rename ViewOp to ReshapeOP

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -36,7 +36,7 @@ class AliasFinder : public OptOutConstDispatch {
       AliasAnalysisResult& analysis)
       : empty_allocation_as_(empty_allocation_as), analysis_(analysis) {}
 
-  void handle(const ViewOp*) override;
+  void handle(const ReshapeOp*) override;
   void handle(const LoadStoreOp*) override;
   void handle(const SliceOp*) override;
   void handle(const BroadcastOp*) override;
@@ -82,7 +82,7 @@ bool AliasFinder::aliasIfCompliant(
   return true;
 }
 
-void AliasFinder::handle(const ViewOp* view) {
+void AliasFinder::handle(const ReshapeOp* view) {
   TensorView* in = view->in();
   TensorView* out = view->out();
 

--- a/csrc/alias_analysis.h
+++ b/csrc/alias_analysis.h
@@ -54,8 +54,8 @@ class AliasAnalysisResult {
   TensorView* getRoot(const TensorView* alias) const;
 
  private:
-  // Maps an alias (e.g. the output of a `ViewOp`) to its direct source (e.g.
-  // the input of the same `ViewOp`). Also stores the preferred output layout
+  // Maps an alias (e.g. the output of a `ReshapeOp`) to its direct source (e.g.
+  // the input of the same `ReshapeOp`). Also stores the preferred output layout
   // for the alias. Consider path compression, a common optimization used in
   // disjoint-set data structure, so it's easy to figure out the root of an
   // alias.

--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -318,7 +318,7 @@ IdModelOptions getIdModelOptions(Fusion* fusion) {
       options.setUnswitchPredicate(true);
       options.setLoop(true);
       continue;
-    } else if (auto reshape = dynamic_cast<ViewOp*>(expr)) {
+    } else if (auto reshape = dynamic_cast<ReshapeOp*>(expr)) {
       // The legacy indexer has an issue when an expand broadcast is
       // involved in reshape transformations. Enable both tensor and
       // predicate indexing if found

--- a/csrc/device_lower/pass/fusion_simplifier.cpp
+++ b/csrc/device_lower/pass/fusion_simplifier.cpp
@@ -66,7 +66,7 @@ class LoadStoreOpInserter : private kir::ExprMutator {
             container, LoadStoreOpType::Set, out, in));
   }
 
-  void handle(ViewOp* vop) final {
+  void handle(ReshapeOp* vop) final {
     auto out = vop->out();
     auto in = vop->in();
     auto container = out->container();

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -120,7 +120,7 @@ bool isTvOp(const Expr* expr) {
           ExpandOp,
           RepeatOp,
           ViewAsScalar,
-          ViewOp,
+          ReshapeOp,
           PadOp,
           SliceOp,
           CatOp,
@@ -2144,8 +2144,13 @@ bool isWarpSpecializedLoop(ForLoop* loop) {
 }
 
 bool isCopyOnly(Expr* expr) {
-  return expr
-      ->isOneOf<LoadStoreOp, BroadcastOp, SqueezeOp, SliceOp, PadOp, ViewOp>();
+  return expr->isOneOf<
+      LoadStoreOp,
+      BroadcastOp,
+      SqueezeOp,
+      SliceOp,
+      PadOp,
+      ReshapeOp>();
 }
 
 bool isCopyOnly(Val* val) {

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -99,7 +99,7 @@ class Val;
   f(ExpandOp);                    \
   f(RepeatOp);                    \
   f(ViewAsScalar);                \
-  f(ViewOp);                      \
+  f(ReshapeOp);                   \
   f(CatOp);                       \
   f(PadOp);                       \
   f(SliceOp);                     \

--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -148,7 +148,7 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
   }
 
   //! Find views that have symbolic outputs
-  void handle(ViewOp* op) override {
+  void handle(ReshapeOp* op) override {
     auto inp_tv = op->in()->as<TensorView>();
     auto out_tv = op->out()->as<TensorView>();
     // If there's no symbolic axis, this is a static reshape op
@@ -327,7 +327,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
   const auto& reshape_tvs = initial_info_->getDynamicReshapedTensorViews();
   for (const auto tv_index : arange((int64_t)reshape_tvs.size())) {
     auto out_tv = reshape_tvs.at(tv_index);
-    auto op = out_tv->definition()->as<ViewOp>();
+    auto op = out_tv->definition()->as<ReshapeOp>();
     auto inp_tv = op->in()->as<TensorView>();
 
     // If there's no symblic axis, this is a static reshape op
@@ -337,7 +337,7 @@ void DynamicTransformConcretizationInfo::analyzeReshapes(
 
     NVF_ERROR(
         out_tv->hasRoot(),
-        "Unexpected output tv of ViewOp: ",
+        "Unexpected output tv of ReshapeOp: ",
         out_tv->toString());
 
     const auto& inp_dom =
@@ -914,7 +914,7 @@ TensorView* DynamicTransformConcretizer::concretizeNonEmptyReshape(
   //   T1[ iS2{i0} rS3{i1} ] = sum(T0[ iS0{i0} iS1{i1} ])
   //   T3[ iS4{i0} ] = -T1[ iS2{i0} rS3{i1} ]
   //
-  // Notice here that the ViewOp is gone since we recognized that there is no
+  // Notice here that the ReshapeOp is gone since we recognized that there is no
   // transformation to perform. Instead, T1 is used directly in place of T2.
   // We also replace the extent i2 from the dynamic reshape output T2 with i0,
   // which is what the code below implements. Since T1 includes a Reduction
@@ -1004,7 +1004,7 @@ void DynamicTransformConcretizer::concretizeReshape() {
   for (const auto& [tv_index, view_info] : info_->getReshapeTransforms()) {
     auto incomplete_out_tv =
         info_->initialInfo()->getDynamicReshapedTensorViews().at(tv_index);
-    auto view_op = incomplete_out_tv->definition()->as<ViewOp>();
+    auto view_op = incomplete_out_tv->definition()->as<ReshapeOp>();
     auto inp_tv = view_op->in()->as<TensorView>();
 
     TensorView* concrete_reshape_out_tv = nullptr;

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -65,8 +65,8 @@ class DynamicTransformInitialInfo {
     return maybe_zero_extents_;
   }
 
-  //! Return a vector of outputs of ViewOp expressions that have dynamic output
-  //! shapes
+  //! Return a vector of outputs of ReshapeOp expressions that have dynamic
+  //! output shapes
   const std::vector<TensorView*>& getDynamicReshapedTensorViews() const {
     return dynamic_reshaped_tvs_;
   }

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -75,7 +75,7 @@ enum class AllocationType : int {
   ReuseBuffer,
   // This is used to cheaply compute the output tensor using
   // `ExpressionEvaluator` (instead of a kernel) for:
-  // 1. PointerArithmetics: For example, the output of a ViewOp is merely a
+  // 1. PointerArithmetics: For example, the output of a ReshapeOp is merely a
   // pointer arithmetic of the input.  In this case, aliased_io is a non-null
   // tensor.
   // 2. To evaluate output tensors which are not aliases. For example, default

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -1890,7 +1890,7 @@ std::pair<IrCloner, std::unique_ptr<Fusion>> SegmentedFusion::makeFusion(
   for (auto inp : getAllInputs(sg)) {
     auto clone_tv = complete_to_segment_map.clone(inp);
     fusion_segment->addInput(clone_tv);
-    if (inp->isDefinitionType<ViewOp>()) {
+    if (inp->isDefinitionType<ReshapeOp>()) {
       NVF_ERROR(clone_tv != nullptr && clone_tv->isA<TensorView>());
       view_tvs.push_back(clone_tv->as<TensorView>());
     }

--- a/csrc/host_ir/jit.cpp
+++ b/csrc/host_ir/jit.cpp
@@ -789,7 +789,7 @@ class HostIrCompileDispatcher : public OptInDispatch {
       : builder_(builder), val_to_value_(val_to_value), container_(container) {}
   using OptInDispatch::handle;
 
-  void handle(ViewOp* vop) final {
+  void handle(ReshapeOp* vop) final {
     auto* in_tv = vop->in()->as<TensorView>();
     auto* out_tv = vop->out()->as<TensorView>();
     llvm::Value* in_tensor = getOrDefault(val_to_value_, in_tv);

--- a/csrc/ir/allocation_utils.h
+++ b/csrc/ir/allocation_utils.h
@@ -104,7 +104,7 @@ bool isCompliantWith(const Layout& layout, const Layout& required);
 // the mapping from `in_logical` to `out_root` and applies that mapping to
 // `preferred_in_layout`. For many ops, this function returns a good initial
 // preferred output layout for aliasing because it tries to preserve the input
-// layout. An op (e.g. ViewOp and SliceOp) that transforms root to logical
+// layout. An op (e.g. ReshapeOp and SliceOp) that transforms root to logical
 // using expressions will have to modify this initial layout so its allocation
 // domain will be a function of its logical domain.
 //

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -1624,16 +1624,16 @@ class ViewAsScalar : public Expr {
   }
 };
 
-class NVF_API ViewOp : public Expr {
+class NVF_API ReshapeOp : public Expr {
  public:
   using Expr::Expr;
 
-  ViewOp(IrBuilderPasskey, Val* out, Val* in);
+  ReshapeOp(IrBuilderPasskey, Val* out, Val* in);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
   const char* getOpString() const override {
-    return "ViewOp";
+    return "ReshapeOp";
   }
 
   std::string toString(int indent_size = 0) const override;

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2312,7 +2312,8 @@ std::vector<PolymorphicValue> ViewAsScalar::evaluate(
 
 NVFUSER_DEFINE_CLONE_AND_CREATE(ViewAsScalar)
 
-ViewOp::ViewOp(IrBuilderPasskey passkey, Val* out, Val* in) : Expr(passkey) {
+ReshapeOp::ReshapeOp(IrBuilderPasskey passkey, Val* out, Val* in)
+    : Expr(passkey) {
   NVF_ERROR(
       in->isA<TensorView>(),
       in->toString(),
@@ -2325,18 +2326,18 @@ ViewOp::ViewOp(IrBuilderPasskey passkey, Val* out, Val* in) : Expr(passkey) {
   addInput(in);
 }
 
-std::string ViewOp::toString(int indent_size) const {
+std::string ReshapeOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << " = view( "
                           << in()->toString() << " )\n";
   return ss.str();
 }
 
-std::string ViewOp::toInlineString(int indent_size) const {
+std::string ReshapeOp::toInlineString(int indent_size) const {
   NVF_CHECK(false, "Tensor op can not be printed inline");
 }
 
-std::vector<PolymorphicValue> ViewOp::evaluate(
+std::vector<PolymorphicValue> ReshapeOp::evaluate(
     const ExpressionEvaluator& ee,
     const std::vector<PolymorphicValue>& inputs) const {
   NVF_ERROR(inputs.size() == 1);
@@ -2345,14 +2346,14 @@ std::vector<PolymorphicValue> ViewOp::evaluate(
   const auto& [out_shape, _] = inferShapeOfOutput(out(), ee);
   // TODO: check allocation domain and contiguity.
 
-  // Use `at::Tensor::reshape` instead of `at::Tensor::view` because `ViewOp`
+  // Use `at::Tensor::reshape` instead of `at::Tensor::view` because `ReshapeOp`
   // doesn't always produce an alias. For example, when merging an expanded
-  // `IterType::Broadcast` and an `IterType::Iteration`, `ViewOp` has to realize
-  // the expand.
+  // `IterType::Broadcast` and an `IterType::Iteration`, `ReshapeOp` has to
+  // realize the expand.
   return {in_tensor.reshape(out_shape)};
 }
 
-NVFUSER_DEFINE_CLONE_AND_CREATE(ViewOp)
+NVFUSER_DEFINE_CLONE_AND_CREATE(ReshapeOp)
 
 LoadStoreOp::LoadStoreOp(
     IrBuilderPasskey passkey,

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -632,18 +632,18 @@ bool isSegmentSet(const Expr* e) {
   return false;
 }
 
-std::vector<ViewOp*> getViewOps(Fusion* fusion) {
+std::vector<ReshapeOp*> getReshapeOps(Fusion* fusion) {
   auto all_exprs = fusion->exprs();
 
-  auto all_view_ops = ir_utils::filterByType<ViewOp>(all_exprs);
+  auto all_view_ops = ir_utils::filterByType<ReshapeOp>(all_exprs);
 
-  std::vector<ViewOp*> view_ops;
+  std::vector<ReshapeOp*> view_ops;
 
   std::copy_if(
       all_view_ops.begin(),
       all_view_ops.end(),
       std::back_inserter(view_ops),
-      [](ViewOp* view) {
+      [](ReshapeOp* view) {
         return std::any_of(
             view->outputs().begin(), view->outputs().end(), [](Val* v) {
               if (!v->isA<TensorView>()) {
@@ -1645,7 +1645,7 @@ std::pair<std::vector<IterDomain*>, std::vector<IterDomain*>>
 getReshapeInputAndOutputIds(TensorView* reshape_out_tv) {
   NVF_ERROR(
       reshape_out_tv->definition() != nullptr &&
-          reshape_out_tv->definition()->isA<ViewOp>(),
+          reshape_out_tv->definition()->isA<ReshapeOp>(),
       "Not a reshape output: ",
       reshape_out_tv->toString());
 

--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -382,7 +382,7 @@ bool isSegmentSet(const Expr* e);
 // Returns all non-trivial view operations. We shouldn't have trivial view
 // operations but this function is to simply make sure if we ever do we don't
 // pull them in.
-std::vector<ViewOp*> getViewOps(Fusion*);
+std::vector<ReshapeOp*> getReshapeOps(Fusion*);
 
 template <typename T>
 std::string toString(const T& nodes) {

--- a/csrc/logical_domain_map.h
+++ b/csrc/logical_domain_map.h
@@ -490,7 +490,7 @@ class ComputeAtLogicalDomainMapBuilder : private BackwardVisitor {
     mapPointwiseLikeOp(wop);
   }
 
-  void handle(ViewOp* op) override {
+  void handle(ReshapeOp* op) override {
     mapPointwiseLikeOp(op);
   }
 

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -194,7 +194,7 @@ TensorView* reshape(TensorView* inp_tv, const std::vector<Val*>& new_sizes) {
           TensorDomain::getContiguityFilledWith(logical_domain, true)),
       inp_tv->dtype());
 
-  IrBuilder::createInContainer<ViewOp>(inp_tv->container(), out_tv, inp_tv);
+  IrBuilder::createInContainer<ReshapeOp>(inp_tv->container(), out_tv, inp_tv);
 
   return out_tv;
 }
@@ -213,7 +213,7 @@ NVF_API TensorView* reshape(
           logical_domain,
           TensorDomain::getContiguityFilledWith(logical_domain, true)),
       x->getDataType().value());
-  IrBuilder::create<ViewOp>(out_tv, x);
+  IrBuilder::create<ReshapeOp>(out_tv, x);
   return out_tv;
 }
 
@@ -245,7 +245,7 @@ TensorView* flatten(TensorView* x, int64_t start_dim, int64_t end_dim) {
       x->domain()->flatten(start_dim, end_dim),
       x->getDataType().value());
 
-  IrBuilder::create<ViewOp>(out, x);
+  IrBuilder::create<ReshapeOp>(out, x);
   return out;
 }
 

--- a/csrc/preseg_passes/consecutive_cast.cpp
+++ b/csrc/preseg_passes/consecutive_cast.cpp
@@ -52,7 +52,7 @@ bool shouldSwapMetaCast(Expr* cast) {
   // issue: https://github.com/NVIDIA/Fuser/issues/3665.
   return (meta != nullptr && !meta->output(0)->isFusionOutput() &&
           meta->output(0)->uses().size() == 1) &&
-      (meta->isOneOf<SqueezeOp, ViewOp>() || ir_utils::isSimpleTVSet(meta));
+      (meta->isOneOf<SqueezeOp, ReshapeOp>() || ir_utils::isSimpleTVSet(meta));
 }
 
 // replays meta operation on `new_in`. return the new output from replayed meta
@@ -83,8 +83,8 @@ Val* replayMetaOnNewInput(
         replayed_meta_out,
         new_in,
         meta->as<BroadcastOp>()->getBroadcastDimFlags());
-  } else if (meta->isA<ViewOp>()) {
-    // replay transformation for ViewOp
+  } else if (meta->isA<ReshapeOp>()) {
+    // replay transformation for ReshapeOp
     NVF_ERROR(meta->output(0)->isA<TensorView>());
     TensorView* meta_tv_out = meta->output(0)->as<TensorView>();
 
@@ -129,7 +129,7 @@ Val* replayMetaOnNewInput(
         new_in->getDataType().value());
 
     // create the view op.
-    IrBuilder::create<ViewOp>(replayed_meta_out, new_in);
+    IrBuilder::create<ReshapeOp>(replayed_meta_out, new_in);
   } else {
     NVF_ERROR(
         ir_utils::isSimpleTVSet(meta), "Unidentified operation for replay");

--- a/csrc/preseg_passes/move_repeat_forward.cpp
+++ b/csrc/preseg_passes/move_repeat_forward.cpp
@@ -261,13 +261,13 @@ class MoveRepeatForward {
   MoveRepeatForward(Fusion* fusion) : fusion_(fusion) {}
 
   void run() {
-    auto reshape_ops = ir_utils::getOpsOfType<ViewOp>(fusion_);
+    auto reshape_ops = ir_utils::getOpsOfType<ReshapeOp>(fusion_);
     std::vector<TensorView*> reshape_output_tvs;
     reshape_output_tvs.reserve(reshape_ops.size());
     std::ranges::transform(
         reshape_ops,
         std::back_inserter(reshape_output_tvs),
-        [](ViewOp* reshape) { return reshape->out(); });
+        [](ReshapeOp* reshape) { return reshape->out(); });
 
     // For each reshape output, if it's a repeating reshape and a
     // valid move target is found, try moving the repetition after the
@@ -459,7 +459,7 @@ class MoveRepeatForward {
         std::distance(repeat_output_tv->getRootDomain().begin(), broadcast_it);
 
     auto repeat_input_tv = repeat_output_tv->definition()
-                               ->as<ViewOp>()
+                               ->as<ReshapeOp>()
                                ->input(0)
                                ->as<TensorView>();
 

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -384,7 +384,7 @@ findPairingSplit(CatOp* cat) {
     // Currently, I limit this to only reshapes and permutes to reduce blast
     // radius.
     auto supported = [](Expr* e) -> bool {
-      if (e->isA<ViewOp>()) {
+      if (e->isA<ReshapeOp>()) {
         return true;
       }
       if (auto* set = dynamic_cast<LoadStoreOp*>(e)) {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -292,7 +292,7 @@ bool InnerOuterPersistentKernelScheduler::canScheduleCompileTime(
     return false;
   }
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
       scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
+++ b/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
@@ -447,7 +447,7 @@ void scheduleOuterReduction(
   for (auto& outer_reduction_tv : outer_reduction_tvs) {
     // Similar to the inner reduction, we need to reorder the outer reduction tv
     // when there are view operations.
-    if (!ir_utils::getViewOps(fusion).empty()) {
+    if (!ir_utils::getReshapeOps(fusion).empty()) {
       // Reorder reference_tv after propagating the view operation. This will
       // reorder for better merging.
       outer_reduction_tv->reorder(

--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -426,7 +426,7 @@ void scheduleOuterReduction(
   for (auto& outer_reduction_tv : outer_reduction_tvs) {
     // Similar to the inner reduction, we need to reorder the outer reduction tv
     // when there are view operations.
-    if (!ir_utils::getViewOps(fusion).empty()) {
+    if (!ir_utils::getReshapeOps(fusion).empty()) {
       // Reorder reference_tv after propagating the view operation. This will
       // reorder for better merging.
       outer_reduction_tv->reorder(

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -1230,7 +1230,7 @@ bool compileTimeCheck(Fusion* fusion, SchedulerType scheduler_type) {
     return false;
   }
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
       scheduler_debug_utils::canScheduleRejectReason(
@@ -1527,7 +1527,7 @@ TensorView* scheduleReductionGeneral(
   // changes registry needs to change.
   auto reduction_tv = reduction_tvs[0];
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     // Propagate reshape transforms through the graph, expecially the reference.
     scheduler_utils::propagateReshapeTransforms(fusion, ca_map);

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -213,7 +213,7 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
           data_cache, [&fusion, &largest_out]() {
             // NOTE: reorder_map is only applied for fusion without view
             // op yet.
-            if (!ir_utils::getViewOps(fusion).empty()) {
+            if (!ir_utils::getReshapeOps(fusion).empty()) {
               return std::make_unique<std::unordered_map<int64_t, int64_t>>();
             }
             return std::make_unique<std::unordered_map<int64_t, int64_t>>(
@@ -781,7 +781,7 @@ bool PointWiseScheduler::canScheduleCompileTime(Fusion* fusion) {
     return false;
   }
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
       scheduler_debug_utils::canScheduleRejectReason(
@@ -867,7 +867,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams* pparams) {
   int64_t rhs_i = -1;
   int64_t lhs_i = -1;
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     // Propagate reshape transforms through the graph, expecially the reference.
     scheduler_utils::propagateReshapeTransforms(fusion, ca_map);

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -1563,7 +1563,7 @@ void scheduleReduction(Fusion* fusion, const ReductionParams* rparams) {
   // changes registry needs to change.
   auto reduction_tv = reduction_tvs[0];
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     // Propagate reshape transforms through the graph, expecially the reference.
     scheduler_utils::propagateReshapeTransforms(fusion, ca_map);
@@ -1719,7 +1719,7 @@ bool ReductionScheduler::canScheduleCompileTime(Fusion* fusion) {
     return false;
   }
 
-  if (!ir_utils::getViewOps(fusion).empty()) {
+  if (!ir_utils::getReshapeOps(fusion).empty()) {
     ComputeAtMap ca_map(fusion);
     if (registry_utils::requiresForwardViewReplay(fusion, ca_map)) {
       scheduler_debug_utils::canScheduleRejectReason(

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -625,7 +625,7 @@ void cancelReshapeInLoopDomains(TensorView* from_tv, bool skip_innermost_id) {
   for (auto exprs_it = all_dep_exprs_from_tv.rbegin();
        exprs_it != all_dep_exprs_from_tv.rend();
        ++exprs_it) {
-    auto reshape = dynamic_cast<ViewOp*>(*exprs_it);
+    auto reshape = dynamic_cast<ReshapeOp*>(*exprs_it);
     if (reshape == nullptr) {
       continue;
     }

--- a/csrc/scheduler/tools/loop_domain_scheduler.h
+++ b/csrc/scheduler/tools/loop_domain_scheduler.h
@@ -17,7 +17,7 @@ class Expr;
 class Fusion;
 class TensorView;
 class IterDomain;
-class ViewOp;
+class ReshapeOp;
 
 namespace scheduler_tools {
 

--- a/csrc/scheduler/tools/static_repeat.cpp
+++ b/csrc/scheduler/tools/static_repeat.cpp
@@ -28,7 +28,7 @@ std::optional<StaticRepeatInfo> getMaybeStaticRepeatInfo(
   }
 
   // Detect reshape
-  auto reshape = dynamic_cast<ViewOp*>(maybe_repeat_out_tv->definition());
+  auto reshape = dynamic_cast<ReshapeOp*>(maybe_repeat_out_tv->definition());
   if (reshape == nullptr) {
     return std::nullopt;
   }

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -145,7 +145,7 @@ struct TransposeViewPropagator : public MaxInfoSpanningTree::Propagator {
     // since view does NOT necessarily always introduce incoherent transform
     // that would break the propagation.
     auto chain_exprs = StmtSort::getExprsBetween({from}, {to});
-    if (!ir_utils::filterByType<ViewOp>(chain_exprs).empty()) {
+    if (!ir_utils::filterByType<ReshapeOp>(chain_exprs).empty()) {
       should_reject = true;
     };
   };

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -677,7 +677,8 @@ PersistentBufferInfo persistentBuffers(Fusion* fusion) {
   }
 
   // don't project if there are view ops and no buffer can be projected
-  persistent_buffer_info.has_view_ops = !ir_utils::getViewOps(fusion).empty();
+  persistent_buffer_info.has_view_ops =
+      !ir_utils::getReshapeOps(fusion).empty();
   if (persistent_buffer_info.has_view_ops) {
     return persistent_buffer_info;
   }
@@ -1235,7 +1236,7 @@ std::vector<TensorView*> getViewTVs(Fusion* fusion) {
   for (auto producer_tv : ir_utils::filterByType<TensorView>(fusion_vals)) {
     auto consumer_tvs = ir_utils::consumerTvsOf(producer_tv);
     for (auto consumer_tv : consumer_tvs) {
-      if (consumer_tv->isDefinitionType<ViewOp>()) {
+      if (consumer_tv->isDefinitionType<ReshapeOp>()) {
         view_tvs.push_back(consumer_tv);
       }
     }
@@ -3080,7 +3081,7 @@ TensorView* scheduleInputToSkipIntermediates(TensorView* tv) {
     }
     Expr* use = tv->uses().front();
 
-    // TODO: support ViewOp here too
+    // TODO: support ReshapeOp here too
     if (!use->isOneOf<BroadcastOp, SqueezeOp, LoadStoreOp>()) {
       break;
     }
@@ -3117,9 +3118,9 @@ TensorView* scheduleInputToSkipIntermediates(TensorView* tv) {
       // NOTE: This simple approach assumes that the allocation domains of the
       // producer are also logical domains. We can then map those to producer to
       // get IDs to use in the consumer's allocation domain to get IDs to use in
-      // the consumer's allocation domain. This fails for ViewOp, which is why
-      // it is currently disabled. In the future, we should propagate through
-      // transforms as well using something similar to
+      // the consumer's allocation domain. This fails for ReshapeOp, which is
+      // why it is currently disabled. In the future, we should propagate
+      // through transforms as well using something similar to
       // scheduler_tools::scheduleLoopDomainsLike();
       auto it = p2c.find(p_id);
       NVF_ERROR(it != p2c.end());

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -950,7 +950,7 @@ TensorView* applyViewTransforms(
       orig_tv->getDataType().value());
   consumer->setDeviceMesh(orig_tv->getDeviceMesh());
 
-  IrBuilder::createInContainer<ViewOp>(
+  IrBuilder::createInContainer<ReshapeOp>(
       orig_tv->container(), consumer, post_reduce_tv);
 
   return consumer;

--- a/python/log
+++ b/python/log
@@ -1,0 +1,1 @@
+zsh: command not found: ninja

--- a/python/python_direct/python_translate.cpp
+++ b/python/python_direct/python_translate.cpp
@@ -425,8 +425,8 @@ class PythonTranslator : public OptInConstDispatch {
       : printer_(os), fusion_(fusion) {}
 
   // The new shape for view operation can be dynamic. Check that all dynamic
-  // scalar dependencies are handled before the ViewOp.
-  bool checkViewShapeDependency(const ViewOp* vop) {
+  // scalar dependencies are handled before the ReshapeOp.
+  bool checkViewShapeDependency(const ReshapeOp* vop) {
     const std::vector<IterDomain*>& logical_out_domain =
         vop->out()->as<TensorView>()->domain()->logical();
     std::vector<Val*> logical_domain_extents;
@@ -501,7 +501,7 @@ class PythonTranslator : public OptInConstDispatch {
   // Check that all of the expression's inputs are defined in FusionDefinition.
   bool checkExpressionDependencies(Expr* e) {
     // short-circuit: Found a view operation without all its shape dependencies.
-    if (e->isA<ViewOp>() && !checkViewShapeDependency(e->as<ViewOp>())) {
+    if (e->isA<ReshapeOp>() && !checkViewShapeDependency(e->as<ReshapeOp>())) {
       return false;
     }
     return std::all_of(
@@ -526,7 +526,7 @@ class PythonTranslator : public OptInConstDispatch {
     // Scalar expressions are not handled by Fusion::exprs, so gather them
     // manually.
     for (Expr* e : to_visit) {
-      if (e->isA<ViewOp>() || e->isA<ExpandOp>() || e->isA<FullOp>()) {
+      if (e->isA<ReshapeOp>() || e->isA<ExpandOp>() || e->isA<FullOp>()) {
         std::vector<Expr*> extent_definitions =
             gatherScalarExpressions(e->output(0)->as<TensorView>());
         to_visit.insert(
@@ -732,7 +732,7 @@ class PythonTranslator : public OptInConstDispatch {
   // Utility functions
 
   // Create a vector for the logical domain of TensorView.
-  // Used with ViewOp and ExpandOp handlers
+  // Used with ReshapeOp and ExpandOp handlers
   std::vector<Val*> getShape(TensorView* tv) {
     const std::vector<IterDomain*>& logical_out_domain =
         tv->domain()->logical();
@@ -1140,7 +1140,7 @@ class PythonTranslator : public OptInConstDispatch {
         {sop->out()});
   }
 
-  void handle(const ViewOp* vop) final {
+  void handle(const ReshapeOp* vop) final {
     NVF_ERROR(vop != nullptr);
 
     // Get extent's for output's logical domain

--- a/tests/cpp/test_combined_inner_outer_reduction.cpp
+++ b/tests/cpp/test_combined_inner_outer_reduction.cpp
@@ -1483,7 +1483,7 @@ TEST_F(CombinedSchedulerTest, ThunderLayerNormBackward) {
 // https://nvbugspro.nvidia.com/bug/5374766
 // when view ops are present, project buffer to inputs is disabled and warp
 // specialized approach is not used.
-TEST_F(CombinedSchedulerTest, ViewOps) {
+TEST_F(CombinedSchedulerTest, ReshapeOps) {
   NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
   EnableOptionsGuard opt_guard;
   EnableOptionsGuard::getCurOptions().set(
@@ -1498,7 +1498,7 @@ TEST_F(CombinedSchedulerTest, ViewOps) {
   fusion->addInput(tv0);
   fusion->addInput(tv1);
 
-  // ViewOp: reshape from 2D to 3D
+  // ReshapeOp: reshape from 2D to 3D
   // 512 * 32 = 16384 elements, reshape to {128, 4, 32} = 16384 elements
   auto tv2 = reshape(tv0, {512, 32}, {128, 4, 32});
   auto tv3 = reshape(tv1, {512, 32}, {128, 4, 32});
@@ -1536,7 +1536,7 @@ TEST_F(CombinedSchedulerTest, ViewOps) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs(args);
 
-  // Verify that ViewOp disables warp specialized approach
+  // Verify that ReshapeOp disables warp specialized approach
   auto runtime = executor_cache.getMostRecentKernelRuntime();
   HeuristicParams* heur =
       runtime->schedulerHeuristics()->heuristicsList().at(0).get();

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -8921,7 +8921,7 @@ TEST_F(NVFuserTest, RepeatNonBroadcast) {
   auto tv1 = repeat(tv0, {2L});
   fusion.addOutput(tv1);
 
-  ASSERT_TRUE(tv1->definition()->isA<ViewOp>());
+  ASSERT_TRUE(tv1->definition()->isA<ReshapeOp>());
   ASSERT_TRUE(tv1->definition()->input(0)->definition()->isA<ExpandOp>());
   ASSERT_TRUE(tv1->definition()
                   ->input(0)

--- a/tests/cpp/test_move_split_cat.cpp
+++ b/tests/cpp/test_move_split_cat.cpp
@@ -544,7 +544,7 @@ TEST_F(MoveSplitCatTest, MultiplePairs) {
   EXPECT_THAT(exprs, Contains(IsPermute()).Times(1));
   // The two reshapes in region 1 stay as is and the two reshapes in region 2
   // are merged. Therefore, three reshapes in total.
-  EXPECT_THAT(exprs, Contains(IsA<ViewOp>()).Times(3));
+  EXPECT_THAT(exprs, Contains(IsA<ReshapeOp>()).Times(3));
 }
 
 TEST_F(MoveSplitCatTest, MultipleCatsOnSameSplit) {

--- a/tests/cpp/test_preseg_passes.cpp
+++ b/tests/cpp/test_preseg_passes.cpp
@@ -1246,7 +1246,7 @@ TEST_F(PresegTest, FusionTestCastOptimizationMetaOp6) {
         2);
     auto expr_iter =
         std::find_if(new_exprs.begin(), new_exprs.end(), [](Expr* new_expr) {
-          return new_expr->isA<ViewOp>();
+          return new_expr->isA<ReshapeOp>();
         });
     EXPECT_TRUE(
         expr_iter != new_exprs.end() &&

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -495,7 +495,7 @@ TEST_F(Tutorial, Reshape) {
     // tv1 = unsqueeze(reshape(squeeze(tv0)));
     ASSERT_TRUE(tv1->definition()->isA<BroadcastOp>());
     auto reshape_output = tv1->definition()->input(0)->as<TensorView>();
-    ASSERT_TRUE(reshape_output->definition()->isA<ViewOp>());
+    ASSERT_TRUE(reshape_output->definition()->isA<ReshapeOp>());
     auto squeeze_output =
         reshape_output->definition()->input(0)->as<TensorView>();
     ASSERT_TRUE(squeeze_output->definition()->isA<SqueezeOp>());


### PR DESCRIPTION
Long overdue cleanup. Just name change from `ViewOp` to `ReshapeOp`.

The test failures don't seem to be related.