### PR TITLE
Ignore different symbol names in codediff

### DIFF
--- a/tools/codediff/codediff.py
+++ b/tools/codediff/codediff.py
@@ -707,26 +707,28 @@ class TestDiff:
     test2: CompiledTest
     kernel_diffs: list[KernelDiff] | None = None
 
-filename_pattern = re.compile(r'__tmp_\w+')
-kernel_pattern = re.compile(r'(?P<prefix>kernel|nvfuser)_\d+')
+
+filename_pattern = re.compile(r"__tmp_\w+")
+kernel_pattern = re.compile(r"(?P<prefix>kernel|nvfuser)_\d+")
+
 
 def sanitize_symbol_name(symb: str) -> str:
     """
-     Replace mangled kernel names like
-       _ZN76_GLOBAL__N__00000000_37___tmp_kernel_pointwise_f0_c1_r0_g0_cu_8995cef2_3255329nvfuser_pointwise_f0_c1_r0_g0ENS_6TensorIfLi2ELi2EEES1_S1_
-     or
-       _ZN76_GLOBAL__N__00000000_37___tmp_kernel_4_cu_8995cef2_3255329nvfuser_4ENS_6TensorIfLi2ELi2EEES1_S1_
+    Replace mangled kernel names like
+      _ZN76_GLOBAL__N__00000000_37___tmp_kernel_pointwise_f0_c1_r0_g0_cu_8995cef2_3255329nvfuser_pointwise_f0_c1_r0_g0ENS_6TensorIfLi2ELi2EEES1_S1_
+    or
+      _ZN76_GLOBAL__N__00000000_37___tmp_kernel_4_cu_8995cef2_3255329nvfuser_4ENS_6TensorIfLi2ELi2EEES1_S1_
 
-     This function first demangles the name, then parses each piece to check
-     for common patterns to replace. This lets us replace stuff like "kernel_4"
-     with "kernel_N" or "nvfuser_4" with "nvfuser_N". Note that this does not
-     "mangle" the name back since there does not seem to be a useful utility
-     for doing so and cxxfilt only does demangling. As this is only for diff
-     purposes, the report will only show the demangled names in the diff
-     portions, but clicking on the original code will show the actual original
-     mangled symbol names.
-     """
-    suffix = ''
+    This function first demangles the name, then parses each piece to check
+    for common patterns to replace. This lets us replace stuff like "kernel_4"
+    with "kernel_N" or "nvfuser_4" with "nvfuser_N". Note that this does not
+    "mangle" the name back since there does not seem to be a useful utility
+    for doing so and cxxfilt only does demangling. As this is only for diff
+    purposes, the report will only show the demangled names in the diff
+    portions, but clicking on the original code will show the actual original
+    mangled symbol names.
+    """
+    suffix = ""
     while len(symb) > 0:
         # PTX sometimes refers to local variables as
         # <demangled_function_name>_<variable_name>. For example,
@@ -742,9 +744,9 @@ def sanitize_symbol_name(symb: str) -> str:
             suffix = symb[-1] + suffix
             symb = symb[:-1]
     # Replace "__tmp_kernel_pointwise_f0_c1_r0_g0_cu" or "__tmp_kernel_4" with "__tmp_filename"
-    d = re.sub(filename_pattern, '__tmp_filename', d)
+    d = re.sub(filename_pattern, "__tmp_filename", d)
     # Replace "kernel_4" or "nvfuser_8" with "kernel_N"
-    d = re.sub(kernel_pattern, lambda m: f'{m.groupdict()['prefix']}_N', d)
+    d = re.sub(kernel_pattern, lambda m: f"{m.groupdict()['prefix']}_N", d)
     return d + suffix
 
 
@@ -752,6 +754,7 @@ def sanitize_symbol_name(symb: str) -> str:
 # https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 symbol_pattern = re.compile(r"\b_Z\w+\b")
 comment_pattern = re.compile(r"//.*$")
+
 
 def sanitize_ptx_lines(lines: list[str]) -> list[str]:
     """Remove comments and remove kernel id"""

--- a/tools/codediff/requirements.txt
+++ b/tools/codediff/requirements.txt
@@ -1,2 +1,3 @@
+cxxfilt
 dataclasses-json
 jinja2


### PR DESCRIPTION
This fixes false positives in codediff such as [this example](http://nv/e5M/nvfuser_github_ci/codegen_diff_p34324383_j206130253_1756904251218282579_codediff_c490444f_532ddcc8_custom_command_20250903_051343.html). 

A diff like this should not be counted as an actual code diff and with the PR it won't be:
```diff
--- c490444f
+++ 532ddcc8
@@ -16,35 +16,35 @@

 .global .align 1 .u8 _ZN3nvf3std17integral_constantIbLb1EE5valueE;
 .global .align 1 .u8 _ZN3nvf3std14__numeric_typeIvE5valueE;
 .global .align 1 .u8 _ZN3nvf3std9is_same_vINS_15DefaultBlockDimES2_EE = 1;
 .extern .shared .align 16 .b8 _ZN3nvf5arrayE[];
 
-.visible .entry _ZN3nvf12nvfuser_1085ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE(
-	.param .align 8 .b8 _ZN3nvf12nvfuser_1085ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE_param_0[24],
-	.param .align 8 .b8 _ZN3nvf12nvfuser_1085ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE_param_1[16]
+.visible .entry _ZN3nvf12nvfuser_1083ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE(
+	.param .align 8 .b8 _ZN3nvf12nvfuser_1083ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE_param_0[24],
+	.param .align 8 .b8 _ZN3nvf12nvfuser_1083ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE_param_1[16]
 )
 {
 	.reg .pred 	%p<35>;
 	.reg .f32 	%f<79>;
 	.reg .b32 	%r<169>;
 	.reg .b64 	%rd<35>;
```
We do this by replacing words starting with `_` such as `ZN3nvf12nvfuser_1085ENS_6TensorIfLi2ELi2EEENS0_IfLi1ELi1EEE_param_0`  with `_foo` when diffing. In the codediff report, the original PTX is still included, not the substituted text.