### PR TITLE
NFC: Use auto* for as<> casts across device lowering, IR, scheduler, Python frontend, and tests

### DIFF
--- a/csrc/device_lower/analysis/predicate_elimination.cpp
+++ b/csrc/device_lower/analysis/predicate_elimination.cpp
@@ -42,7 +42,7 @@ void assertOnWarpOps(const Expr* expr) {
   // Prohibit predicates for LdMatrix expressions in Mma k main loop;
   // Allow predicates for general LdMatrix usage.
   if (ir_utils::isLdMatrixOp(expr)) {
-    const LoadStoreOp* ldst = expr->as<LoadStoreOp>();
+    const auto* ldst = expr->as<LoadStoreOp>();
     TensorView* in_tv = ir_utils::getTv(ldst->in());
     NVF_ERROR(in_tv != nullptr);
 

--- a/csrc/device_lower/analysis/tma.cpp
+++ b/csrc/device_lower/analysis/tma.cpp
@@ -1070,11 +1070,11 @@ std::vector<TMADim> run(
 } // namespace collapse_tma_domain
 
 TMAInfo getTMAInfo(LoadStoreOp* ldst) {
-  TensorView* producer_tv = ldst->in()->as<TensorView>();
+  auto* producer_tv = ldst->in()->as<TensorView>();
   // In case the producer is aliased, use the alias instead
   producer_tv = GpuLower::current()->getMaybeTensorProducerAlias(producer_tv);
 
-  TensorView* consumer_tv = ldst->out()->as<TensorView>();
+  auto* consumer_tv = ldst->out()->as<TensorView>();
   TensorView *smem_tv = nullptr, *gmem_tv = nullptr;
   if (producer_tv->getMemoryType() == MemoryType::Shared) {
     NVF_ERROR(consumer_tv->getMemoryType() == MemoryType::Global);

--- a/csrc/device_lower/pass/circular_buffer.cpp
+++ b/csrc/device_lower/pass/circular_buffer.cpp
@@ -450,7 +450,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
     if (!id_def->isA<Split>()) {
       return nullptr;
     }
-    Split* id_def_split = id_def->as<Split>();
+    auto* id_def_split = id_def->as<Split>();
     if (id_def_split->factor() != inner_loop->stop()) {
       return nullptr;
     }
@@ -1009,7 +1009,7 @@ class CloneTmaCircularBufferLoopAndInsertSync
   Val* getSizeOfTmaLoad(LoadStoreOp* ldst) {
     NVF_ERROR(ldst != nullptr);
 
-    TensorView* consumer_tv = ldst->out()->as<TensorView>();
+    auto* consumer_tv = ldst->out()->as<TensorView>();
     NVF_ERROR(
         GpuLower::current()->consumerToTMAInfo().count(consumer_tv),
         "Unable to find TMA info for consumer_tv: ",

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -1951,7 +1951,7 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
     bool is_tma_ldmatrix = false;
     if (ir_utils::isLdMatrixOp(ldst)) {
       NVF_ERROR(ldst->in()->isA<TensorView>());
-      TensorView* in_tv = ldst->in()->as<TensorView>();
+      auto* in_tv = ldst->in()->as<TensorView>();
       NVF_ERROR(in_tv->definition() != nullptr);
       is_tma_ldmatrix = ir_utils::isCpAsyncBulkLoad(in_tv->definition());
       if (is_tma_ldmatrix) {
@@ -2027,7 +2027,7 @@ void IndexLowering::handle(const LoadStoreOp* ldst) {
 
       // Get the index for the output of stmatrix.
       NVF_ERROR(ldst->out()->isA<TensorView>());
-      TensorView* out_tv = ldst->out()->as<TensorView>();
+      auto* out_tv = ldst->out()->as<TensorView>();
       MmaInputSmemSwizzle swizzle = getSwizzle(out_tv);
       switch (swizzle) {
         case MmaInputSmemSwizzle::None: {
@@ -2418,7 +2418,7 @@ namespace {
 Val* indexBlackwellMmaOutput(
     const MmaOp* mma,
     const std::vector<ForLoop*>& for_loops) {
-  TensorView* tmem_tv = mma->out()->as<TensorView>();
+  auto* tmem_tv = mma->out()->as<TensorView>();
   NVF_ERROR(tmem_tv->getMemoryType() == MemoryType::Tensor, "Invalid tmem_tv");
   const auto& tmem_info = GpuLower::current()->tmemInfo();
   const auto& tensor_indexer = GpuLower::current()->tensorIndexer();

--- a/csrc/device_lower/pass/loops.cpp
+++ b/csrc/device_lower/pass/loops.cpp
@@ -95,7 +95,7 @@ void LoopNestGenerator::handle(Expr* expr) {
     return;
   }
 
-  TensorView* out_tv = expr->output(0)->as<TensorView>();
+  auto* out_tv = expr->output(0)->as<TensorView>();
 
   // Grab the loop structure
   NVF_ERROR(

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -2111,7 +2111,7 @@ IterDomain* getConcreteLoopID(IterDomain* id) {
 
     // Try to see if the CA concrete domain can be used instead
     for (auto loop_val : *loop_group) {
-      IterDomain* loop_id = loop_val->as<IterDomain>();
+      auto* loop_id = loop_val->as<IterDomain>();
       if (ca_map.idExistsInMap(loop_id, IdMappingMode::LOOP)) {
         auto ca_map_concrete =
             ca_map.getConcreteMappedID(loop_id, IdMappingMode::LOOP);

--- a/csrc/host_ir/pass/stream_parallel_type.cpp
+++ b/csrc/host_ir/pass/stream_parallel_type.cpp
@@ -201,7 +201,7 @@ std::vector<Expr*> groupStreamParallelRegions(
         "Each expr should have at most one output.");
 
     // Get the output tensor and check for stream parallelization
-    TensorView* output = expr->output(0)->as<TensorView>();
+    auto* output = expr->output(0)->as<TensorView>();
     IterDomain* stream_axis = getStreamAxis(output->getLoopDomain());
 
     // If no stream axis found, keep the expression as is

--- a/csrc/id_model/loop_promotion.cpp
+++ b/csrc/id_model/loop_promotion.cpp
@@ -626,7 +626,7 @@ std::unordered_map<ValGroup, IterDomain*> LoopPromotionMapBuilder::
   for (const ValGroup& iel_group : iel_graph.disjointValSets().disjointSets()) {
     NVF_ERROR(!iel_group->empty());
 
-    IterDomain* iel_group_id = iel_group->front()->as<IterDomain>();
+    auto* iel_group_id = iel_group->front()->as<IterDomain>();
 
     if (!iel_group_id->isBroadcast()) {
       continue;
@@ -1306,7 +1306,7 @@ std::unordered_map<ValGroup, IterDomain*> LoopPromotionMapBuilder::
     bool is_const = false;
 
     for (Val* val : *loop_group) {
-      IterDomain* loop_id = val->as<IterDomain>();
+      auto* loop_id = val->as<IterDomain>();
 
       // Ignore broadcast if this group also has non-broadcast
       // IDs. See the above comment on has_both_broadcast_and_concrete

--- a/csrc/index_compute.cpp
+++ b/csrc/index_compute.cpp
@@ -2724,8 +2724,8 @@ std::pair<Val*, Val*> Index::getCpAsyncBulkGmemIndex(
     const std::unordered_set<ForLoop*>& rotated_loops) {
   FUSER_PERF_SCOPE("Index::getCpAsyncBulkGmemIndex");
 
-  TensorView* producer_tv = ldst->in()->as<TensorView>();
-  TensorView* consumer_tv = ldst->out()->as<TensorView>();
+  auto* producer_tv = ldst->in()->as<TensorView>();
+  auto* consumer_tv = ldst->out()->as<TensorView>();
 
   bool is_load = false;
   TensorView* gmem_tv = nullptr;

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -332,7 +332,7 @@ bool Expr::sameAs(const Statement* other) const {
   if (!other->isA<Expr>()) {
     return false;
   }
-  const Expr* other_expr = other->as<Expr>();
+  const auto* other_expr = other->as<Expr>();
   if (!sameOp(other_expr)) {
     return false;
   }

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2673,7 +2673,7 @@ bool IterDomain::sameAs(const Statement* other) const {
     return false;
   }
 
-  const IterDomain* other_id = other->as<IterDomain>();
+  const auto* other_id = other->as<IterDomain>();
 
   // Here're the data fields of IterDomain:
   // start_
@@ -3493,7 +3493,7 @@ bool TensorDomain::sameAs(const Statement* const other) const {
     return false;
   }
 
-  const TensorDomain* other_td = other->as<TensorDomain>();
+  const auto* other_td = other->as<TensorDomain>();
 
   if (nDims() != other_td->nDims()) {
     return false;

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -770,7 +770,7 @@ void UnmappableReductionDomains::handleReductionOutput(TensorView* out_tv) {
 
 void UnmappableReductionDomains::handle(ReductionOp* op) {
   // Builds a map from reduction domains to consumer domains.
-  TensorView* out_tv = op->out()->as<TensorView>();
+  auto* out_tv = op->out()->as<TensorView>();
   handleReductionOutput(out_tv);
 }
 
@@ -783,7 +783,7 @@ void UnmappableReductionDomains::handle(GroupedReductionOp* op) {
 
 void UnmappableReductionDomains::handle(MmaOp* mma) {
   // Builds a map from reduction domains to consumer domains.
-  TensorView* out_tv = mma->out()->as<TensorView>();
+  auto* out_tv = mma->out()->as<TensorView>();
   handleReductionOutput(out_tv);
 }
 
@@ -1490,11 +1490,11 @@ void ComputeAtLogicalDomainMapBuilder::handle(SqueezeOp* op) {
 }
 
 void ComputeAtLogicalDomainMapBuilder::handle(ViewAsScalar* op) {
-  const TensorView* out_tv = op->output(0)->as<TensorView>();
+  const auto* out_tv = op->output(0)->as<TensorView>();
   const TensorDomain* out_td = out_tv->domain();
   const auto& out_root = out_td->maybeRoot();
 
-  const TensorView* in_tv = op->input(0)->as<TensorView>();
+  const auto* in_tv = op->input(0)->as<TensorView>();
   const TensorDomain* in_td = in_tv->domain();
 
   std::vector<IterDomain*> in_logical =

--- a/csrc/preseg_passes/consecutive_cast.cpp
+++ b/csrc/preseg_passes/consecutive_cast.cpp
@@ -86,7 +86,7 @@ Val* replayMetaOnNewInput(
   } else if (meta->isA<ReshapeOp>()) {
     // replay transformation for ReshapeOp
     NVF_ERROR(meta->output(0)->isA<TensorView>());
-    TensorView* meta_tv_out = meta->output(0)->as<TensorView>();
+    auto* meta_tv_out = meta->output(0)->as<TensorView>();
 
     const std::vector<IterDomain*>& meta_tv_out_root_domain =
         meta_tv_out->getMaybeRootDomain();
@@ -339,7 +339,7 @@ void castOptimizationPass(Fusion* fusion) {
 
         // compute logical_dom to alloc_dom permutation
         if (expr_out->isA<TensorView>()) {
-          TensorView* expr_out_tv = expr_out->as<TensorView>();
+          auto* expr_out_tv = expr_out->as<TensorView>();
           expr_out_allocation_permutation = ir_utils::computePermutation(
               expr_out_tv->getLogicalDomain(),
               expr_out_tv->getMaybeAllocationDomain());

--- a/csrc/preseg_passes/move_pad.cpp
+++ b/csrc/preseg_passes/move_pad.cpp
@@ -347,7 +347,7 @@ std::vector<Val*> maybeMovePadBeforeDefinition(
             {pad->getPadWidths()},
             TensorDomain::noReductions(
                 pad->out()->as<TensorView>()->getLogicalDomain()));
-        PadOp* new_pad_op = new_pad_in->definition()->as<PadOp>();
+        auto* new_pad_op = new_pad_in->definition()->as<PadOp>();
         stack.push_back(new_pad_op);
         simple_pad_set.insert(new_pad_op);
         return new_pad_in;

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -322,7 +322,7 @@ TensorView* maybeDoReplacement(TensorView* orig) {
     // The second op was simply a "Set" operation, so we just skip it
     replacement = first->output(0)->as<TensorView>();
   } else {
-    TensorView* input_tv = first->input(0)->as<TensorView>();
+    auto* input_tv = first->input(0)->as<TensorView>();
     switch (simple_op_type_opt.value()) {
       case AxisOp::PRESERVE:
         // This is equivalent to a set Op

--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -53,7 +53,7 @@ bool isLoadGlobalToLocal(const Expr* expr) {
   if (!expr->isA<LoadStoreOp>()) {
     return false;
   }
-  const LoadStoreOp* ldst = expr->as<LoadStoreOp>();
+  const auto* ldst = expr->as<LoadStoreOp>();
 
   if (ldst->opType() != LoadStoreOpType::Set) {
     return false;
@@ -93,7 +93,7 @@ const Expr* findExpand(const LoadStoreOp* ldst) {
       if (!def_out->isA<TensorView>()) {
         continue;
       }
-      const TensorView* def_out_tv = def_out->as<TensorView>();
+      const auto* def_out_tv = def_out->as<TensorView>();
 
       for (const Expr* use : def_out->uses()) {
         if (use->isA<ExpandOp>()) {

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -670,7 +670,7 @@ int64_t HopperPlus::numCGAs() const {
 void HopperPlus::inspectPrologues() const {
   for (TensorView* mma_result : mma_results_) {
     for (Val* v : mma_result->definition()->inputs()) {
-      TensorView* op_input = v->as<TensorView>();
+      auto* op_input = v->as<TensorView>();
 
       // We currently require all operands to lie in smem, meaning we cannot yet
       // handle any prologue computation. This includes `BroadcastOp` which
@@ -857,7 +857,7 @@ void Blackwell::scheduleEpilogueWithoutSmemEpilogue() {
     propagate_to.push_back(c);
   }
   for (Val* dv : fusion_->outputs()) {
-    TensorView* d = dv->as<TensorView>();
+    auto* d = dv->as<TensorView>();
     NVF_ERROR(d->definition() && d->definition()->isA<LoadStoreOp>());
 
     // Apply the default scheduling that is common to all register
@@ -921,7 +921,7 @@ void Hopper::scheduleEpilogueWithoutSmemEpilogue() {
     propagate_to.push_back(c);
   }
   for (Val* dv : fusion_->outputs()) {
-    TensorView* d = dv->as<TensorView>();
+    auto* d = dv->as<TensorView>();
     NVF_ERROR(d->definition() && d->definition()->isA<LoadStoreOp>());
 
     // Apply the default scheduling that is common to all register
@@ -1038,9 +1038,9 @@ void Hopper::scheduleEpilogueWithSmemEpilogue() {
 
   // Manually schedule register cache and output TensorView
   for (Val* dv : fusion_->outputs()) {
-    TensorView* d = dv->as<TensorView>();
+    auto* d = dv->as<TensorView>();
     NVF_ERROR(d->definition() && d->definition()->isA<LoadStoreOp>());
-    TensorView* dc = d->definition()->input(0)->as<TensorView>();
+    auto* dc = d->definition()->input(0)->as<TensorView>();
     NVF_ERROR(dc != nullptr);
 
     // The chain of operations storing data to global memory:
@@ -1207,9 +1207,9 @@ void Blackwell::scheduleEpilogueWithSmemEpilogue() {
   //   dc (registers) -> d_smem -> [tma_store] -> d (gmem)
   // We schedule d_smem and propagate it back.
   for (Val* dv : fusion_->outputs()) {
-    TensorView* d = dv->as<TensorView>();
+    auto* d = dv->as<TensorView>();
     NVF_ERROR(d->definition() && d->definition()->isA<LoadStoreOp>());
-    TensorView* dc = d->definition()->input(0)->as<TensorView>();
+    auto* dc = d->definition()->input(0)->as<TensorView>();
     TensorView* d_smem = cacheBefore(d, LoadStoreOpType::Set);
     dc->setMemoryType(MemoryType::Local);
     d_smem->setMemoryType(MemoryType::Shared);

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -582,7 +582,7 @@ ProblemShape getProblemShape(
   ProblemShape shape{1, 1, 1, 1};
   for (const auto& [g, dom] : dim_roles) {
     NVF_ERROR(!g->empty());
-    IterDomain* id = g->front()->as<IterDomain>();
+    auto* id = g->front()->as<IterDomain>();
     const PolymorphicValue extent =
         runtime_info.expressionEvaluator().evaluate(id->extent());
     NVF_ERROR(

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -112,7 +112,7 @@ bool ResizeScheduler::canScheduleCompileTime(Fusion* fusion) {
 
   // Slicing of or to a broadcast ID is not allowed yet.
   for (auto resize_tensor_op : resize_tensor_ops) {
-    TensorView* out_tv = resize_tensor_op->output(0)->as<TensorView>();
+    auto* out_tv = resize_tensor_op->output(0)->as<TensorView>();
     for (auto logical_id : out_tv->getLogicalDomain()) {
       Resize* resize = dynamic_cast<Resize*>(logical_id->definition());
       if (resize == nullptr) {

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -809,7 +809,7 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
     Val* num_devices = of_tv->container()->oneVal();
     for (Expr* expr : exprs | std::views::reverse) {
       validateDeviceSplit(expr);
-      Split* split = expr->as<Split>();
+      auto* split = expr->as<Split>();
       logical_id = split->in();
       num_devices = SimplifyingIrBuilder::mulExpr(num_devices, split->factor());
     }

--- a/csrc/transform_iter.cpp
+++ b/csrc/transform_iter.cpp
@@ -296,7 +296,7 @@ void ReplayTransformations::runReplay() {
           val->getValType().value() == ValType::IterDomain,
           "Expected IterDomain only for Replay Transformations, but found ",
           val);
-      IterDomain* id = val->as<IterDomain>();
+      auto* id = val->as<IterDomain>();
       NVF_ERROR(
           id_map_.find(id) != id_map_.end(),
           "Could not find required input: ",

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -373,7 +373,7 @@ void testValidate(
   for (auto i : arange(non_hidden_outputs.size())) {
     Val* out = non_hidden_outputs[i];
     NVF_ERROR(out->isA<TensorView>());
-    TensorView* out_tv = out->as<TensorView>();
+    auto* out_tv = out->as<TensorView>();
 
     NVF_ERROR(
         fusion_outputs[i].is<at::Tensor>(),

--- a/python/python_direct/python_translate.cpp
+++ b/python/python_direct/python_translate.cpp
@@ -657,7 +657,7 @@ class PythonTranslator : public OptInConstDispatch {
     // all TensorViews for an iterDomain whose extent matches the desired
     // value and then use size op.
     for (const nvfuser::Val* tv_val : tensors()) {
-      const TensorView* tv = tv_val->as<TensorView>();
+      const auto* tv = tv_val->as<TensorView>();
 
       // Get extents for each IterDomain
       std::vector<IterDomain*> filtered_logical_domain =
@@ -1143,7 +1143,7 @@ class PythonTranslator : public OptInConstDispatch {
                         });
     std::vector<int64_t> squeeze_dims(filter_range.begin(), filter_range.end());
 
-    TensorView* in_tv = sop->in()->as<TensorView>();
+    auto* in_tv = sop->in()->as<TensorView>();
     NVF_ERROR(in_tv != nullptr);
 
     // TODO: Use std::ranges::zip_view AND std::ranges::any_of with cpp23
@@ -1171,7 +1171,7 @@ class PythonTranslator : public OptInConstDispatch {
     NVF_ERROR(vop != nullptr);
 
     // Get extent's for output's logical domain
-    TensorView* out_tv = vop->out()->as<TensorView>();
+    auto* out_tv = vop->out()->as<TensorView>();
     std::vector<Val*> new_shape = getShape(out_tv);
 
     // TODO Check if new_shape is a vector of symbolic fusion inputs
@@ -1194,8 +1194,8 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const ExpandOp* eop) final {
     NVF_ERROR(eop != nullptr);
-    TensorView* in_tv = eop->in()->as<TensorView>();
-    TensorView* out_tv = eop->out()->as<TensorView>();
+    auto* in_tv = eop->in()->as<TensorView>();
+    auto* out_tv = eop->out()->as<TensorView>();
     NVF_ERROR(in_tv->nDims() == out_tv->nDims());
     std::vector<Val*> shape = getShape(out_tv);
 
@@ -1374,7 +1374,7 @@ class PythonTranslator : public OptInConstDispatch {
   // created instead of a CastOp.
   void handle(const LoadStoreOp* lsop) final {
     if (lsop->out()->isA<TensorView>()) {
-      TensorView* out_tv = lsop->out()->as<TensorView>();
+      auto* out_tv = lsop->out()->as<TensorView>();
       NVF_ERROR(!(out_tv->hasRoot() && out_tv->hasAllocation()));
 
       // short-circuit: lsop is a permutation.
@@ -1401,7 +1401,7 @@ class PythonTranslator : public OptInConstDispatch {
   }
 
   void handlePermute(const LoadStoreOp* lsop) {
-    TensorView* out_tv = lsop->out()->as<TensorView>();
+    auto* out_tv = lsop->out()->as<TensorView>();
 
     std::optional<std::vector<int64_t>> new2old = ir_utils::computePermutation(
         out_tv->getRootDomain(), out_tv->getLogicalDomain());
@@ -1418,7 +1418,7 @@ class PythonTranslator : public OptInConstDispatch {
   }
 
   void handleStrideOrder(const LoadStoreOp* lsop) {
-    TensorView* out_tv = lsop->out()->as<TensorView>();
+    auto* out_tv = lsop->out()->as<TensorView>();
     visited_vals_.insert(lsop->out());
     static const std::vector<std::string> argument_names = {"stride_order"};
     printer_.generateKwargsOperation(
@@ -1431,7 +1431,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const FullOp* fop) final {
     NVF_ERROR(fop != nullptr);
-    TensorView* out_tv = fop->output(0)->as<TensorView>();
+    auto* out_tv = fop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
 
     // Fill value can be dynamic so create it
@@ -1449,7 +1449,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const IotaOp* iop) final {
     NVF_ERROR(iop != nullptr);
-    TensorView* out_tv = iop->output(0)->as<TensorView>();
+    auto* out_tv = iop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
 
     dispatch(iop->length());
@@ -1471,7 +1471,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const IndexSelectOp* isop) final {
     NVF_ERROR(isop != nullptr);
-    TensorView* out_tv = isop->output(0)->as<TensorView>();
+    auto* out_tv = isop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
     static const std::vector<std::string> argument_names = {"dim"};
     printer_.generateKwargsOperation(
@@ -1484,7 +1484,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const SelectOp* sop) final {
     NVF_ERROR(sop != nullptr);
-    TensorView* out_tv = sop->output(0)->as<TensorView>();
+    auto* out_tv = sop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
     static const std::vector<std::string> argument_names = {"dim"};
     printer_.generateKwargsOperation(
@@ -1497,7 +1497,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const ScatterOp* sop) final {
     NVF_ERROR(sop != nullptr);
-    TensorView* out_tv = sop->output(0)->as<TensorView>();
+    auto* out_tv = sop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
     static const std::vector<std::string> argument_names = {"dim"};
     printer_.generateKwargsOperation(
@@ -1510,7 +1510,7 @@ class PythonTranslator : public OptInConstDispatch {
 
   void handle(const GatherOp* gop) final {
     NVF_ERROR(gop != nullptr);
-    TensorView* out_tv = gop->output(0)->as<TensorView>();
+    auto* out_tv = gop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
     static const std::vector<std::string> argument_names = {"dim"};
     printer_.generateKwargsOperation(
@@ -1540,7 +1540,7 @@ class PythonTranslator : public OptInConstDispatch {
   void handle(const ArgsortOp* argsortop) final {
     NVF_ERROR(argsortop != nullptr);
 
-    TensorView* out_tv = argsortop->output(0)->as<TensorView>();
+    auto* out_tv = argsortop->output(0)->as<TensorView>();
     visited_vals_.insert(out_tv);
     static const auto default_args = std::make_tuple(
         KeywordArgument<decltype(argsortop->dim())>{"dim", std::nullopt},

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -411,7 +411,7 @@ struct SliceOpRecord : RecordFunctor {
   }
 
   void operator()(FusionState& fd) final {
-    TensorView* arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
+    auto* arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
     const std::vector<Val*>& start = fd.getFusionStateVector(args_.at(1).index);
     const std::vector<Val*>& end = fd.getFusionStateVector(args_.at(2).index);
     const std::vector<Val*>& stride =
@@ -482,7 +482,7 @@ struct ReshapeOpRecord : RecordFunctor {
   }
 
   void operator()(FusionState& fd) final {
-    TensorView* arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
+    auto* arg = fd.getFusionState(args_.at(0).index)->as<TensorView>();
     const std::vector<Val*>& new_shape =
         fd.getFusionStateVector(args_.at(1).index);
     auto output = reshape(arg, new_shape);

--- a/python/python_frontend/fusion_state.cpp
+++ b/python/python_frontend/fusion_state.cpp
@@ -79,7 +79,7 @@ std::vector<Val*> getExtents(Fusion* fusion) {
     if (!v->isA<TensorView>()) {
       continue;
     }
-    TensorView* tv = v->as<TensorView>();
+    auto* tv = v->as<TensorView>();
     std::vector<IterDomain*> logical_dom =
         TensorDomain::noReductions(tv->getLogicalDomain());
     std::transform(

--- a/python/python_frontend/translation.cpp
+++ b/python/python_frontend/translation.cpp
@@ -707,7 +707,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map ReductionOp to python frontend
   void handle(const ReductionOp* rop) final {
-    TensorView* out_tv = rop->out()->as<TensorView>();
+    auto* out_tv = rop->out()->as<TensorView>();
 
     // The min and max reduction operations expect the dtype argument to by
     // PrimDataType::Null
@@ -741,17 +741,17 @@ class FusionTranslator : public OptInConstDispatch {
     NVF_ERROR(wop->initN()->evaluate().as<int64_t>() == 0);
 
     NVF_ERROR(wop->outAvg()->isA<TensorView>());
-    TensorView* out_avg_tv = wop->outAvg()->as<TensorView>();
+    auto* out_avg_tv = wop->outAvg()->as<TensorView>();
     Tensor out_avg = fd_->defineTensor(out_avg_tv->nDims());
     map_val_to_fd_index_.emplace(wop->outAvg(), out_avg());
 
     NVF_ERROR(wop->outVar()->isA<TensorView>());
-    TensorView* out_var_tv = wop->outVar()->as<TensorView>();
+    auto* out_var_tv = wop->outVar()->as<TensorView>();
     Tensor out_var = fd_->defineTensor(out_var_tv->nDims());
     map_val_to_fd_index_.emplace(wop->outVar(), out_var());
 
     NVF_ERROR(wop->outN()->isA<TensorView>());
-    TensorView* out_N_tv = wop->outN()->as<TensorView>();
+    auto* out_N_tv = wop->outN()->as<TensorView>();
     Tensor out_N = fd_->defineTensor(out_N_tv->nDims());
     map_val_to_fd_index_.emplace(wop->outN(), out_N());
 
@@ -779,7 +779,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Add DimsOpRecord to create permutation in FusionDefinition
   void handlePermute(const LoadStoreOp* lsop) {
-    TensorView* out_tv = lsop->out()->as<TensorView>();
+    auto* out_tv = lsop->out()->as<TensorView>();
 
     std::optional<std::vector<int64_t>> new2old = ir_utils::computePermutation(
         out_tv->getRootDomain(), out_tv->getLogicalDomain());
@@ -829,7 +829,7 @@ class FusionTranslator : public OptInConstDispatch {
   // Map ReshapeOp to python frontend
   void handle(const ReshapeOp* vop) final {
     // Get extent's for output's logical domain
-    TensorView* out_tv = vop->out()->as<TensorView>();
+    auto* out_tv = vop->out()->as<TensorView>();
     Vector new_shape = getShape(out_tv);
 
     Tensor output = fd_->defineTensor(out_tv->nDims());
@@ -842,8 +842,8 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map ExpandOp to python frontend
   void handle(const ExpandOp* eop) final {
-    TensorView* in_tv = eop->in()->as<TensorView>();
-    TensorView* out_tv = eop->out()->as<TensorView>();
+    auto* in_tv = eop->in()->as<TensorView>();
+    auto* out_tv = eop->out()->as<TensorView>();
     NVF_ERROR(in_tv->nDims() == out_tv->nDims());
     Vector new_shape = getShape(out_tv);
 
@@ -967,7 +967,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map RNGOp to RandomDistOpRecord
   void handle(const RNGOp* rop) final {
-    TensorView* out_tv = rop->output(0)->as<TensorView>();
+    auto* out_tv = rop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1032,7 +1032,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map LinearOp to python frontend
   void handle(const LinearOp* lop) final {
-    TensorView* out_tv = lop->out()->as<TensorView>();
+    auto* out_tv = lop->out()->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1061,7 +1061,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map FullOp to python frontend
   void handle(const FullOp* fop) final {
-    TensorView* out_tv = fop->output(0)->as<TensorView>();
+    auto* out_tv = fop->output(0)->as<TensorView>();
     Vector tensor_shape = getShape(out_tv);
 
     Scalar fill_value = createScalar(fop->getFillValue());
@@ -1078,7 +1078,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map IotaOp to python frontend
   void handle(const IotaOp* iop) final {
-    TensorView* out_tv = iop->output(0)->as<TensorView>();
+    auto* out_tv = iop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1096,7 +1096,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map IndexSelectOp to IndexSelectOpRecord
   void handle(const IndexSelectOp* isop) final {
-    TensorView* out_tv = isop->output(0)->as<TensorView>();
+    auto* out_tv = isop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1109,7 +1109,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map SelectOp to IndexSelectOpRecord
   void handle(const SelectOp* sop) final {
-    TensorView* out_tv = sop->output(0)->as<TensorView>();
+    auto* out_tv = sop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1122,7 +1122,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map ScatterOp to python frontend
   void handle(const ScatterOp* sop) final {
-    TensorView* out_tv = sop->output(0)->as<TensorView>();
+    auto* out_tv = sop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1136,7 +1136,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map ArgsortOp to python frontend
   void handle(const ArgsortOp* argsortop) final {
-    TensorView* out_tv = argsortop->output(0)->as<TensorView>();
+    auto* out_tv = argsortop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 
@@ -1341,7 +1341,7 @@ class FusionTranslator : public OptInConstDispatch {
 
   // Map GatherOp to python frontend
   void handle(const GatherOp* gop) final {
-    TensorView* out_tv = gop->output(0)->as<TensorView>();
+    auto* out_tv = gop->output(0)->as<TensorView>();
     Tensor output = fd_->defineTensor(out_tv->nDims());
     map_val_to_fd_index_.emplace(out_tv, output());
 

--- a/tests/cpp/test_combined_inner_outer_reduction.cpp
+++ b/tests/cpp/test_combined_inner_outer_reduction.cpp
@@ -1066,7 +1066,7 @@ class TmaWarpSpecializedTest
         runtime->schedulerHeuristics()->heuristicsList().at(0).get();
     ASSERT_NE(heur, nullptr);
     ASSERT_TRUE(heur->isA<ReductionParams>());
-    ReductionParams* rparams = heur->as<ReductionParams>();
+    auto* rparams = heur->as<ReductionParams>();
     EXPECT_TRUE(rparams->computation_warp_groups > 1);
   }
 

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -1685,7 +1685,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer2_CUDA) {
         val->getValType().value() != ValType::TensorView) {
       continue;
     }
-    TensorView* tv = val->as<TensorView>();
+    auto* tv = val->as<TensorView>();
     NVF_CHECK(tv->nDims() == computeAtTarget->nDims());
     if (tv == tv5) {
       NVF_CHECK(tv->getComputeAtPosition() == 0);
@@ -1775,7 +1775,7 @@ TEST_F(NVFuserTest, FusionComputeAtCommonConsumer3_CUDA) {
   for (Val* val : fusion.vals()) {
     if (!val->isFusionInput() &&
         val->getValType().value() == ValType::TensorView) {
-      TensorView* tv = val->as<TensorView>();
+      auto* tv = val->as<TensorView>();
       tv->axis(1)->parallelize(ParallelType::Unroll);
       tv->axis(-1)->parallelize(ParallelType::TIDx);
     }

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -1549,8 +1549,8 @@ TEST_F(IndexingTest, AlmostExactTraversalWithNonOneBroadcast) {
           getLoopIndices(consumer_tv, indexer_, for_loops_);
       TensorView* tv2 = tv;
       TensorView* tv3 = consumer_tv;
-      IterDomain* id11 = tv3->axis(1)->definition()->input(0)->as<IterDomain>();
-      IterDomain* id9 = id11->definition()->input(1)->as<IterDomain>();
+      auto* id11 = tv3->axis(1)->definition()->input(0)->as<IterDomain>();
+      auto* id9 = id11->definition()->input(1)->as<IterDomain>();
       Val* id11_idx = addExpr(
           mulExpr(loop_indices.at(1), tv3->axis(2)->extent()),
           loop_indices.at(2));

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -2538,7 +2538,7 @@ TEST_F(MatmulSchedulerPluginTest, BasicMatmul) {
   HeuristicParams* heur = runtime->getMostRecentExecutorLog().params.get();
   ASSERT_NE(heur, nullptr);
   ASSERT_TRUE(heur->isA<MatmulParams>());
-  MatmulParams* mmheur = heur->as<MatmulParams>();
+  auto* mmheur = heur->as<MatmulParams>();
   EXPECT_EQ(mmheur->circular_buffer_options.smem_circular_buffer_stage, 0);
 
   testValidate(

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -189,8 +189,8 @@ TEST_P(MultiDeviceHostIrTest, SingleCommTwoFusionAndWait) {
   auto post_compute =
       IrBuilder::create<PostOnStream>(hu, compute_inputs, compute_outputs);
   // [Step 5)b.] Create Communication Ir representing executing the Fusion
-  TensorView* communication_input = tv1->as<TensorView>();
-  TensorView* communication_output = tv2->as<TensorView>();
+  auto* communication_input = tv1->as<TensorView>();
+  auto* communication_output = tv2->as<TensorView>();
   for (auto tv : {communication_input, communication_output}) {
     // Allgather requires contiguous input and output tensors
     tv->setContiguity(true);

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -468,7 +468,7 @@ TEST_F(Tutorial, Reshape) {
     ASSERT_TRUE(tv1->hasRoot());
     ASSERT_EQ(tv1->getLogicalDomain().size(), 1);
     ASSERT_TRUE(tv1->getLogicalDomain().at(0)->definition()->isA<Merge>());
-    Merge* tv1_merge = tv1->getLogicalDomain().at(0)->definition()->as<Merge>();
+    auto* tv1_merge = tv1->getLogicalDomain().at(0)->definition()->as<Merge>();
     ASSERT_EQ(tv1_merge->inner(), tv1->getRootDomain().at(1));
     ASSERT_EQ(tv1_merge->outer(), tv1->getRootDomain().at(0));
   }


### PR DESCRIPTION
NFC: Consistently use auto* for as<> casts across device lowering, IR, scheduler, Python frontend, and tests. No functional changes; style cleanup only.