### PR TITLE
Fix WORKING_DIRECTORY in gen_nvfuser_direct_version and gen_nvfuser_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -665,7 +665,7 @@ if(BUILD_PYTHON)
     "${PYTHON_EXECUTABLE}" ${NVFUSER_PYTHON_DIR}/tools/gen_nvfuser_version.py nvfuser
     DEPENDS ${NVFUSER_PYTHON_DIR}/tools/gen_nvfuser_version.py
     DEPENDS ${NVFUSER_PYTHON_DIR}/version.txt
-    WORKING_DIRECTORY ${NVFUSER_ROOT}/tools/
+    WORKING_DIRECTORY ${NVFUSER_PYTHON_DIR}/tools/
   )
   add_custom_target(
     gen_nvfuser_version ALL
@@ -786,7 +786,7 @@ if(BUILD_PYTHON)
     "${PYTHON_EXECUTABLE}" ${NVFUSER_PYTHON_DIR}/tools/gen_nvfuser_version.py nvfuser_direct
     DEPENDS ${NVFUSER_PYTHON_DIR}/tools/gen_nvfuser_version.py
     DEPENDS ${NVFUSER_PYTHON_DIR}/version.txt
-    WORKING_DIRECTORY ${NVFUSER_ROOT}/tools/
+    WORKING_DIRECTORY ${NVFUSER_PYTHON_DIR}/tools/
   )
   add_custom_target(
     gen_nvfuser_direct_version ALL


### PR DESCRIPTION
The `WORKING_DIRECTORY` argument was pointing to `NVFUSER_ROOT/tools`, which no longer contains `gen_nvfuser_version.py`. Changing the argument to `NVFUSER_PYTHON_DIR/tools` fixes the issue.

```bash
>>> cd python/build
>>> cmake --build .
[2/2] Generating /opt/pytorch/nvfuser/python/nvfuser/version.py
>>> cmake --build .
# `nvfuser/version.py` and `nvfuser_direct/version.py` already exist
ninja: no work to do.
```