### PR TITLE
Use logical domain in `squeeze` API 

### DIFF
--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -292,7 +292,10 @@ TensorView* squeeze(
     const std::vector<bool>& to_squeeze,
     bool squeeze_expanded) {
   NVF_ERROR(x != nullptr, "Input is invalid.");
-  auto x_dom = x->domain()->noReductions();
+  // SqueezeOp is cloned during segmentation where the loop domain
+  // may have device parallelization. Hence, use the logical domain
+  // explcitly to avoid a mismatch between domain and `to_squeeze` dims.
+  auto x_dom = TensorDomain::noReductions(x->getLogicalDomain());
   const auto ndims = static_cast<int64_t>(x_dom.size());
 
   NVF_ERROR(

--- a/csrc/ops/alias.cpp
+++ b/csrc/ops/alias.cpp
@@ -296,7 +296,7 @@ TensorView* squeeze(
   // may have device parallelization. Hence, use the logical domain
   // explcitly to avoid a mismatch between domain and `to_squeeze` dims.
   auto x_dom = TensorDomain::noReductions(x->getLogicalDomain());
-  const auto ndims = static_cast<int64_t>(x_dom.size());
+  const auto ndims = std::ssize(x_dom);
 
   NVF_ERROR(
       ndims == (int64_t)to_squeeze.size(),

--- a/tests/python/multidevice/test_multidevice.py
+++ b/tests/python/multidevice/test_multidevice.py
@@ -330,7 +330,7 @@ def test_privatize_squeeze(multidevice_direct_test):
         _definition(fd)
         _multidevice_schedule(fd)
 
-    unsharded = torch.randn(d * 3, 5, 6, dtype=torch.bfloat16, device="cpu")
+    unsharded = torch.randn(d * 3, 5, 6, dtype=torch.bfloat16)
     sharded = multidevice_direct_test.shard_tensor(unsharded, 0, mesh)
     out1, out2 = fd.execute([sharded])
     torch.testing.assert_close(out1.cpu(), unsharded.to(torch.float).sum(0))

--- a/tests/python/multidevice/test_multidevice.py
+++ b/tests/python/multidevice/test_multidevice.py
@@ -303,3 +303,35 @@ def test_sdpa_loop_split(multidevice_direct_test, qkv_format: QkvFormat):
         [expected_out, expected_q_grad, expected_k_grad, expected_v_grad],
     ):
         assert_close(actual, expected)
+
+
+@pytest.mark.mpi
+def test_privatize_squeeze(multidevice_direct_test):
+    d = multidevice_direct_test.size
+    mesh = nvfuser.multidevice.DeviceMesh(torch.arange(d))
+
+    def _definition(fd: FusionDefinition):
+        inp = fd.define_tensor((-1, -1, -1), dtype=DataType.BFloat16)
+        tv1 = fd.ops.broadcast(inp, [True, False, False, False])
+        tv2 = fd.ops.squeeze(tv1, dims=[0])
+        tv3 = fd.ops.cast(tv2, dtype=DataType.Float)
+        tv4 = fd.ops.sum(tv3, dims=[0])
+        tv5 = fd.ops.sum(tv3, dims=[1])
+        fd.add_output(tv4)
+        fd.add_output(tv5)
+
+    def _multidevice_schedule(fd: FusionDefinition):
+        for t in fd.fusion.inputs():
+            t.set_device_mesh(mesh)
+            t.split(0, d, inner_split=False)
+            t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
+
+    with FusionDefinition() as fd:
+        _definition(fd)
+        _multidevice_schedule(fd)
+
+    unsharded = torch.randn(d * 3, 5, 6, dtype=torch.bfloat16, device="cpu")
+    sharded = multidevice_direct_test.shard_tensor(unsharded, 0, mesh)
+    out1, out2 = fd.execute([sharded])
+    torch.testing.assert_close(out1.cpu(), unsharded.to(torch.float).sum(0))
+    torch.testing.assert_close(out2, sharded.to(torch.float).sum(1))


### PR DESCRIPTION
`privatizeUpcastOrSqueezeOps` in segmentation clones the `squeeze` operation. The `squeeze` op uses `domain()` (like most APIs) which returns the loop domain, and has device splits at segmentation stage. This produces an error since the `to_squeeze` dimensions are w.r.t. to logical domain.

Unblocks #4873 