### PR TITLE
[WIP] Multi-role warp specialization

### DIFF
--- a/csrc/device_lower/analysis/circular_buffer.cpp
+++ b/csrc/device_lower/analysis/circular_buffer.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <variant>
 #include <vector>
 
 namespace nvfuser {
@@ -846,69 +847,62 @@ IterDomain* getCircularBufferAxis(const TensorView* tv) {
   return tv->axis(cb_axis);
 }
 
+// Does this Expr represent an async producer?
+// TODO: move to lower_utils or ir_utils
+bool isAsyncProducer(Expr* e) {
+  if (ir_utils::isCpAsyncBulkLoad(e) &&
+      e->output(0)->as<TensorView>()->isCircularBuffered()) {
+    return true;
+  } else if (auto* mma = dynamic_cast<MmaOp*>(e); mma && mma->isBlackwell()) {
+    return true;
+  }
+  return false;
+}
+
 std::vector<AsyncWarp> createAsyncWarps(const std::vector<Expr*>& exprs) {
   std::vector<AsyncWarp> async_warps;
 
-  // Gather all async operations.
-  // TODO Add support for blackwell MmaOp
-  std::vector<Expr*> async_warp_exprs;
-  std::copy_if(
-      exprs.begin(),
-      exprs.end(),
-      std::back_inserter(async_warp_exprs),
-      [](Expr* e) {
-        return ir_utils::isCpAsyncBulkLoad(e) &&
-            e->output(0)->as<TensorView>()->isCircularBuffered();
-      });
+  for (Expr* e : exprs) {
+    if (!isAsyncProducer(e)) {
+      continue;
+    }
+    NVF_ERROR(
+        e->outputs().size() == 1,
+        "Expected async expression to produce only a single output");
+    NVF_ERROR(
+        e->output(0)->isA<TensorView>(),
+        "Expected async expression to produce a TensorView but found ",
+        e->output(0)->toString());
+    auto tv = e->output(0)->as<TensorView>();
+    const CircularBufferOptions& opt = tv->circularBufferOptions();
+    if (!std::holds_alternative<WarpSpecialized>(opt.type)) {
+      // Skip pipelined circular buffers
+      continue;
+    }
+    const auto& ws = std::get<WarpSpecialized>(opt.type);
+    if (ws.async_warp + 1 > (int64_t)async_warps.size()) {
+      async_warps.resize(ws.async_warp + 1);
+    }
+    AsyncWarp& warp = async_warps.at(ws.async_warp);
+    warp.exprs.push_back(e);
+    warp.tvs.push_back(tv);
 
-  // short-circuit: no async operations detected.
-  if (async_warp_exprs.empty()) {
-    return async_warps;
+    const std::optional<int64_t> opt_stage_slice_position =
+        ir_utils::getStageSlicePosition(tv);
+    const int64_t stage_slice_pos = opt_stage_slice_position.value_or(-1);
+    if (warp.stage_slice_position == -1) {
+      warp.stage_slice_position = stage_slice_pos;
+    } else {
+      NVF_ERROR(
+          warp.stage_slice_position == stage_slice_pos,
+          "Found conflicting stage slice positions ",
+          warp.stage_slice_position,
+          " and ",
+          stage_slice_pos,
+          " within the same async warp");
+    }
   }
 
-  // TODO Divide into operations into separate AsyncWarps for multi-role
-  // specialization. The current assumption is a single AsyncWarp with same
-  // stage_slice_position.
-
-  // Get TensorViews for async warps.
-  std::vector<TensorView*> async_warp_tvs;
-  std::transform(
-      async_warp_exprs.begin(),
-      async_warp_exprs.end(),
-      std::back_inserter(async_warp_tvs),
-      [](Expr* e) {
-        auto output_tvs =
-            ir_utils::filterByType<TensorView>(e->outputs()).vector();
-        NVF_ERROR(output_tvs.size() == 1);
-        return output_tvs.front();
-      });
-  NVF_ERROR(!async_warp_tvs.empty());
-
-  // Check that all operations in the same warp have the same
-  // stage_slice_position.
-  std::vector<int64_t> stage_slice_positions;
-  std::transform(
-      async_warp_tvs.begin(),
-      async_warp_tvs.end(),
-      std::back_inserter(stage_slice_positions),
-      [](TensorView* tv) {
-        std::optional<int64_t> opt_stage_slice_position =
-            ir_utils::getStageSlicePosition(tv);
-        return opt_stage_slice_position.value_or(-1);
-      });
-  NVF_ERROR(
-      stage_slice_positions.size() == 1 ||
-      std::all_of(
-          stage_slice_positions.begin() + 1,
-          stage_slice_positions.end(),
-          [&](int64_t v) { return v == stage_slice_positions.front(); }));
-
-  TensorView* async_warp_tv = async_warp_tvs.front();
-  NVF_ERROR(async_warp_tv != nullptr);
-  int64_t stage_slice_position = stage_slice_positions.front();
-
-  async_warps.emplace_back(
-      async_warp_exprs, async_warp_tvs, stage_slice_position);
   return async_warps;
 }
 

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -238,7 +238,7 @@ struct WarpSpecialized {
   // This value must be non-negative and all TVs with matching async_warp values
   // must have matching circular buffer position, stage_slice_position, and num
   // stages.
-  int64_t async_warp = -1;
+  int64_t async_warp = 0;
 
   explicit WarpSpecialized(
       ParallelType on,

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -228,9 +228,17 @@ inline std::ostream& operator<<(std::ostream& os, const Pipelined& pipelined) {
 struct WarpSpecialized {
   ParallelType on = ParallelType::Serial;
   // The number of registers for load and compute warps respectively.
+  // NOTE: if multiple async_warp options exist (i.e. multi-role warp
+  // specialization) then all values of num_registers must match in the compute
+  // warp position.
   std::optional<std::pair<int64_t, int64_t>> num_registers = std::nullopt;
   // The iterDomain position to define the shape of the circular buffer stage.
   std::optional<int64_t> stage_slice_position = std::nullopt;
+  // The async warp used for the definition of this TV
+  // -1 indicates the synchronous CUDA warps will be used.
+  // For non-negative values, all TVs with matching async_warp values must have
+  // matching circular buffer position, stage_slice_position, and num stages.
+  int64_t async_warp = -1;
 
   explicit WarpSpecialized(
       ParallelType on,

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -234,10 +234,10 @@ struct WarpSpecialized {
   std::optional<std::pair<int64_t, int64_t>> num_registers = std::nullopt;
   // The iterDomain position to define the shape of the circular buffer stage.
   std::optional<int64_t> stage_slice_position = std::nullopt;
-  // The async warp used for the definition of this TV
-  // -1 indicates the synchronous CUDA warps will be used.
-  // For non-negative values, all TVs with matching async_warp values must have
-  // matching circular buffer position, stage_slice_position, and num stages.
+  // The async warp used for the definition of this TV.
+  // This value must be non-negative and all TVs with matching async_warp values
+  // must have matching circular buffer position, stage_slice_position, and num
+  // stages.
   int64_t async_warp = -1;
 
   explicit WarpSpecialized(

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -2601,8 +2601,13 @@ TEST_P(CircularBufferingTest, SingleDimTwoAsyncWarps) {
   tv4->axis(-1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv4);
 
-  tv2->circularBuffer(number_of_stages, prefetch_distance);
-  tv3->circularBuffer(number_of_stages, prefetch_distance);
+  // tv2->circularBuffer(number_of_stages, prefetch_distance);
+  // tv3->circularBuffer(number_of_stages, prefetch_distance);
+  WarpSpecialized ws(ParallelType::TIDy);
+  ws.async_warp = 0;
+  tv2->circularBuffer(number_of_stages, ws);
+  ws.async_warp = 1;
+  tv3->circularBuffer(number_of_stages, ws);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   auto t0 = at::randn({1000}, options);


### PR DESCRIPTION
Status: generates ITE tree but kernel hangs. `TwoAsyncWarps` test runs successfully with `NVFUSER_ENABLE=kernel_debug` so there's a race that's mitigated by slowing down the kernel.

Generated kernel:
```c++

// Codegen generated code
template <nvfuser_index_t in0>
__device__ __inline__ void decreaseRegisters() {
  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n"::"n"(in0));
}
template <nvfuser_index_t in0>
__device__ __inline__ void increaseRegisters() {
  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n"::"n"(in0));
}

__global__ void __launch_bounds__(/*maxThreadsPerBlock=*/384, /*minBlocksPerMultiprocessor=*/1) nvfuser_none_f0_c0_r0_g0(Tensor<float, 2, 2> T0, Tensor<float, 2, 2> T1, Tensor<float, 2, 2> T4) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  nvfuser_index_t i0;
  i0 = ceilDiv(T0.logical_size[0LL], 2);
  nvfuser_index_t i1;
  i1 = ceilDiv((ceilDiv(T0.logical_size[1LL], 128)), 2);
  nvfuser_index_t i2;
  i2 = 4 * T0.logical_size[1LL];
  uint32_t i3;
  i3 = __to_uint32(i2);
  nvfuser_index_t i4;
  i4 = (T0.logical_size[1LL] * i0) * ((nvfuser_index_t)blockIdx.x);
  float* ptr5;
  ptr5 = T0.data + i4;
  float* T3 = reinterpret_cast<float*>(array + smem_offset + (((((T0.logical_size[1LL] * 2) * 4) + 128) + 127) & -128));
  float* T2 = reinterpret_cast<float*>(array + smem_offset + 128);
  uint32_t i6;
  i6 = toSmem(T2);
  float* ptr7;
  ptr7 = T1.data + i4;
  uint32_t i8;
  i8 = toSmem(T3);
  nvfuser_index_t i9;
  i9 = ((nvfuser_index_t)threadIdx.x) + (128 * ((nvfuser_index_t)threadIdx.y));
  nvfuser_index_t i10;
  i10 = i9 + i4;
  bool b11;
  b11 = ((nvfuser_index_t)threadIdx.x) < 32ULL;
  bool b12;
  b12 = ((nvfuser_index_t)threadIdx.y) == 0ULL;
  bool b13;
  b13 = ((nvfuser_index_t)threadIdx.z) == 0ULL;
  bool b14;
  b14 = ((nvfuser_index_t)threadIdx.y) == 2;
  nvfuser_index_t i15;
  i15 = ((nvfuser_index_t)threadIdx.x) / 32;
  bool b16;
  b16 = (((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL;
  nvfuser_index_t i17;
  i17 = i0 * ((nvfuser_index_t)blockIdx.x);
  bool b18;
  b18 = ((nvfuser_index_t)threadIdx.y) < 2;
  uint64_t* T5 = reinterpret_cast<uint64_t*>(array + smem_offset + 0);
  #pragma unroll
  for(nvfuser_index_t i19 = 0; i19 < 2; ++i19) {
    if ((((Hopper::electSync(4294967295U) && b11) && b12) && b13)) {
      mbarrier::init(toSmem((&T5[i19])), 2U);
    }
  }
  #pragma unroll
  for(nvfuser_index_t i20 = 0; i20 < 2; ++i20) {
    if ((((Hopper::electSync(4294967295U) && b11) && b12) && b13)) {
      mbarrier::init(toSmem((&T5[(i20 + 2LL)])), 256U);
    }
  }
  __syncthreads();
  if ((b14 && (i15 == 0))) {
    decreaseRegisters<152>();
    #pragma unroll 1
    for(nvfuser_index_t i21 = 0; i21 < i0; ++i21) {
      if (((b16 && Hopper::electSync(4294967295U)) && ((i17 + i21) < T0.logical_size[0LL]))) {
        mbarrier::waitParity(toSmem((&T5[((i21 % 2) + 2LL)])), __to_uint32(((i21 / 2) % 2)));
        mbarrier::arriveExpectTX(toSmem((&T5[(i21 % 2)])), i3);
        Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ (ptr5 + (T0.logical_size[1LL] * i21)), i3, toSmem((&T5[(i21 % 2)])) }), (i6 + (i2 * (i21 % 2))));
      }
    }
    return;
  } else {
    if ((b14 && (i15 == 1))) {
      decreaseRegisters<152>();
      #pragma unroll 1
      for(nvfuser_index_t i21 = 0; i21 < i0; ++i21) {
        if ((b16 && Hopper::electSync(4294967295U))) {
          mbarrier::waitParity(toSmem((&T5[((i21 % 2) + 2LL)])), __to_uint32(((i21 / 2) % 2)));
          mbarrier::arriveExpectTX(toSmem((&T5[(i21 % 2)])), i3);
          Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ (ptr7 + (T0.logical_size[1LL] * i21)), i3, toSmem((&T5[(i21 % 2)])) }), (i8 + (i2 * (i21 % 2))));
        }
      }
      return;
    } else {
      increaseRegisters<176>();
      #pragma unroll
      for(nvfuser_index_t i22 = 0; i22 < 2; ++i22) {
        mbarrier::arrive(toSmem((&T5[(i22 + 2LL)])));
      }
      increaseRegisters<176>();
      #pragma unroll
      for(nvfuser_index_t i23 = 0; i23 < 2; ++i23) {
        mbarrier::arrive(toSmem((&T5[(i23 + 2LL)])));
      }
      #pragma unroll 1
      for(nvfuser_index_t i24 = 0; i24 < i0; ++i24) {
        nvfuser_index_t i25;
        i25 = i9 + (T0.logical_size[1LL] * (i24 % 2));
        nvfuser_index_t i26;
        i26 = i10 + (T0.logical_size[1LL] * i24);
        bool b27;
        b27 = (i17 + i24) < T0.logical_size[0LL];
        bool b28;
        b28 = b18 && b27;
        if (b27) {
          mbarrier::waitParity(toSmem((&T5[(i24 % 2)])), __to_uint32(((i24 / 2) % 2)));
        }
        #pragma unroll 1
        for(nvfuser_index_t i29 = 0; i29 < i1; ++i29) {
          nvfuser_index_t i30;
          i30 = 256 * i29;
          nvfuser_index_t i31;
          i31 = i25 + i30;
          if ((b28 && ((i9 + i30) < T0.logical_size[1LL]))) {
            T4[(i26 + i30)]
              = T2[i31]
              * T3[i31];
          }
        }
        mbarrier::arrive(toSmem((&T5[((i24 % 2) + 2LL)])));
      }
    }
  }
  #pragma unroll
  for(nvfuser_index_t i32 = 0; i32 < 2; ++i32) {
    if ((((Hopper::electSync(4294967295U) && b11) && b12) && b13)) {
      mbarrier::inval(toSmem((&T5[(i32 + 2LL)])));
    }
  }
  #pragma unroll
  for(nvfuser_index_t i33 = 0; i33 < 2; ++i33) {
    if ((((Hopper::electSync(4294967295U) && b11) && b12) && b13)) {
      mbarrier::inval(toSmem((&T5[i33])));
    }
  }
}
```