### PR TITLE
Add `SdpaFwdOp::evaluate` on meta device

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -586,9 +586,8 @@ void UnaryOp::printHelper(std::stringstream& ss, std::string input) const {
     ss << inline_uop.value() << input;
   } else {
     if (op_type == UnaryOpType::Cast) {
-      std::optional<std::string> cast_str = cast_func_str(
-          std::make_pair(
-              in()->getDataType().value(), out()->getDataType().value()));
+      std::optional<std::string> cast_str = cast_func_str(std::make_pair(
+          in()->getDataType().value(), out()->getDataType().value()));
       NVF_ERROR(cast_str != std::nullopt, "Unsupported Cast");
       ss << cast_str.value();
     } else {
@@ -4098,11 +4097,10 @@ std::vector<Expr*> TensorDomain::allExprs() const {
         })) {
       exprs.pushBack(def);
     } else {
-      NVF_ERROR(
-          std::none_of(
-              def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
-                return all_id_set.find(inp) != all_id_set.end();
-              }));
+      NVF_ERROR(std::none_of(
+          def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
+            return all_id_set.find(inp) != all_id_set.end();
+          }));
     }
   }
 
@@ -4124,11 +4122,10 @@ std::vector<Statement*> TensorDomain::allStatements() const {
               })) {
         stmts.pushBack(def);
       } else {
-        NVF_ERROR(
-            std::none_of(
-                def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
-                  return all_id_set.find(inp) != all_id_set.end();
-                }));
+        NVF_ERROR(std::none_of(
+            def->inputs().begin(), def->inputs().end(), [&](Val* inp) {
+              return all_id_set.find(inp) != all_id_set.end();
+            }));
       }
     }
 
@@ -4519,11 +4516,10 @@ std::string SliceOp::toString(int indent_size) const {
   indent(ss, indent_size) << "   = slice( " << in()->toString() << ", {";
   for (const auto& slice : getRanges()) {
     ss << " {"
-       << toDelimitedString(
-              std::vector<std::string>{
-                  slice.start->toString(),
-                  slice.stop->toString(),
-                  slice.step->toString()})
+       << toDelimitedString(std::vector<std::string>{
+              slice.start->toString(),
+              slice.stop->toString(),
+              slice.step->toString()})
        << "}";
   }
   ss << " } )\n";

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4907,7 +4907,7 @@ std::tuple<Tensor, Tensor> _scaled_dot_product_flash_attention_meta(
       {batch_size, num_heads, seqlen_q}, q.options().dtype(at::kFloat));
 
   // Reshape output to convert nnz to batch_size and seq_len
-  Tensor attention = output.transpose(1, 2);
+  at::Tensor attention = output.transpose(1, 2);
   return std::make_tuple(attention, logsumexp);
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4903,22 +4903,14 @@ std::tuple<
     at::Tensor,
     at::Tensor>
 _scaled_dot_product_flash_attention_meta(const at::Tensor& query) {
-  // Query (Batch x Num_heads x Q_seq_len  x Dim_per_head)
-  // Query -> Query(Batch x Q_seq_len  x Num_heads x Dim_per_head)
-  at::Tensor q_t = query.transpose(1, 2);
-
-  const auto sizes = q_t.sizes();
+  const auto sizes = query.sizes();
   const int batch_size = sizes[0];
-  int seqlen_q = sizes[1];
-  int num_heads = sizes[2];
-  at::Tensor output = at::empty_like(q_t);
+  int num_heads = sizes[1];
+  int seqlen_q = sizes[2];
   auto logsumexp = at::empty(
-      {batch_size, num_heads, seqlen_q}, q_t.options().dtype(at::kFloat));
-
-  // Reshape output to convert nnz to batch_size and seq_len
-  at::Tensor attention = output.transpose(1, 2);
+      {batch_size, num_heads, seqlen_q}, query.options().dtype(at::kFloat));
   return std::make_tuple(
-      attention,
+      query,
       logsumexp,
       at::Tensor(),
       at::Tensor(),

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4892,11 +4892,11 @@ std::string SdpaFwdOp::toInlineString(int indent_size) const {
 
 namespace spda_meta {
 
-std::tuple<Tensor, Tensor> _scaled_dot_product_flash_attention_meta(
-    const Tensor& query) {
+std::tuple<at::Tensor, at::Tensor> _scaled_dot_product_flash_attention_meta(
+    const at::Tensor& query) {
   // Query (Batch x Num_heads x Q_seq_len  x Dim_per_head)
   // Query -> Query(Batch x Q_seq_len  x Num_heads x Dim_per_head)
-  Tensor q_t = query.transpose(1, 2);
+  at::Tensor q_t = query.transpose(1, 2);
 
   const auto sizes = q_t.sizes();
   const int batch_size = sizes[0];

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -868,12 +868,19 @@ TEST_F(SDPATest, Sharded_SdpaFwd) {
       {q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)});
 
   ExpressionEvaluator ee;
-  ee.bind(executor_cache.fusion()->inputs().at(0), q.to(at::kMeta));
-  ee.bind(executor_cache.fusion()->inputs().at(1), k.to(at::kMeta));
-  ee.bind(executor_cache.fusion()->inputs().at(2), v.to(at::kMeta));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(0), q.to(at::kMeta).unsqueeze(0));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(1), k.to(at::kMeta).unsqueeze(0));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(2), v.to(at::kMeta).unsqueeze(0));
   MetaSdpaOut aten_out_meta = {
-      ee.evaluate(executor_cache.fusion()->outputs().at(0)).as<at::Tensor>(),
-      ee.evaluate(executor_cache.fusion()->outputs().at(1)).as<at::Tensor>(),
+      ee.evaluate(executor_cache.fusion()->outputs().at(0))
+          .as<at::Tensor>()
+          .squeeze(0),
+      ee.evaluate(executor_cache.fusion()->outputs().at(1))
+          .as<at::Tensor>()
+          .squeeze(0),
   };
   validateSdpaFwdOutputs(nvf_out, aten_out, aten_out_meta);
 }
@@ -1068,12 +1075,19 @@ TEST_F(SDPATest, ComputeAt) {
       {q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0)});
 
   ExpressionEvaluator ee;
-  ee.bind(executor_cache.fusion()->inputs().at(0), q.to(at::kMeta));
-  ee.bind(executor_cache.fusion()->inputs().at(1), k.to(at::kMeta));
-  ee.bind(executor_cache.fusion()->inputs().at(2), v.to(at::kMeta));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(0), q.to(at::kMeta).unsqueeze(0));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(1), k.to(at::kMeta).unsqueeze(0));
+  ee.bind(
+      executor_cache.fusion()->inputs().at(2), v.to(at::kMeta).unsqueeze(0));
   MetaSdpaOut aten_out_meta = {
-      ee.evaluate(executor_cache.fusion()->outputs().at(0)).as<at::Tensor>(),
-      ee.evaluate(executor_cache.fusion()->outputs().at(1)).as<at::Tensor>(),
+      ee.evaluate(executor_cache.fusion()->outputs().at(0))
+          .as<at::Tensor>()
+          .squeeze(0),
+      ee.evaluate(executor_cache.fusion()->outputs().at(1))
+          .as<at::Tensor>()
+          .squeeze(0),
   };
   validateSdpaFwdOutputs(nvf_out, aten_out, aten_out_meta);
 }

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -47,7 +47,7 @@ using AtenSdpaOut = std::tuple<
     at::Tensor,
     at::Tensor>;
 auto validateSdpaFwdOutputs = [](KernelArgumentHolder nvf_out,
-                                 AtenSdpaOut aten_out) {
+                                 AtenSdpaOut aten_out, AtenSdpaOut aten_out_meta) {
   auto
       [attn,
        log_sumexp,
@@ -64,6 +64,31 @@ auto validateSdpaFwdOutputs = [](KernelArgumentHolder nvf_out,
   // garbage values for this case, so we skip validating those values.
   NVF_CHECK(at::allclose(nvf_out[0].as<at::Tensor>(), attn));
   NVF_CHECK(at::allclose(nvf_out[1].as<at::Tensor>(), log_sumexp));
+
+  auto
+      [attn_meta,
+       log_sumexp_meta,
+       cum_seq_q_meta,
+       cum_seq_k_meta,
+       query_seq_len_meta,
+       key_seq_len_meta,
+       philox_seed_meta,
+       philox_offset_meta,
+       debug_attn_mask_meta] = aten_out_meta;
+  EXPECT_EQ(attn.sizes(), attn_meta.sizes());
+  EXPECT_EQ(log_sumexp.sizes(), log_sumexp_meta.sizes());
+  EXPECT_EQ(cum_seq_q.sizes(), cum_seq_q_meta.sizes());
+  EXPECT_EQ(cum_seq_k.sizes(), cum_seq_k_meta.sizes());
+  EXPECT_EQ(philox_seed.sizes(), philox_seed_meta.sizes());
+  EXPECT_EQ(philox_offset.sizes(), philox_offset_meta.sizes());
+  EXPECT_EQ(debug_attn_mask.sizes(), debug_attn_mask_meta.sizes());
+  EXPECT_EQ(attn.strides(), attn_meta.strides());
+  EXPECT_EQ(log_sumexp.strides(), log_sumexp_meta.strides());
+  EXPECT_EQ(cum_seq_q.strides(), cum_seq_q_meta.strides());
+  EXPECT_EQ(cum_seq_k.strides(), cum_seq_k_meta.strides());
+  EXPECT_EQ(philox_seed.strides(), philox_seed_meta.strides());
+  EXPECT_EQ(philox_offset.strides(), philox_offset_meta.strides());
+  EXPECT_EQ(debug_attn_mask.strides(), debug_attn_mask_meta.strides());
 };
 
 // Check SDPAFwdOp mapping in IdModel and ComputeAtMap.
@@ -258,7 +283,23 @@ TEST_F(SDPATest, NonCausalAttnConcrete) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   auto nvf_out = executor_cache.runFusionWithInputs({q, k, v});
-  validateSdpaFwdOutputs(nvf_out, aten_out);
+
+  ExpressionEvaluator ee;
+  ee.bind(tvq, q.to(at::kMeta));
+  ee.bind(tvk, k.to(at::kMeta));
+  ee.bind(tvv, v.to(at::kMeta));
+  AtenSdpaOut aten_out_meta = {
+      ee.evaluate(fusion->outputs().at(0)),
+      ee.evaluate(fusion->outputs().at(1)),
+      ee.evaluate(fusion->outputs().at(2)),
+      ee.evaluate(fusion->outputs().at(3)),
+      ee.evaluate(fusion->outputs().at(4)),
+      ee.evaluate(fusion->outputs().at(5)),
+      ee.evaluate(fusion->outputs().at(6)),
+      ee.evaluate(fusion->outputs().at(7)),
+      ee.evaluate(fusion->outputs().at(8)),
+  };
+  validateSdpaFwdOutputs(nvf_out, aten_out, aten_out_meta);
 }
 
 TEST_F(SDPATest, NonCausalAttnSymbolic) {


### PR DESCRIPTION
In preparing for the fix of https://github.com/NVIDIA/Fuser/issues/4888, I am working on https://github.com/NVIDIA/Fuser/pull/5082, which requires the use of `Expr::evaluate` on meta tensors to infer shape and strides of fusion segments selected to be scheduled by the `ExprEval` scheduler. As a consequence of this change, all the `Expr::evaluate` functions should support meta device, and the returned output tensor's shape and stride must match that on device type CUDA.

According to https://docs.pytorch.org/docs/stable/meta.html
> In some cases, not all device types (e.g., CPU and CUDA) have exactly the same output metadata for an operation; we typically prefer representing the CUDA behavior faithfully in this situation.

It is generally safe to assume that we can use device type meta to infer shapes and strides of device type CUDA. But unfortunately, not all operators implement meta device, and `at::_scaled_dot_product_flash_attention` is such an example.

In this PR, I am adding my own `at::_scaled_dot_product_flash_attention` implementation on meta devices.