### PR TITLE
Refactor: use auto* for LHS of dynamic_cast

### DIFF
--- a/csrc/alias_analysis.cpp
+++ b/csrc/alias_analysis.cpp
@@ -163,7 +163,7 @@ void AliasFinder::handle(const ReshapeOp* view) {
 }
 
 void AliasFinder::handle(const LoadStoreOp* set) {
-  TensorView* in = dynamic_cast<TensorView*>(set->in());
+  auto* in = dynamic_cast<TensorView*>(set->in());
   if (in == nullptr) {
     return;
   }
@@ -268,7 +268,7 @@ void AliasFinder::handle(const SliceOp* slice) {
 }
 
 void AliasFinder::handle(const BroadcastOp* bcast) {
-  TensorView* in = dynamic_cast<TensorView*>(bcast->in());
+  auto* in = dynamic_cast<TensorView*>(bcast->in());
   if (in == nullptr) {
     return;
   }
@@ -296,7 +296,7 @@ void AliasFinder::handle(const BroadcastOp* bcast) {
 }
 
 void AliasFinder::handle(const SqueezeOp* squeeze) {
-  TensorView* in = dynamic_cast<TensorView*>(squeeze->in());
+  auto* in = dynamic_cast<TensorView*>(squeeze->in());
   if (in == nullptr) {
     return;
   }

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -793,7 +793,7 @@ class AllocationDomainSetup : private kir::IrVisitor {
     const ExprGroups& merge_outer_uses = exact_graph.getUses(merge_outer_group);
     ExprGroup reverse_merge;
     for (const auto& merge_outer_use : merge_outer_uses) {
-      Merge* merge = dynamic_cast<Merge*>(merge_outer_use->front());
+      auto* merge = dynamic_cast<Merge*>(merge_outer_use->front());
       if (merge == nullptr) {
         continue;
       }

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -473,7 +473,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     // Check that outer_loop matches known invariants for persistent kernel.
     IterDomain* outer_id =
         lower_utils::getConcreteLoopID(outer_loop->iterDomain());
-    Split* persistent_split = dynamic_cast<Split*>(outer_id->definition());
+    auto* persistent_split = dynamic_cast<Split*>(outer_id->definition());
     NVF_ERROR(
         persistent_split != nullptr,
         "Expected ",
@@ -904,7 +904,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     const auto& ldst_mbarrier_map = GpuLower::current()->mbarrierMap();
     std::unordered_map<TensorView*, kir::MBarrierWaitParity*> wait_exprs;
     for (auto tv : circular_buffer_load_tvs_) {
-      LoadStoreOp* ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
+      auto* ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
       auto mbarrier_it = ldst_mbarrier_map.find(ldst);
       if (mbarrier_it == ldst_mbarrier_map.end()) {
         // This circular buffer tensor does not use mbarrier to synchronize.
@@ -932,7 +932,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
         if (circular_buffer_load_tvs_.count(tv) == 0) {
           continue;
         }
-        LoadStoreOp* ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
+        auto* ldst = dynamic_cast<LoadStoreOp*>(tv->definition());
         if (ldst == nullptr) {
           continue;
         }

--- a/csrc/host_ir/pass/convert_op_to_communication.cpp
+++ b/csrc/host_ir/pass/convert_op_to_communication.cpp
@@ -22,7 +22,7 @@ namespace nvfuser::hir_pass {
 
 void ConvertOpToCommunication::passImplementation(Fusion* fusion) {
   FusionGuard fg(fusion);
-  hir::HostIrContainer* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
+  auto* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
   NVF_CHECK(hic, "Expected HostIrContainer");
   DeviceIdxType my_device_index = Communicator::getInstance().deviceId();
 

--- a/csrc/host_ir/pass/insert_deallocations.cpp
+++ b/csrc/host_ir/pass/insert_deallocations.cpp
@@ -13,7 +13,7 @@ namespace nvfuser::hir_pass {
 
 void InsertDeallocations::passImplementation(Fusion* fusion) {
   FusionGuard fg(fusion);
-  hir::HostIrContainer* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
+  auto* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
   NVF_CHECK(hic, "Expected HostIrContainer");
 
   const std::vector<Expr*>& top_level_exprs = hic->topLevelExprs();

--- a/csrc/host_ir/pass/stream_parallel_type.cpp
+++ b/csrc/host_ir/pass/stream_parallel_type.cpp
@@ -539,7 +539,7 @@ void StreamParallelType::passImplementation(Fusion* fusion) {
 
   // Set up the fusion environment and build the ID model
   FusionGuard fg(fusion);
-  hir::HostIrContainer* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
+  auto* hic = dynamic_cast<hir::HostIrContainer*>(fusion);
   NVF_CHECK(hic, "Expected HostIrContainer");
 
   IdModel id_model(fusion);

--- a/csrc/ir/cloner.h
+++ b/csrc/ir/cloner.h
@@ -189,8 +189,8 @@ T* IrBuilder::clone(const T* src, IrCloner* ir_cloner) {
       "Cloner doesn't have a valid container to store cloned object.");
 
   T* dest = new T(src, ir_cloner);
-  const Statement* src_stmt = dynamic_cast<const Statement*>(src);
-  Statement* dest_stmt = dynamic_cast<Statement*>(dest);
+  const auto* src_stmt = dynamic_cast<const Statement*>(src);
+  auto* dest_stmt = dynamic_cast<Statement*>(dest);
 
   auto dest_container = ir_cloner->container();
   auto src_container = src_stmt->container();

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2453,7 +2453,7 @@ std::string LoadStoreOp::toString(int indent_size) const {
   std::string optype = load_store_type2string(opType());
   std::string modifier = "";
   { // Get modifier
-    TensorView* tv = dynamic_cast<TensorView*>(out());
+    auto* tv = dynamic_cast<TensorView*>(out());
     if (auto ti = dynamic_cast<kir::TensorIndex*>(out())) {
       tv = ti->view();
     }

--- a/csrc/preseg_passes/finalize_multidevice_domains.cpp
+++ b/csrc/preseg_passes/finalize_multidevice_domains.cpp
@@ -70,7 +70,7 @@ void setLoopAndAllocationDomain(TensorView* tv, bool is_resharding) {
       {tv->getLoopDomain().begin(), tv->getLoopDomain().end()});
 
   for (auto* expr : transform_exprs) {
-    Split* split = dynamic_cast<Split*>(expr);
+    auto* split = dynamic_cast<Split*>(expr);
     NVF_ERROR(
         split != nullptr,
         "Expected all transform exprs to be a split between allocation and "

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -1065,7 +1065,7 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     std::ranges::copy_if(
         tv->uses(), std::back_inserter(uses_to_update), [&](Expr* use) {
           return std::ranges::any_of(use->outputs(), [&](Val* out) {
-            TensorView* out_tv = dynamic_cast<TensorView*>(out);
+            auto* out_tv = dynamic_cast<TensorView*>(out);
             if (out_tv == nullptr) {
               return false;
             }

--- a/csrc/scheduler/matmul_ampere-.cpp
+++ b/csrc/scheduler/matmul_ampere-.cpp
@@ -956,7 +956,7 @@ void AmpereMinus::schedulePrologues() {
     std::unordered_set<TensorView*>
         mma_input_set; // to prevent double insertion
     for (TensorView* mma_result : mma_results_) {
-      MmaOp* mma = dynamic_cast<MmaOp*>(mma_result->definition());
+      auto* mma = dynamic_cast<MmaOp*>(mma_result->definition());
       NVF_ERROR(mma != nullptr);
       TensorView* mma_input = nullptr;
       if (operand_type == MmaOperand::A) {

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1758,8 +1758,8 @@ class MatmulPatternMatcher : IterVisitor {
       // Float, but the Fusion was segmented and casts to half precision were
       // inserted at the segmentation edge (see
       // castInputOutputToLowerPrecision in fusion_segmenter.cpp).
-      TensorView* ltv = dynamic_cast<TensorView*>(bop->lhs());
-      TensorView* rtv = dynamic_cast<TensorView*>(bop->rhs());
+      auto* ltv = dynamic_cast<TensorView*>(bop->lhs());
+      auto* rtv = dynamic_cast<TensorView*>(bop->rhs());
       if (ltv == nullptr || rtv == nullptr) {
         // Found a scalar input
         return;

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -114,7 +114,7 @@ bool ResizeScheduler::canScheduleCompileTime(Fusion* fusion) {
   for (auto resize_tensor_op : resize_tensor_ops) {
     TensorView* out_tv = resize_tensor_op->output(0)->as<TensorView>();
     for (auto logical_id : out_tv->getLogicalDomain()) {
-      Resize* resize = dynamic_cast<Resize*>(logical_id->definition());
+      auto* resize = dynamic_cast<Resize*>(logical_id->definition());
       if (resize == nullptr) {
         continue;
       }


### PR DESCRIPTION
This PR replaces explicit pointer types on the left-hand side with auto* when the right-hand side is a dynamic_cast<Type*> (including const-qualified forms). It reduces duplication and keeps declarations concise while preserving constness and pointer semantics.

Summary
- Scope: csrc directory (excluded third_party)
- Changes: 19 instances across 13 files
- Rationale: Avoid repeating type names next to dynamic_cast; clearer and less error-prone

Validation
- Verified no remaining matches of the targeted pattern in csrc
- Built locally with _bn; successful, no related warnings/errors

Please let me know if you prefer limiting this change to particular submodules or expanding the sweep further.
