### PR TITLE
enable codegen for layout op

### DIFF
--- a/runtime/block_layout.cu
+++ b/runtime/block_layout.cu
@@ -27,7 +27,8 @@ __device__ nvfuser_index_t offsetAfterSwizzlePadding(
    *   col_tile = ceilDiv(col_size / BLOCK_COL)
    */
 
-  // we first convert `row_idx` and `col_idx` to the logical index on the 5d tensor.
+  // we first convert `row_idx` and `col_idx` to the logical index on the 5d
+  // tensor.
   nvfuser_index_t row_tile_idx = row_idx / BLOCK_ROW_SIZE;
   nvfuser_index_t row_block_idx = row_idx % BLOCK_ROW_SIZE;
   nvfuser_index_t row_block_inner_idx = row_block_idx / BLOCK_ROW_OUTER;


### PR DESCRIPTION
#5116 PR3: enable codegen for layout op <- this PR
#5115 PR2: add layout op runtime function
#5114 PR1: add layout op

    1. Add indexing lowing for `GroupedBlockScalingFactorLayoutOp`:
      we resolve indexing for input TV;
      we compute logical index for `row_idx` and `col_idx`;
        -- added `Index::getLinearRootIndex` and `Index::getConsumerPerDimRootIndex`
           in order to compute the row/col indices.
      expanded TensorIndex object to store extra logical index;

    2. Add codegen for `GroupedBlockScalingFactorLayoutOp`;
      The operation adds lowering logic to use the runtime function. The codegen
      utilizes the extra indexing bits added during index lowering.

    3. Relax domain validation in `OptOutMutator::mutate(TensorDomain*)`
      mutating the domain shouldn't try to validate the coverage, because it's not
      a guarantee that TensorDomain entries matches identically (e.g. layout op as
      well as scatter op);

    4. Add cpp test with a manual kernel to validate the correctness of the layout
      op.
