### PR TITLE
Remove many switch-defaults for enum classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,7 +623,8 @@ install(DIRECTORY "${NVFUSER_SRCS_DIR}/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvfuser"
   FILES_MATCHING
   PATTERN "*.h"
-  PATTERN "csrc/C++20/type_traits"
+  PATTERN "csrc/C++20/compare"
+  PATTERN "csrc/C++23/utility"
   PATTERN "csrc/struct.inl")
 
 # TODO guard including flatbuffers headers

--- a/csrc/C++23/utility
+++ b/csrc/C++23/utility
@@ -1,0 +1,21 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+namespace std {
+
+#if __cplusplus < 202302L
+
+// https://en.cppreference.com/w/cpp/utility/unreachable.html
+[[noreturn]] inline void unreachable() {
+  __builtin_unreachable();
+}
+
+#endif // __cplusplus < 202302L
+
+} // namespace std

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -10,8 +10,7 @@
 #include <ATen/cuda/CUDAContext.h>
 
 #include <sstream>
-#include <stdexcept>
-#include <unordered_map>
+#include <unordered_set>
 
 #include <ir/all_nodes.h>
 #include <tensor_metadata.h>
@@ -89,8 +88,6 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode) {
       return DataType::Int32;
     case KernelIndexMode::INT64:
       return DataType::Int;
-    default:
-      NVF_CHECK(false, "Invalid kernel index mode type.");
   }
 }
 
@@ -330,8 +327,8 @@ static const char* val_type2string(ValType t) {
       return "Predicate";
     case ValType::TensorIndex:
       return "TensorIndex";
-    default:
-      NVF_THROW("No string found for val type.");
+    case ValType::Stream:
+      return "Stream";
   }
 }
 
@@ -357,8 +354,6 @@ const char* predicate_type2string(PredicateType t) {
       return "OneDimTmaLoadExpectArrive";
     case PredicateType::OneDimTmaWaitParity:
       return "OneDimTmaWaitParity";
-    default:
-      NVF_THROW("No string found for predicate type.");
   }
 }
 
@@ -613,8 +608,6 @@ static const char* binary_op_type2string(BinaryOpType t) {
       return "lessThan";
     case BinaryOpType::NE:
       return "notEqual";
-    default:
-      NVF_THROW("No string found for binary op type.");
   }
 }
 
@@ -719,8 +712,6 @@ static const char* ternary_op_type2string(TernaryOpType t) {
       return "where";
     case TernaryOpType::Philox:
       return "philox";
-    default:
-      NVF_THROW("Unexpected TernaryOpType");
   }
 }
 
@@ -811,8 +802,6 @@ static const char* memory_type2string(MemoryType t) {
       return "global";
     case MemoryType::Tensor:
       return "tensor";
-    default:
-      NVF_THROW("Unexpected MemoryType");
   }
 }
 
@@ -832,9 +821,6 @@ static const char* id_map_mode_type2string(IdMappingMode t) {
       return "innermost";
     case IdMappingMode::PERMISSIVE_RESIZE:
       return "permissive_resize";
-    default:
-      // Don't try to print t as it would recursively call this function
-      NVF_THROW("Unexpected IdMappingMode Type.");
   }
 }
 
@@ -854,9 +840,6 @@ static const char* iter_type2string(IterType t) {
       return "v";
     case IterType::Symbolic:
       return "?";
-    default:
-      // Don't try to print t as it would recursively call this function
-      NVF_THROW("Unexpected IterType");
   }
 }
 
@@ -899,8 +882,6 @@ const char* load_store_type2string(LoadStoreOpType t) {
       return "LdTMem";
     case LoadStoreOpType::StTMem:
       return "StTMem";
-    default:
-      NVF_THROW("Unexpected parallel type");
   }
 }
 
@@ -1510,8 +1491,8 @@ std::ostream& operator<<(std::ostream& os, const SwizzleType& swizzle) {
     case SwizzleType::XOR:
       os << "Xor";
       break;
-    default:
-      NVF_THROW("undefined 2D swizzle");
+    case SwizzleType::CyclicShift:
+      os << "CyclicShift";
       break;
   }
   return os;
@@ -1531,9 +1512,6 @@ std::ostream& operator<<(std::ostream& os, const Swizzle2DType& swizzle) {
     case Swizzle2DType::CyclicShift:
       os << "CyclicShift";
       break;
-    default:
-      NVF_THROW("undefined 2D swizzle");
-      break;
   }
   return os;
 }
@@ -1549,9 +1527,6 @@ std::ostream& operator<<(std::ostream& os, const SwizzleMode& swizzle) {
     case SwizzleMode::Data:
       os << "Data";
       break;
-    default:
-      NVF_THROW("undefined 2D swizzle");
-      break;
   }
   return os;
 }
@@ -1563,9 +1538,6 @@ std::ostream& operator<<(std::ostream& os, const KernelIndexMode& index_mode) {
       break;
     case KernelIndexMode::INT64:
       os << "INT64";
-      break;
-    default:
-      NVF_THROW("undefined index mode");
       break;
   }
   return os;
@@ -1584,9 +1556,6 @@ std::ostream& operator<<(std::ostream& os, const CacheOp& cache_op) {
       break;
     case CacheOp::Global:
       os << "Global";
-      break;
-    default:
-      NVF_THROW("undefined cache operator");
       break;
   }
   return os;
@@ -1846,8 +1815,6 @@ std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
       return os << "16x256b";
     case TMemRegisterDataPath::Path16x32bx2:
       return os << "16x32bx2";
-    default:
-      NVF_THROW("Unknown TMemRegisterDataPath");
   }
 }
 

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -89,7 +89,7 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode) {
     case KernelIndexMode::INT64:
       return DataType::Int;
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 KernelIndexMode indexTypeToMode(DataType index_type) {
@@ -331,7 +331,7 @@ static const char* val_type2string(ValType t) {
     case ValType::Stream:
       return "Stream";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 const char* predicate_type2string(PredicateType t) {
@@ -357,7 +357,7 @@ const char* predicate_type2string(PredicateType t) {
     case PredicateType::OneDimTmaWaitParity:
       return "OneDimTmaWaitParity";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 bool needFloatSuffix(UnaryOpType t) {
@@ -612,7 +612,7 @@ static const char* binary_op_type2string(BinaryOpType t) {
     case BinaryOpType::NE:
       return "notEqual";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 static const char* binary_op_integer_op2string(BinaryOpType t) {
@@ -717,7 +717,7 @@ static const char* ternary_op_type2string(TernaryOpType t) {
     case TernaryOpType::Philox:
       return "philox";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 static const char* rng_op_type2string(RNGOpType t) {
@@ -808,7 +808,7 @@ static const char* memory_type2string(MemoryType t) {
     case MemoryType::Tensor:
       return "tensor";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 static const char* id_map_mode_type2string(IdMappingMode t) {
@@ -828,7 +828,7 @@ static const char* id_map_mode_type2string(IdMappingMode t) {
     case IdMappingMode::PERMISSIVE_RESIZE:
       return "permissive_resize";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 static const char* iter_type2string(IterType t) {
@@ -848,7 +848,7 @@ static const char* iter_type2string(IterType t) {
     case IterType::Symbolic:
       return "?";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 static const char* thread_size2string(ParallelType t) {
@@ -891,7 +891,7 @@ const char* load_store_type2string(LoadStoreOpType t) {
     case LoadStoreOpType::StTMem:
       return "StTMem";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 const unsigned int _WORD_SHIFT = 16;
@@ -1825,7 +1825,7 @@ std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
     case TMemRegisterDataPath::Path16x32bx2:
       return os << "16x32bx2";
   }
-  __builtin_unreachable();
+  unreachable();
 }
 
 std::ostream& operator<<(

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -89,6 +89,7 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode) {
     case KernelIndexMode::INT64:
       return DataType::Int;
   }
+  __builtin_unreachable();
 }
 
 KernelIndexMode indexTypeToMode(DataType index_type) {
@@ -330,6 +331,7 @@ static const char* val_type2string(ValType t) {
     case ValType::Stream:
       return "Stream";
   }
+  __builtin_unreachable();
 }
 
 const char* predicate_type2string(PredicateType t) {
@@ -355,6 +357,7 @@ const char* predicate_type2string(PredicateType t) {
     case PredicateType::OneDimTmaWaitParity:
       return "OneDimTmaWaitParity";
   }
+  __builtin_unreachable();
 }
 
 bool needFloatSuffix(UnaryOpType t) {
@@ -609,6 +612,7 @@ static const char* binary_op_type2string(BinaryOpType t) {
     case BinaryOpType::NE:
       return "notEqual";
   }
+  __builtin_unreachable();
 }
 
 static const char* binary_op_integer_op2string(BinaryOpType t) {
@@ -713,6 +717,7 @@ static const char* ternary_op_type2string(TernaryOpType t) {
     case TernaryOpType::Philox:
       return "philox";
   }
+  __builtin_unreachable();
 }
 
 static const char* rng_op_type2string(RNGOpType t) {
@@ -803,6 +808,7 @@ static const char* memory_type2string(MemoryType t) {
     case MemoryType::Tensor:
       return "tensor";
   }
+  __builtin_unreachable();
 }
 
 static const char* id_map_mode_type2string(IdMappingMode t) {
@@ -822,6 +828,7 @@ static const char* id_map_mode_type2string(IdMappingMode t) {
     case IdMappingMode::PERMISSIVE_RESIZE:
       return "permissive_resize";
   }
+  __builtin_unreachable();
 }
 
 static const char* iter_type2string(IterType t) {
@@ -841,6 +848,7 @@ static const char* iter_type2string(IterType t) {
     case IterType::Symbolic:
       return "?";
   }
+  __builtin_unreachable();
 }
 
 static const char* thread_size2string(ParallelType t) {
@@ -883,6 +891,7 @@ const char* load_store_type2string(LoadStoreOpType t) {
     case LoadStoreOpType::StTMem:
       return "StTMem";
   }
+  __builtin_unreachable();
 }
 
 const unsigned int _WORD_SHIFT = 16;
@@ -1816,6 +1825,7 @@ std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
     case TMemRegisterDataPath::Path16x32bx2:
       return os << "16x32bx2";
   }
+  __builtin_unreachable();
 }
 
 std::ostream& operator<<(

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -89,7 +89,7 @@ PrimDataType indexModeToDtype(KernelIndexMode index_mode) {
     case KernelIndexMode::INT64:
       return DataType::Int;
   }
-  unreachable();
+  std::unreachable();
 }
 
 KernelIndexMode indexTypeToMode(DataType index_type) {
@@ -331,7 +331,7 @@ static const char* val_type2string(ValType t) {
     case ValType::Stream:
       return "Stream";
   }
-  unreachable();
+  std::unreachable();
 }
 
 const char* predicate_type2string(PredicateType t) {
@@ -357,7 +357,7 @@ const char* predicate_type2string(PredicateType t) {
     case PredicateType::OneDimTmaWaitParity:
       return "OneDimTmaWaitParity";
   }
-  unreachable();
+  std::unreachable();
 }
 
 bool needFloatSuffix(UnaryOpType t) {
@@ -612,7 +612,7 @@ static const char* binary_op_type2string(BinaryOpType t) {
     case BinaryOpType::NE:
       return "notEqual";
   }
-  unreachable();
+  std::unreachable();
 }
 
 static const char* binary_op_integer_op2string(BinaryOpType t) {
@@ -717,7 +717,7 @@ static const char* ternary_op_type2string(TernaryOpType t) {
     case TernaryOpType::Philox:
       return "philox";
   }
-  unreachable();
+  std::unreachable();
 }
 
 static const char* rng_op_type2string(RNGOpType t) {
@@ -808,7 +808,7 @@ static const char* memory_type2string(MemoryType t) {
     case MemoryType::Tensor:
       return "tensor";
   }
-  unreachable();
+  std::unreachable();
 }
 
 static const char* id_map_mode_type2string(IdMappingMode t) {
@@ -828,7 +828,7 @@ static const char* id_map_mode_type2string(IdMappingMode t) {
     case IdMappingMode::PERMISSIVE_RESIZE:
       return "permissive_resize";
   }
-  unreachable();
+  std::unreachable();
 }
 
 static const char* iter_type2string(IterType t) {
@@ -848,7 +848,7 @@ static const char* iter_type2string(IterType t) {
     case IterType::Symbolic:
       return "?";
   }
-  unreachable();
+  std::unreachable();
 }
 
 static const char* thread_size2string(ParallelType t) {
@@ -891,7 +891,7 @@ const char* load_store_type2string(LoadStoreOpType t) {
     case LoadStoreOpType::StTMem:
       return "StTMem";
   }
-  unreachable();
+  std::unreachable();
 }
 
 const unsigned int _WORD_SHIFT = 16;
@@ -1825,7 +1825,7 @@ std::ostream& operator<<(std::ostream& os, TMemRegisterDataPath dp) {
     case TMemRegisterDataPath::Path16x32bx2:
       return os << "16x32bx2";
   }
-  unreachable();
+  std::unreachable();
 }
 
 std::ostream& operator<<(

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -7,20 +7,6 @@
 // clang-format on
 #pragma once
 
-#include <ATen/ATen.h>
-#include <exceptions.h>
-#include <torch/csrc/jit/ir/ir.h>
-#include <torch/torch.h>
-#include <visibility.h>
-
-#include <debug.h>
-#include <mma_type.h>
-#include <options.h>
-#include <tma.h>
-#include <type.h>
-
-#include <c10/core/thread_pool.h>
-
 #include <concepts>
 #include <coroutine>
 #include <deque>
@@ -35,6 +21,19 @@
 #include <typeinfo>
 #include <unordered_map>
 #include <vector>
+
+#include <ATen/ATen.h>
+#include <c10/core/thread_pool.h>
+#include <torch/torch.h>
+
+#include <debug.h>
+#include <exceptions.h>
+#include <mma_type.h>
+#include <options.h>
+#include <tma.h>
+#include <type.h>
+#include <visibility.h>
+#include <C++23/utility>
 
 //! IR header hierarchy
 //! 1. ** utils.h ** - PolymorphicBase and NonCopyable
@@ -619,7 +618,6 @@ void checkAllEqual(std::initializer_list<T> elements) {
 
 #if __cplusplus >= 202302L
 
-using std::unreachable;
 using std::views::enumerate;
 using std::views::zip;
 
@@ -818,10 +816,6 @@ auto enumerate(std::ranges::viewable_range auto&& r) {
 
 using views::enumerate;
 using views::zip;
-
-[[noreturn]] inline void unreachable() {
-  __builtin_unreachable();
-}
 
 #endif // C++23
 

--- a/csrc/utils.h
+++ b/csrc/utils.h
@@ -619,6 +619,7 @@ void checkAllEqual(std::initializer_list<T> elements) {
 
 #if __cplusplus >= 202302L
 
+using std::unreachable;
 using std::views::enumerate;
 using std::views::zip;
 
@@ -811,12 +812,16 @@ enumerate_view(R&&) -> enumerate_view<std::views::all_t<R>>;
 // Helper function
 auto enumerate(std::ranges::viewable_range auto&& r) {
   return enumerate_view{std::forward<decltype(r)>(r)};
-};
+}
 
 } // namespace views
 
 using views::enumerate;
 using views::zip;
+
+[[noreturn]] inline void unreachable() {
+  __builtin_unreachable();
+}
 
 #endif // C++23
 


### PR DESCRIPTION
This way, any missing cases are captured as early as compile time. 

__builtin_unreachable is necessary to suppress the "control reaches end of non-void function [-Werror=return-type]" error reported by gcc. This is still better than using NVF_THROW in `default` because missing cases are still captured at compile time. 