### PR TITLE
Don't mix the runtime and driver APIs

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -138,10 +138,14 @@ bool isExactParallelSharedMemAccess(TensorView* tv) {
 bool needSharedMemPredicate(TensorView* producer, TensorView* consumer) {
   // Indexing is based on consumer loop ids so check the consumer.
 
+  bool _debug = consumer->name() == 11;
+
   // If consumer schedule contains in-exact thread parallel
   //  dimensions, need to predicate against out of bound
   //  shared memory access by out of bound threads.
   if (!isExactParallelSharedMemAccess(consumer)) {
+    if (_debug)
+      std::cerr << "DEBUG1\n";
     return true;
   }
 
@@ -182,6 +186,8 @@ bool needSharedMemPredicate(TensorView* producer, TensorView* consumer) {
         // Disable shared memory producers that is a consumer
         //  of another shared memory tensor. The initialization would
         //  break potential opportunity to re-use shared mem buffer.
+        if (_debug)
+          std::cerr << "DEBUG2\n";
         return true;
       }
     }
@@ -193,6 +199,8 @@ bool needSharedMemPredicate(TensorView* producer, TensorView* consumer) {
     //  eg. as in issue 1133, so disabling this removal pattern for now.
     if (id->getParallelType() == ParallelType::Unroll ||
         id->getParallelType() == ParallelType::Unswitch) {
+      if (_debug)
+        std::cerr << "DEBUG3\n";
       return true;
     }
   }
@@ -205,6 +213,8 @@ bool needSharedMemPredicate(TensorView* producer, TensorView* consumer) {
   auto consumer_def = consumer->definition();
   if (ir_utils::isReductionOp(consumer_def)) {
     if (producer->getMemoryType() == MemoryType::Shared) {
+      if (_debug)
+        std::cerr << "DEBUG4\n";
       return true;
     }
   }

--- a/csrc/driver_api.cpp
+++ b/csrc/driver_api.cpp
@@ -117,7 +117,7 @@ void getDriverEntryPoint(
 
 namespace nvfuser {
 
-ALL_DRIVER_API_WRAPPER(DEFINE_DRIVER_API_WRAPPER);
+NVF_ALL_DRIVER_API_WRAPPER(DEFINE_DRIVER_API_WRAPPER);
 
 } // namespace nvfuser
 

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -40,21 +40,23 @@ namespace nvfuser {
 // to go lower than that. When we increase the minimum supported version, we
 // can accordingly increase the requested versions. However, we don't have to
 // unless new driver capabilities are needed.
-#define ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn) \
-  fn(cuDeviceGetAttribute, 11000);                     \
-  fn(cuDeviceGetName, 11000);                          \
-  fn(cuFuncGetAttribute, 11000);                       \
-  fn(cuFuncSetAttribute, 11000);                       \
-  fn(cuGetErrorName, 11000);                           \
-  fn(cuGetErrorString, 11000);                         \
-  fn(cuLaunchCooperativeKernel, 11000);                \
-  fn(cuLaunchKernel, 11000);                           \
-  fn(cuModuleGetFunction, 11000);                      \
-  fn(cuModuleLoadData, 11000);                         \
-  fn(cuModuleLoadDataEx, 11000);                       \
-  fn(cuModuleUnload, 11000);                           \
-  fn(cuMemGetAddressRange, 11000);                     \
-  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000)
+#define ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn)    \
+  fn(cuDeviceGetAttribute, 11000);                        \
+  fn(cuDeviceGetName, 11000);                             \
+  fn(cuFuncGetAttribute, 11000);                          \
+  fn(cuFuncSetAttribute, 11000);                          \
+  fn(cuGetErrorName, 11000);                              \
+  fn(cuGetErrorString, 11000);                            \
+  fn(cuLaunchCooperativeKernel, 11000);                   \
+  fn(cuLaunchKernel, 11000);                              \
+  fn(cuModuleGetFunction, 11000);                         \
+  fn(cuModuleLoadData, 11000);                            \
+  fn(cuModuleLoadDataEx, 11000);                          \
+  fn(cuModuleUnload, 11000);                              \
+  fn(cuMemGetAddressRange, 11000);                        \
+  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000); \
+  fn(cuOccupancyAvailableDynamicSMemPerBlock, 11000);     \
+  fn(cuOccupancyMaxActiveClusters, 11080)
 
 // Stream memory operations (e.g. cuStreamWriteValue32) are specified for both
 // 11 and 12+. In CUDA 11, these operations require NVreg_EnableStreamMemOPs=1

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -55,8 +55,7 @@ namespace nvfuser {
   fn(cuModuleUnload, 11000);                              \
   fn(cuMemGetAddressRange, 11000);                        \
   fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000); \
-  fn(cuOccupancyAvailableDynamicSMemPerBlock, 11000);     \
-  fn(cuOccupancyMaxActiveClusters, 11080)
+  fn(cuOccupancyAvailableDynamicSMemPerBlock, 11000)
 
 // Stream memory operations (e.g. cuStreamWriteValue32) are specified for both
 // 11 and 12+. In CUDA 11, these operations require NVreg_EnableStreamMemOPs=1
@@ -68,19 +67,34 @@ namespace nvfuser {
 // integrated into the vanilla APIs and are therefore removed. Refer to
 // https://docs.nvidia.com/cuda/archive/11.7.1/cuda-driver-api/group__CUDA__MEMOP.html
 #if (CUDA_VERSION >= 12000)
-#define ALL_DRIVER_API_WRAPPER(fn)                \
-  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
-  fn(cuStreamWaitValue32, 12000);                 \
-  fn(cuStreamWriteValue32, 12000);                \
-  fn(cuTensorMapEncodeTiled, 12000)
+#define STREAM_DRIVER_API_WRAPPER(fn) \
+  fn(cuStreamWaitValue32, 12000);     \
+  fn(cuStreamWriteValue32, 12000)
 #elif (CUDA_VERSION >= 11000)
-#define ALL_DRIVER_API_WRAPPER(fn)                \
-  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
-  fn(cuStreamWaitValue32, 11000);                 \
+#define STREAM_DRIVER_API_WRAPPER(fn) \
+  fn(cuStreamWaitValue32, 11000);     \
   fn(cuStreamWriteValue32, 11000)
 #else
 #error "CUDA_VERSION < 11000 isn't supported."
 #endif
+
+#if (CUDA_VERSION >= 11080)
+#define DRIVER_API_WRAPPER_CUDA_118(fn) fn(cuOccupancyMaxActiveClusters, 11080)
+#else
+#define DRIVER_API_WRAPPER_CUDA_118(fn)
+#endif
+
+#if (CUDA_VERSION >= 12000)
+#define DRIVER_API_WRAPPER_CUDA_120(fn) fn(cuTensorMapEncodeTiled, 12000)
+#else
+#define DRIVER_API_WRAPPER_CUDA_120(fn)
+#endif
+
+#define ALL_DRIVER_API_WRAPPER(fn)                \
+  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
+  STREAM_DRIVER_API_WRAPPER(fn);                  \
+  DRIVER_API_WRAPPER_CUDA_118(fn);                \
+  DRIVER_API_WRAPPER_CUDA_120(fn)
 
 ALL_DRIVER_API_WRAPPER(DECLARE_DRIVER_API_WRAPPER);
 

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -40,21 +40,21 @@ namespace nvfuser {
 // to go lower than that. When we increase the minimum supported version, we
 // can accordingly increase the requested versions. However, we don't have to
 // unless new driver capabilities are needed.
-#define ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn)    \
-  fn(cuDeviceGetAttribute, 11000);                        \
-  fn(cuDeviceGetName, 11000);                             \
-  fn(cuFuncGetAttribute, 11000);                          \
-  fn(cuFuncSetAttribute, 11000);                          \
-  fn(cuGetErrorName, 11000);                              \
-  fn(cuGetErrorString, 11000);                            \
-  fn(cuLaunchCooperativeKernel, 11000);                   \
-  fn(cuLaunchKernel, 11000);                              \
-  fn(cuModuleGetFunction, 11000);                         \
-  fn(cuModuleLoadData, 11000);                            \
-  fn(cuModuleLoadDataEx, 11000);                          \
-  fn(cuModuleUnload, 11000);                              \
-  fn(cuMemGetAddressRange, 11000);                        \
-  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000); \
+#define NVF_ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn) \
+  fn(cuDeviceGetAttribute, 11000);                         \
+  fn(cuDeviceGetName, 11000);                              \
+  fn(cuFuncGetAttribute, 11000);                           \
+  fn(cuFuncSetAttribute, 11000);                           \
+  fn(cuGetErrorName, 11000);                               \
+  fn(cuGetErrorString, 11000);                             \
+  fn(cuLaunchCooperativeKernel, 11000);                    \
+  fn(cuLaunchKernel, 11000);                               \
+  fn(cuModuleGetFunction, 11000);                          \
+  fn(cuModuleLoadData, 11000);                             \
+  fn(cuModuleLoadDataEx, 11000);                           \
+  fn(cuModuleUnload, 11000);                               \
+  fn(cuMemGetAddressRange, 11000);                         \
+  fn(cuOccupancyMaxActiveBlocksPerMultiprocessor, 11000);  \
   fn(cuOccupancyAvailableDynamicSMemPerBlock, 11000)
 
 // Stream memory operations (e.g. cuStreamWriteValue32) are specified for both
@@ -67,36 +67,37 @@ namespace nvfuser {
 // integrated into the vanilla APIs and are therefore removed. Refer to
 // https://docs.nvidia.com/cuda/archive/11.7.1/cuda-driver-api/group__CUDA__MEMOP.html
 #if (CUDA_VERSION >= 12000)
-#define STREAM_DRIVER_API_WRAPPER(fn) \
-  fn(cuStreamWaitValue32, 12000);     \
+#define NVF_STREAM_DRIVER_API_WRAPPER(fn) \
+  fn(cuStreamWaitValue32, 12000);         \
   fn(cuStreamWriteValue32, 12000)
 #elif (CUDA_VERSION >= 11000)
-#define STREAM_DRIVER_API_WRAPPER(fn) \
-  fn(cuStreamWaitValue32, 11000);     \
+#define NVF_STREAM_DRIVER_API_WRAPPER(fn) \
+  fn(cuStreamWaitValue32, 11000);         \
   fn(cuStreamWriteValue32, 11000)
 #else
 #error "CUDA_VERSION < 11000 isn't supported."
 #endif
 
 #if (CUDA_VERSION >= 11080)
-#define DRIVER_API_WRAPPER_CUDA_118(fn) fn(cuOccupancyMaxActiveClusters, 11080)
+#define NVF_DRIVER_API_WRAPPER_CUDA_118(fn) \
+  fn(cuOccupancyMaxActiveClusters, 11080)
 #else
-#define DRIVER_API_WRAPPER_CUDA_118(fn)
+#define NVF_DRIVER_API_WRAPPER_CUDA_118(fn)
 #endif
 
 #if (CUDA_VERSION >= 12000)
-#define DRIVER_API_WRAPPER_CUDA_120(fn) fn(cuTensorMapEncodeTiled, 12000)
+#define NVF_DRIVER_API_WRAPPER_CUDA_120(fn) fn(cuTensorMapEncodeTiled, 12000)
 #else
-#define DRIVER_API_WRAPPER_CUDA_120(fn)
+#define NVF_DRIVER_API_WRAPPER_CUDA_120(fn)
 #endif
 
-#define ALL_DRIVER_API_WRAPPER(fn)                \
-  ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
-  STREAM_DRIVER_API_WRAPPER(fn);                  \
-  DRIVER_API_WRAPPER_CUDA_118(fn);                \
-  DRIVER_API_WRAPPER_CUDA_120(fn)
+#define NVF_ALL_DRIVER_API_WRAPPER(fn)                \
+  NVF_ALL_DRIVER_API_WRAPPER_VERSION_INDEPENDENT(fn); \
+  NVF_STREAM_DRIVER_API_WRAPPER(fn);                  \
+  NVF_DRIVER_API_WRAPPER_CUDA_118(fn);                \
+  NVF_DRIVER_API_WRAPPER_CUDA_120(fn)
 
-ALL_DRIVER_API_WRAPPER(DECLARE_DRIVER_API_WRAPPER);
+NVF_ALL_DRIVER_API_WRAPPER(DECLARE_DRIVER_API_WRAPPER);
 
 #undef DECLARE_DRIVER_API_WRAPPER
 

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -16,9 +16,6 @@
 
 namespace nvfuser {
 
-#define DECLARE_DRIVER_API_WRAPPER(funcName, version) \
-  extern decltype(::funcName)* funcName
-
 // List of driver APIs that you want the magic to happen.
 //
 // The second argument is the **requested** driver API version.
@@ -96,6 +93,9 @@ namespace nvfuser {
   NVF_STREAM_DRIVER_API_WRAPPER(fn);                  \
   NVF_DRIVER_API_WRAPPER_CUDA_118(fn);                \
   NVF_DRIVER_API_WRAPPER_CUDA_120(fn)
+
+#define DECLARE_DRIVER_API_WRAPPER(funcName, version) \
+  extern decltype(::funcName)* funcName
 
 NVF_ALL_DRIVER_API_WRAPPER(DECLARE_DRIVER_API_WRAPPER);
 


### PR DESCRIPTION
Encountered an error like:

```
unknown file: Failure
C++ exception with description " INTERNAL ASSERT FAILED at /home/scratch.nmaruyama_ent/nvfuser/debug4/csrc/scheduler/matmul_utils.cpp:1128, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues.
Expected _result == cudaSuccess . CUDA error: cudaErrorInvalidResourceHandle failed with error invalid resource handle
Exception raised from getMaxActiveClusters at
```

With the this PR's changes, I no longer see the error.