### PR TITLE
Convert python benchmarks to direct bindings except `benchmark_overlap.py`

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 from .core import BENCHMARK_CONFIG
-from nvfuser.pytorch_utils import DEVICE_PROPERTIES
+from nvfuser_direct.pytorch_utils import DEVICE_PROPERTIES
 
 
 def pytest_addoption(parser):
@@ -142,7 +142,7 @@ def pytest_collection_modifyitems(session, config, items):
     default.
     """
 
-    from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
+    from nvfuser_direct.pytorch_utils import retry_on_oom_or_skip_test
 
     executors = ["eager", "torchcompile", "thunder", "thunder-torchcompile"]
 

--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -6,12 +6,12 @@ import pytest_benchmark
 import torch
 from typing import List, Callable, Union
 import numpy as np
-from nvfuser import FusionDefinition, FusionCache
-from nvfuser.pytorch_utils import DEVICE_PROPERTIES
+from nvfuser_direct import FusionDefinition, FusionCache
+from nvfuser_direct.pytorch_utils import DEVICE_PROPERTIES
 import warnings
 import thunder
 from thunder.executors.nvfuserex import nvfuserex
-from nvfuser.benchmark_utils import FusionProfileTimer, CuptiTimer
+from nvfuser_direct.benchmark_utils import FusionProfileTimer, CuptiTimer
 
 # These variables can be overwritten through CLI commands
 # --benchmark-rounds=rounds --benchmark-warmup-rounds=warmup_rounds

--- a/benchmarks/python/global_params.py
+++ b/benchmarks/python/global_params.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import torch
 from typing import Union, List, Tuple
-from nvfuser import DataType
+from nvfuser_direct import DataType
 from .core import BENCHMARK_CONFIG
-from nvfuser.pytorch_utils import DEVICE_PROPERTIES
+from nvfuser_direct.pytorch_utils import DEVICE_PROPERTIES
 import itertools
 import os
 from random import sample

--- a/benchmarks/python/host/test_adaptive_layernorm_host.py
+++ b/benchmarks/python/host/test_adaptive_layernorm_host.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
+from nvfuser_direct import FusionDefinition, DataType
 from ..core import run_benchmark
 import torch
 

--- a/benchmarks/python/host/test_many_pointwise_ops_host.py
+++ b/benchmarks/python/host/test_many_pointwise_ops_host.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from ..core import run_benchmark
 import torch
 from ..global_params import PROMOTE_DTYPES

--- a/benchmarks/python/host/test_many_segments_host.py
+++ b/benchmarks/python/host/test_many_segments_host.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
+from nvfuser_direct import FusionDefinition, DataType
 from ..core import run_benchmark
 import torch
 

--- a/benchmarks/python/normalization.py
+++ b/benchmarks/python/normalization.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
-from nvfuser import FusionDefinition, DataType
+from nvfuser_direct import FusionDefinition, DataType
 from .global_params import PROMOTE_DTYPES
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 import torch
 from .core import run_benchmark, unary_bwd_torch, clear_dynamo_cache, with_executor
 import numpy as np

--- a/benchmarks/python/test_broadcast_add_fwd.py
+++ b/benchmarks/python/test_broadcast_add_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_cat.py
+++ b/benchmarks/python/test_cat.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
 import torch
-from nvfuser import FusionDefinition, DataType
+from nvfuser_direct import FusionDefinition, DataType
 from .core import run_benchmark, with_executor
 
 # These tests are sourced from automation added into thunder.

--- a/benchmarks/python/test_dropout_layernorm_bwd.py
+++ b/benchmarks/python/test_dropout_layernorm_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_dropout_layernorm_fwd.py
+++ b/benchmarks/python/test_dropout_layernorm_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_dropout_rmsnorm_bwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_dropout_rmsnorm_fwd.py
+++ b/benchmarks/python/test_dropout_rmsnorm_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_gelu_bwd.py
+++ b/benchmarks/python/test_gelu_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_gelu_bwd_reduction.py
+++ b/benchmarks/python/test_gelu_bwd_reduction.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_gelu_fwd.py
+++ b/benchmarks/python/test_gelu_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_groupnorm_fwd.py
+++ b/benchmarks/python/test_groupnorm_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_huggingface_attn_bwd.py
+++ b/benchmarks/python/test_huggingface_attn_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_huggingface_attn_fwd.py
+++ b/benchmarks/python/test_huggingface_attn_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_layernorm_bwd.py
+++ b/benchmarks/python/test_layernorm_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_layernorm_fwd.py
+++ b/benchmarks/python/test_layernorm_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_matmul.py
+++ b/benchmarks/python/test_matmul.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition
+from nvfuser_direct import FusionDefinition
 from .core import run_benchmark
 import torch
 

--- a/benchmarks/python/test_nanogpt_attn_bwd.py
+++ b/benchmarks/python/test_nanogpt_attn_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_nanogpt_attn_fwd.py
+++ b/benchmarks/python/test_nanogpt_attn_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_attn_inputs, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_pointwise_mul.py
+++ b/benchmarks/python/test_pointwise_mul.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_reduction.py
+++ b/benchmarks/python/test_reduction.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_reduction_epilogue.py
+++ b/benchmarks/python/test_reduction_epilogue.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_rmsnorm_bwd.py
+++ b/benchmarks/python/test_rmsnorm_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_rmsnorm_fwd.py
+++ b/benchmarks/python/test_rmsnorm_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_scale_bias_relu_bwd.py
+++ b/benchmarks/python/test_scale_bias_relu_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_scale_bias_relu_fwd.py
+++ b/benchmarks/python/test_scale_bias_relu_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_silu_mul_bwd.py
+++ b/benchmarks/python/test_silu_mul_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_silu_mul_fwd.py
+++ b/benchmarks/python/test_silu_mul_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_softmax_bwd.py
+++ b/benchmarks/python/test_softmax_bwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import (
     run_benchmark,
     clear_dynamo_cache,

--- a/benchmarks/python/test_softmax_fwd.py
+++ b/benchmarks/python/test_softmax_fwd.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/benchmarks/python/test_transpose.py
+++ b/benchmarks/python/test_transpose.py
@@ -2,8 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import pytest
-from nvfuser import FusionDefinition, DataType
-from nvfuser.pytorch_utils import torch_dtype_to_nvfuser_dtype
+from nvfuser_direct import FusionDefinition, DataType
+from nvfuser_direct.pytorch_utils import torch_dtype_to_nvfuser_dtype
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
 from .global_params import generate_input_sizes, FLOAT_DTYPES, PROMOTE_DTYPES

--- a/python/nvfuser_direct/benchmark_utils.py
+++ b/python/nvfuser_direct/benchmark_utils.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from cupti import cupti
+import cxxfilt
+import pytest
+
+
+# Base class for all timers used by pytest-benchmark.
+class Timer:
+    def __init__(self):
+        self.current_time = 0.0
+
+    def _increment_global_time(self, elapsed_time: float) -> None:
+        self.current_time += elapsed_time
+
+    def __call__(self):
+        raise NotImplementedError("Subclass must implement this method")
+
+    def cleanup(self):
+        pass
+
+
+def demangle_kernel_name(mangled_name):
+    try:
+        return cxxfilt.demangle(mangled_name)
+    except Exception:
+        return mangled_name  # Return original if demangling fails
+
+
+def cupti_call_safe(func, *args):
+    """Wrapper for CUPTI calls. Failing CUPTI calls will exit the program."""
+    try:
+        return func(*args)
+    except Exception as e:
+        print(f"CUPTI call {func.__name__} failed: {e}")
+        pytest.exit(1)
+
+
+class CuptiProfiler:
+    # List of activities to be recorded by CUPTI.
+    activity_kinds: list[cupti.ActivityKind] = [
+        cupti.ActivityKind.CONCURRENT_KERNEL,
+    ]
+
+    # Private class variable to store the subscriber handle.
+    __subscriber_handle = None
+
+    def _error_if_not_valid(self) -> None:
+        if not self.is_valid:
+            raise RuntimeError(
+                "CuptiProfiler is not valid. " "This instance has been torn down."
+            )
+
+    def _func_buffer_requested(self) -> tuple[int, int]:
+        # 8MB buffer size as recommended by CUPTI samples.
+        # max_num_records=0 indicates the buffer is filled with as many records as possible.
+        buffer_size = 8 * 1024 * 1024
+        max_num_records = 0
+        return buffer_size, max_num_records
+
+    def _func_buffer_completed(self, activities: list[cupti.ActivityAPI]) -> None:
+        for activity in activities:
+            # Activity.end and Activity.start are in nanoseconds.
+            duration = (activity.end - activity.start) / 1e9
+            self.profiler_output.append((demangle_kernel_name(activity.name), duration))
+
+    def __init__(self):
+        if CuptiProfiler.__subscriber_handle is not None:
+            raise RuntimeError(
+                "Only one instance of CuptiProfiler can be created. "
+                "CUPTI only supports one subscriber at a time."
+            )
+
+        self.profiler_output: list[tuple[str, float]] = []
+
+        # Subscribe to CUPTI and register activity callbacks.
+        CuptiProfiler.__subscriber_handle = cupti_call_safe(cupti.subscribe, None, None)
+        cupti_call_safe(
+            cupti.activity_register_callbacks,
+            self._func_buffer_requested,
+            self._func_buffer_completed,
+        )
+        self.is_valid = True
+
+    def start(self) -> None:
+        self._error_if_not_valid()
+        cupti_call_safe(cupti.activity_flush_all, 1)
+        self.profiler_output = []
+        for activity_kind in CuptiProfiler.activity_kinds:
+            cupti_call_safe(cupti.activity_enable, activity_kind)
+
+    def stop(self) -> list[tuple[str, float]]:
+        self._error_if_not_valid()
+        for activity_kind in CuptiProfiler.activity_kinds:
+            cupti_call_safe(cupti.activity_disable, activity_kind)
+        cupti_call_safe(cupti.activity_flush_all, 0)
+        return self.profiler_output
+
+    def teardown_cupti(self) -> None:
+        self._error_if_not_valid()
+        if CuptiProfiler.__subscriber_handle is None:
+            return
+        cupti_call_safe(cupti.unsubscribe, CuptiProfiler.__subscriber_handle)
+        cupti_call_safe(cupti.finalize)
+        CuptiProfiler.__subscriber_handle = None
+        # Invalidate the profiler so it cannot be used again.
+        self.is_valid = False
+
+
+class CuptiTimer(Timer):
+    def __init__(self):
+        super().__init__()
+        self.cupti_profiler = CuptiProfiler()
+        self.is_running = False
+
+    def __call__(self):
+        torch.cuda.synchronize()
+
+        if not self.is_running:
+            self.cupti_profiler.start()
+            self.is_running = True
+            return self.current_time
+
+        profiler_output = self.cupti_profiler.stop()
+        self.is_running = False
+
+        # Check if any activities were recorded
+        if len(profiler_output) == 0:
+            self.cleanup()
+            raise RuntimeError("No activities were recorded.")
+
+        self._increment_global_time(sum(duration for _, duration in profiler_output))
+        return self.current_time
+
+    def cleanup(self):
+        self.is_running = False
+        self.cupti_profiler.teardown_cupti()
+
+
+class FusionProfileTimer(Timer):
+    def __init__(self):
+        super().__init__()
+        self.fd = None
+        # Specifies if the timer in host measurement is called at the start/finish of execution.
+        # Timings are measured at the end of execution.
+        self.execution_start = True
+
+    def set_fd(self, fd):
+        self.fd = fd
+
+    def __call__(self):
+        if not self.execution_start:
+            profile = self.fd.profile()
+            elapsed_host_time = profile.host_time_ms / 1e3
+            self._increment_global_time(elapsed_host_time)
+        self.execution_start = not self.execution_start
+        return self.current_time

--- a/python/nvfuser_direct/pytorch_utils.py
+++ b/python/nvfuser_direct/pytorch_utils.py
@@ -5,10 +5,8 @@ import torch
 
 from ._C_DIRECT import DataType
 
-import ctypes
+from typing import Type, Union
 import functools
-import gc
-from typing import Type, Union, Tuple
 
 NumberTypeType = Union[Type[bool], Type[int], Type[float], Type[complex]]
 
@@ -47,117 +45,6 @@ def torch_dtype_to_nvfuser_dtype(dtype: Union[torch.dtype, NumberTypeType]):
     Translates from torch.dtype to nvFuser's DataType enum
     """
     return _torch_dtype_to_nvfuser_dtype_map[dtype]
-
-
-def get_device_properties() -> Tuple[int, float]:
-    """
-    Computes device properties using ctypes and cuda.
-    Note: Consider using CUDA-Python when CUDA support >= 12.0.
-    """
-    libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
-    for libname in libnames:
-        try:
-            cuda = ctypes.CDLL(libname)
-        except OSError:
-            continue
-        else:
-            break
-    else:
-        raise OSError("could not load any of: " + " ".join(libnames))
-
-    # Device attribute enums (taken from cuda.h)
-    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1ge12b8a782bebe21b1ac0091bf9f4e2a3
-
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
-    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
-    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12
-    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
-    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
-    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37
-    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38
-    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
-
-    device_properties = {}
-    device = torch.cuda.current_device()
-    cuda_properties = torch.cuda.get_device_properties(device)
-
-    device_properties["gpu_name"] = cuda_properties.name
-    device_properties["gpu_compute_capability_major"] = cuda_properties.major
-    device_properties["gpu_compute_capability_minor"] = cuda_properties.minor
-    device_properties["gpu_gmem_bytes"] = cuda_properties.total_memory
-    device_properties["gpu_sm_count"] = cuda_properties.multi_processor_count
-
-    max_threads_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_threads_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_max_threads_per_block"] = max_threads_per_block.value
-
-    smem_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(smem_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_smem_bytes_per_block"] = smem_per_block.value
-
-    max_reg_per_block = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_reg_per_block),
-        CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
-        device,
-    )
-    device_properties["gpu_regs_per_block"] = max_reg_per_block.value
-
-    max_clock_khz = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_clock_khz),
-        CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
-        device,
-    )
-    device_properties["gpu_clock_rate_khz"] = max_clock_khz.value
-
-    l2_cache_size = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(l2_cache_size), CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device
-    )
-    device_properties["gpu_l2_bytes"] = l2_cache_size.value
-
-    memory_clock_rate = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(memory_clock_rate), CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device
-    )
-    device_properties["gpu_mem_clock_khz"] = memory_clock_rate.value
-
-    memory_bus_width = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(memory_bus_width),
-        CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
-        device,
-    )
-    device_properties["gpu_mem_bus_width"] = memory_bus_width.value
-
-    max_threads_per_sm = ctypes.c_int()
-    cuda.cuDeviceGetAttribute(
-        ctypes.byref(max_threads_per_sm),
-        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
-        device,
-    )
-    device_properties["gpu_max_threads_per_sm"] = max_threads_per_sm.value
-
-    # Compute peak bandwidth in GBps
-    peak_bandwidth = (2 * memory_bus_width.value * memory_clock_rate.value) / (1e6 * 8)
-    device_properties["gpu_peak_bandwidth_gbps"] = peak_bandwidth
-
-    return device_properties
-
-
-DEVICE_PROPERTIES = None
-if torch.cuda.is_available():
-    # Loading libraries will raise errors on non-CUDA machines.
-    DEVICE_PROPERTIES = get_device_properties()
 
 
 def retry_on_oom_or_skip_test(func):

--- a/python/nvfuser_direct/pytorch_utils.py
+++ b/python/nvfuser_direct/pytorch_utils.py
@@ -1,12 +1,14 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import torch
 
-from ._C_DIRECT import DataType
+from ._C import DataType
 
-from typing import Type, Union
+import ctypes
 import functools
+import gc
+from typing import Type, Union, Tuple
 
 NumberTypeType = Union[Type[bool], Type[int], Type[float], Type[complex]]
 
@@ -45,6 +47,117 @@ def torch_dtype_to_nvfuser_dtype(dtype: Union[torch.dtype, NumberTypeType]):
     Translates from torch.dtype to nvFuser's DataType enum
     """
     return _torch_dtype_to_nvfuser_dtype_map[dtype]
+
+
+def get_device_properties() -> Tuple[int, float]:
+    """
+    Computes device properties using ctypes and cuda.
+    Note: Consider using CUDA-Python when CUDA support >= 12.0.
+    """
+    libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
+    for libname in libnames:
+        try:
+            cuda = ctypes.CDLL(libname)
+        except OSError:
+            continue
+        else:
+            break
+    else:
+        raise OSError("could not load any of: " + " ".join(libnames))
+
+    # Device attribute enums (taken from cuda.h)
+    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1ge12b8a782bebe21b1ac0091bf9f4e2a3
+
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
+    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12
+    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
+    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
+    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37
+    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
+
+    device_properties = {}
+    device = torch.cuda.current_device()
+    cuda_properties = torch.cuda.get_device_properties(device)
+
+    device_properties["gpu_name"] = cuda_properties.name
+    device_properties["gpu_compute_capability_major"] = cuda_properties.major
+    device_properties["gpu_compute_capability_minor"] = cuda_properties.minor
+    device_properties["gpu_gmem_bytes"] = cuda_properties.total_memory
+    device_properties["gpu_sm_count"] = cuda_properties.multi_processor_count
+
+    max_threads_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_max_threads_per_block"] = max_threads_per_block.value
+
+    smem_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(smem_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_smem_bytes_per_block"] = smem_per_block.value
+
+    max_reg_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_reg_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_regs_per_block"] = max_reg_per_block.value
+
+    max_clock_khz = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_clock_khz),
+        CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
+        device,
+    )
+    device_properties["gpu_clock_rate_khz"] = max_clock_khz.value
+
+    l2_cache_size = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(l2_cache_size), CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device
+    )
+    device_properties["gpu_l2_bytes"] = l2_cache_size.value
+
+    memory_clock_rate = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_clock_rate), CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device
+    )
+    device_properties["gpu_mem_clock_khz"] = memory_clock_rate.value
+
+    memory_bus_width = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_bus_width),
+        CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
+        device,
+    )
+    device_properties["gpu_mem_bus_width"] = memory_bus_width.value
+
+    max_threads_per_sm = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_sm),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+        device,
+    )
+    device_properties["gpu_max_threads_per_sm"] = max_threads_per_sm.value
+
+    # Compute peak bandwidth in GBps
+    peak_bandwidth = (2 * memory_bus_width.value * memory_clock_rate.value) / (1e6 * 8)
+    device_properties["gpu_peak_bandwidth_gbps"] = peak_bandwidth
+
+    return device_properties
+
+
+DEVICE_PROPERTIES = None
+if torch.cuda.is_available():
+    # Loading libraries will raise errors on non-CUDA machines.
+    DEVICE_PROPERTIES = get_device_properties()
 
 
 def retry_on_oom_or_skip_test(func):

--- a/python/nvfuser_direct/pytorch_utils.py
+++ b/python/nvfuser_direct/pytorch_utils.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import torch
 
-from ._C import DataType
+from ._C_DIRECT import DataType
 
 import ctypes
 import functools


### PR DESCRIPTION
* `benchmark_overlap.py` uses multidevice executor, which isn't supported by direct bindings.
* Replace `import nvfuser` with `import nvfuser_direct` in python benchmarks.
* Copy `benchmark_utils.py` to `nvfuser_direct` module