### PR TITLE
Add unsafe_reduce presegmentation pass

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/polymorphic_value.cpp
   ${NVFUSER_SRCS_DIR}/predicate_compute.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/add_axioms.cpp
+  ${NVFUSER_SRCS_DIR}/preseg_passes/unsafe_reduce.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/allocation_order_inference.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/consecutive_cast.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/exact_mapped_extent_substitution.cpp

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -29,6 +29,7 @@
 #include <preseg_passes/segment_inplace_update.h>
 #include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
 #include <preseg_passes/translate_repeat_to_expand.h>
+#include <preseg_passes/unsafe_reduce.h>
 
 namespace nvfuser::preseg_passes {
 
@@ -50,6 +51,7 @@ namespace nvfuser::preseg_passes {
   // removes consecutive cast operations
   OptimizationPass<ConsecutiveCastPass>::runPass(fusion);
   OptimizationPass<AddAxiomsPass>::runPass(fusion);
+  OptimizationPass<UnsafeReducePass>::runPass(fusion);
   OptimizationPass<MoveSplitCatPass>::runPass(fusion);
   // MovePadPass needs to happen:
   // 1. before MarkAliasPrepare; and

--- a/csrc/preseg_passes/unsafe_reduce.cpp
+++ b/csrc/preseg_passes/unsafe_reduce.cpp
@@ -1,0 +1,105 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <preseg_passes/unsafe_reduce.h>
+
+#include <unordered_map>
+#include <vector>
+
+#include <ir/utils.h>
+
+namespace nvfuser::preseg_passes {
+
+enum class NanStatus {
+  UNCHANGED,
+  SQUELCHED,
+  REPAIRED,
+};
+
+bool isMinMaxReduce(Expr* expr) {
+  if (auto op = dynamic_cast<ReductionOp*>(expr)) {
+    auto reduction_type = op->getReductionOpType();
+    return reduction_type == BinaryOpType::Min ||
+        reduction_type == BinaryOpType::Max;
+  }
+  return false;
+}
+
+void UnsafeReducePass::runPass(Fusion* fusion) {
+  FusionGuard fusion_guard(fusion);
+
+  for (Expr* reduceExpr : fusion->exprs()) {
+    if (!isMinMaxReduce(reduceExpr)) {
+      continue;
+    }
+
+    std::unordered_map<TensorView*, NanStatus> status;
+
+    // Mark parent tv as repaired
+    auto parentTv = reduceExpr->input(0)->as<TensorView>();
+    status[parentTv] = NanStatus::REPAIRED;
+
+    // Mark reduceExpr outputs as squelched
+    auto candidateTv = reduceExpr->output(0)->as<TensorView>();
+    status[candidateTv] = NanStatus::SQUELCHED;
+
+    // Propagate NanStatus downstream
+    auto traversal =
+        StmtSort::getExprsBetween({reduceExpr->input(0)}, fusion->outputs());
+    for (Expr* expr : traversal) {
+      if (expr == reduceExpr) {
+        // reduceExpr is the source of SQUELCHED status,
+        // do not overwrite it here.
+        continue;
+      }
+
+      bool anyRepair = false;
+      bool anySquelch = false;
+
+      auto input_tvs = ir_utils::filterByType<TensorView>(expr->inputs());
+      for (TensorView* tv : input_tvs) {
+        if (!status.count(tv)) {
+          continue;
+        }
+
+        anyRepair |= status[tv] == NanStatus::REPAIRED;
+        anySquelch |= status[tv] == NanStatus::SQUELCHED;
+      }
+
+      NanStatus propagate = NanStatus::UNCHANGED;
+      if (anyRepair) {
+        propagate = NanStatus::REPAIRED;
+      } else if (anySquelch) {
+        propagate = NanStatus::SQUELCHED;
+      }
+
+      auto output_tvs = ir_utils::filterByType<TensorView>(expr->outputs());
+      for (TensorView* tv : output_tvs) {
+        if (propagate != NanStatus::UNCHANGED) {
+          status[tv] = propagate;
+        }
+      }
+    }
+
+    // Check whether any squelched status reached output nodes
+    bool squelchedOutput = false;
+    auto output_tvs = ir_utils::filterByType<TensorView>(fusion->outputs());
+    for (TensorView* tv : output_tvs) {
+      if (!status.count(tv)) {
+        continue;
+      }
+
+      squelchedOutput |= status[tv] == NanStatus::SQUELCHED;
+    }
+
+    std::cout << "DEBUGPRINT: " << squelchedOutput << "\n";
+  }
+
+  return;
+}
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/unsafe_reduce.h
+++ b/csrc/preseg_passes/unsafe_reduce.h
@@ -1,0 +1,25 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <preseg_passes/optimization_pass.h>
+
+namespace nvfuser::preseg_passes {
+
+//! UnsafeReducePass
+class UnsafeReducePass : public OptimizationPass<UnsafeReducePass> {
+  friend class OptimizationPass<UnsafeReducePass>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+  static constexpr std::string_view name() {
+    return "UnsafeReducePass";
+  }
+};
+
+} // namespace nvfuser::preseg_passes

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -2585,8 +2585,14 @@ TEST_F(NVFuserTest, FusionSegmentReducePointwise_CUDA) {
   TensorView* tv3 = add(tv0, IrBuilder::create<Val>(1.0)); // Group 0
   TensorView* tv4 =
       max(tv3, {0}); // Group 0 (use max instead to avoid numerical issues)
+
+  //*
+  TensorView* tv7 = add(tv3, tv1);
+  TensorView* tv5 = add(tv4, tv7);
+  /*/
   TensorView* tv5 = add(tv4, tv1); //  Group 0 (Non Broadcast after reduce,
-                                   //  keeps normalization scheduler away)
+  //*/
+  //  keeps normalization scheduler away)
   TensorView* tv6 = add(tv5, tv2); //  Group 1 (Broadcast after reduce)
 
   fusion->addOutput(tv6);


### PR DESCRIPTION
Add a preseg pass to do dataflow analysis and find cases where we can disable Nan checking inside of Min/Max reduce https://github.com/NVIDIA/Fuser/issues/319 