### PR TITLE
[SMOKE TEST] Reproduce failure in `jit_python_tests_20_B100_TNVF`

### DIFF
--- a/tests/python/direct/test_cutlass_gemm.py
+++ b/tests/python/direct/test_cutlass_gemm.py
@@ -5,10 +5,13 @@
 
 import pytest
 import torch
+from python.direct_utils import is_pre_blackwell
 from nvfuser_direct import nvf_cutlass
 
 
-@pytest.mark.skip(reason="broke jit_python_tests_20_B100_TNVF")
+@pytest.mark.skipif(
+    is_pre_blackwell(), reason="Only supported on blackwell and newer devices."
+)
 @pytest.mark.parametrize("config", [[1024, 128, 256], [32, 128, 256]])
 @pytest.mark.parametrize("tokens_per_expert_neg_one", [[115, 144, 8], [5, 7, 9]])
 @pytest.mark.parametrize("tensor_dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
Revert #5155 to reenable bf16 grouped gemm on blackwell. This PR runs the CI to Reproduce failure in `jit_python_tests_20_B100_TNVF`
