### PR TITLE
Add remaining complex tests to direct bindings

### DIFF
--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -67,20 +67,6 @@ The following tests only exist in legacy frontend:
 - `test_cuda_code_and_scheduled_fusion_ir_strings` - Tests CUDA code generation (101 lines)
 - `test_arithmetic_ops` - TODO: Tests __neg__ and __abs__ arithmetic operations
 
-**General tests to add with more Than 50 Lines of Code:**
-The following tests are complex and will be moved to tests/python/direct/test_high_complexity.py.
-- `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes
-- `test_cat_symbolic` - Tests symbolic concatenation
-- `test_slice_error_checks` - Tests slice error checking
-- `test_deterministic_random` - Tests deterministic random number generation
-- `test_uniform_range` - Tests uniform range generation
-- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model
-- `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
-- `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
-- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass
-
-- `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
-
 ### Tests Only in Direct Frontend (Not in Main)
 
 The following 12 tests exist in `tests/python/direct/test_python_frontend.py` but are **NOT** present in `tests/python/test_python_frontend.py`:
@@ -183,6 +169,20 @@ Both test files contain these 80 common tests:
 - `test_zero_size_dim` - Tests zero size dimensions
 
 ### Additional Direct Frontend Test Files
+
+#### test_high_complexity.py
+The following 10 tests are moved from `tests/python/test_python_frontend.py` to `tests/python/direct/test_high_complexity.py`:
+
+- `test_broadcast_in_dim_with_dynamic_shapes` - Tests broadcasting with dynamic shapes
+- `test_cat_symbolic` - Tests symbolic concatenation
+- `test_slice_error_checks` - Tests slice error checking
+- `test_deterministic_random` - Tests deterministic random number generation
+- `test_uniform_range` - Tests uniform range generation
+- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model
+- `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
+- `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
+- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass
+- `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass
 
 #### test_repro.py (32 tests)
 The following 19 issue-specific tests have been migrated from the main frontend to the direct frontend and are now available in `tests/python/direct/test_repro.py`:

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -74,10 +74,10 @@ The following tests are complex and will be moved to tests/python/direct/test_hi
 - `test_slice_error_checks` - Tests slice error checking
 - `test_deterministic_random` - Tests deterministic random number generation
 - `test_uniform_range` - Tests uniform range generation
-- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model (201 lines)
+- `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model
 - `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
-
 - `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
+
 - `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
 

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -77,8 +77,8 @@ The following tests are complex and will be moved to tests/python/direct/test_hi
 - `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model
 - `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
 - `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
+- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass
 
-- `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)
 
 ### Tests Only in Direct Frontend (Not in Main)

--- a/tests/python/direct/README.md
+++ b/tests/python/direct/README.md
@@ -75,8 +75,8 @@ The following tests are complex and will be moved to tests/python/direct/test_hi
 - `test_deterministic_random` - Tests deterministic random number generation
 - `test_uniform_range` - Tests uniform range generation
 - `test_cat_qwen2_v2` - Tests concatenation for Qwen2 v2 model (201 lines)
-
 - `test_nanogpt_mha_dpa` - Tests NanoGPT multi-head attention
+
 - `test_nanogpt_split_mha_linears` - Tests NanoGPT split MHA linear layers
 - `test_prim_layer_norm_fwd` - Tests layer normalization forward pass (127 lines)
 - `test_prim_rms_norm_fwd` - Tests RMS normalization forward pass (65 lines)

--- a/tests/python/direct/test_high_complexity.py
+++ b/tests/python/direct/test_high_complexity.py
@@ -711,3 +711,85 @@ def test_nanogpt_mha_dpa(nvfuser_direct_test):
 
     for idx in range(len(nvf_out)):
         nvfuser_direct_test.assertEqual(eager_out, nvf_out[idx])
+
+
+def test_nanogpt_split_mha_linears(nvfuser_direct_test):
+    inputs = [
+        torch.randn(16, 128, 3072, device="cuda"),
+    ]
+
+    def nvfuser_fusion_0(fd: FusionDefinition) -> None:
+        T0 = fd.from_pytorch(inputs[0])
+        T0_slice1 = fd.ops.slice(T0, [0, 0, 0], [16, 128, 1024], [1, 1, 1])
+        T0_slice2 = fd.ops.slice(T0, [0, 0, 1024], [16, 128, 2048], [1, 1, 1])
+        T0_slice3 = fd.ops.slice(T0, [0, 0, 2048], [16, 128, 3072], [1, 1, 1])
+        T1_slice1 = fd.ops.reshape(T0_slice1, [16, 128, 16, 64])
+        T1_slice2 = fd.ops.reshape(T0_slice2, [16, 128, 16, 64])
+        T1_slice3 = fd.ops.reshape(T0_slice3, [16, 128, 16, 64])
+        T2_slice1 = fd.ops.permute(T1_slice1, [0, 2, 1, 3])
+        T2_slice2 = fd.ops.permute(T1_slice2, [0, 2, 1, 3])
+        T2_slice3 = fd.ops.permute(T1_slice3, [0, 2, 1, 3])
+        fd.add_output(T2_slice1)
+        fd.add_output(T2_slice2)
+        fd.add_output(T2_slice3)
+
+    def torch_def_0(acts, n_embd, n_head):
+        B, T, C = acts.size()
+        q, k, v = acts.split(n_embd, dim=2)
+        k = k.view(B, T, n_head, (C // 3) // n_head).transpose(1, 2)  # (B, nh, T, hs)
+        q = q.view(B, T, n_head, (C // 3) // n_head).transpose(1, 2)  # (B, nh, T, hs)
+        v = v.view(B, T, n_head, (C // 3) // n_head).transpose(1, 2)  # (B, nh, T, hs)
+        return (
+            q,
+            k,
+            v,
+        )
+
+    def nvfuser_fusion_1(fd: FusionDefinition) -> None:
+        T0 = fd.define_tensor(
+            shape=[-1, -1, -1],
+            contiguity=[True, True, True],
+            dtype=DataType.Float,
+            is_cpu=False,
+        )
+        T1 = fd.ops.slice(
+            T0,
+            start_indices=[0, 0, 0],
+            end_indices=[16, 128, 1024],
+            strides=[1, 1, 1],
+        )
+        T2 = fd.ops.slice(
+            T0,
+            start_indices=[0, 0, 1024],
+            end_indices=[16, 128, 2048],
+            strides=[1, 1, 1],
+        )
+        T3 = fd.ops.slice(
+            T0,
+            start_indices=[0, 0, 2048],
+            end_indices=[16, 128, 3072],
+            strides=[1, 1, 1],
+        )
+        fd.add_output(T1)
+        fd.add_output(T2)
+        fd.add_output(T3)
+
+    def torch_def_1(acts, n_embd, n_head):
+        B, T, C = acts.size()
+        q, k, v = acts.split(n_embd, dim=2)
+        return (
+            q,
+            k,
+            v,
+        )
+
+    tests = [
+        (nvfuser_fusion_0, torch_def_0),
+        (nvfuser_fusion_1, torch_def_1),
+    ]
+
+    for nvf_func, torch_func in tests:
+        nvf_out, _ = nvfuser_direct_test.exec_nvfuser(nvf_func, inputs)
+        eager_out = torch_func(*inputs, 1024, 16)
+        for idx in range(len(eager_out)):
+            nvfuser_direct_test.assertEqual(eager_out[idx], nvf_out[idx])


### PR DESCRIPTION
This PR adds the remaining tests from `tests/python/test_python_frontend.py` to `tests/python/direct/test_high_complexity.py`.

PR Stack:
- #5128
- #5129
- #5130  **<<< This PR.**
- #5131