### PR TITLE
Patch allocation logic to produce outputs with correct logical size

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -800,7 +800,7 @@ IterDomain* projectShardedAllocationToLogical(
 
   IterDomain* logical_id = allocation_id;
   for (Expr* expr : exprs | std::views::reverse) {
-    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: " expr->toString());
+    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: ", expr->toString());
     logical_id = expr->as<Split>()->in();
   }
   return logical_id;
@@ -819,7 +819,7 @@ IterDomain* projectLogicalToShardedAllocation(
        tv->getMaybeAllocationDomain().end()});
   IterDomain* allocation_id = logical_id;
   for (auto expr : exprs) {
-    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: " expr->toString());
+    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: ", expr->toString());
     allocation_id = expr->as<Split>()->inner();
   }
   return allocation_id;

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -781,7 +781,8 @@ bool isValidateDeviceSplit(Expr* expr) {
     return false;
   }
   auto* split = expr->as<Split>();
-  if (split == nullptr || !split->outer()->isDeviceDim() || split->innerSplit()) {
+  if (split == nullptr || !split->outer()->isDeviceDim() ||
+      split->innerSplit()) {
     return false;
   }
   return true;
@@ -800,7 +801,10 @@ IterDomain* projectShardedAllocationToLogical(
 
   IterDomain* logical_id = allocation_id;
   for (Expr* expr : exprs | std::views::reverse) {
-    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: ", expr->toString());
+    NVF_ERROR(
+        isValidateDeviceSplit(expr),
+        "invalid device split: ",
+        expr->toString());
     logical_id = expr->as<Split>()->in();
   }
   return logical_id;
@@ -819,7 +823,10 @@ IterDomain* projectLogicalToShardedAllocation(
        tv->getMaybeAllocationDomain().end()});
   IterDomain* allocation_id = logical_id;
   for (auto expr : exprs) {
-    NVF_ERROR(isValidateDeviceSplit(expr), "invalid device split: ", expr->toString());
+    NVF_ERROR(
+        isValidateDeviceSplit(expr),
+        "invalid device split: ",
+        expr->toString());
     allocation_id = expr->as<Split>()->inner();
   }
   return allocation_id;

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -169,7 +169,7 @@ std::vector<int64_t> unshardedSizes(
 
 // Validate the expression is a valid DID split: expr is an outer split with
 // device dim as the outer dimension.
-void validateDeviceSplit(Expr* expr);
+bool isValidateDeviceSplit(Expr* expr);
 
 // Find the producing logical id of the given allocation id traversing
 // through device splits. For unsharded allocation_id, logical_id is the same as

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -655,7 +655,7 @@ class BackwardTraverseFromAllocToLogical {
       auto [tensor_new_shape, tensor_new_strides] =
           getShapeAndStrideAfterDimMerged(tensor_, new_shape);
       // NOTE: split implies ceilDiv, which means tensor_new_shape have artificially padded extent. We use expr_eval to slice out the padding session.
-      tensor_new_shape[left] = ee_.evaluate(in)->as<int64_t>();
+      tensor_new_shape[left] = ee_.evaluate(in).as<int64_t>();
       tensor_ = tensor_.as_strided(tensor_new_shape, tensor_new_strides);
     }
 

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -655,7 +655,7 @@ class BackwardTraverseFromAllocToLogical {
       auto [tensor_new_shape, tensor_new_strides] =
           getShapeAndStrideAfterDimMerged(tensor_, new_shape);
       // NOTE: split implies ceilDiv, which means tensor_new_shape have artificially padded extent. We use expr_eval to slice out the padding session.
-      tensor_new_shape[left] = ee.evaluate(in)->as<int64_t>();
+      tensor_new_shape[left] = ee_.evaluate(in)->as<int64_t>();
       tensor_ = tensor_.as_strided(tensor_new_shape, tensor_new_strides);
     }
 

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -654,6 +654,8 @@ class BackwardTraverseFromAllocToLogical {
     } else {
       auto [tensor_new_shape, tensor_new_strides] =
           getShapeAndStrideAfterDimMerged(tensor_, new_shape);
+      // NOTE: split implies ceilDiv, which means tensor_new_shape have artificially padded extent. We use expr_eval to slice out the padding session.
+      tensor_new_shape[left] = ee.evaluate(in)->as<int64_t>();
       tensor_ = tensor_.as_strided(tensor_new_shape, tensor_new_strides);
     }
 

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -654,7 +654,7 @@ class BackwardTraverseFromAllocToLogical {
     if (areDimsToBeMergedContiguous(tensor_, new_shape)) {
       tensor_ = tensor_.view(new_shape);
       if (in_extent != tensor_.size(left)) {
-        tensor_ = tensor.slice(left, 0, in_extent);
+        tensor_ = tensor_.slice(left, 0, in_extent);
       }
     } else {
       auto [tensor_new_shape, tensor_new_strides] =

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -444,8 +444,8 @@ getShapeAndStrideAfterDimMerged(
   std::vector<int64_t> tensor_new_strides(tensor_new_shape.size(), 1);
   int64_t prod = 1;
   for (int i = static_cast<int>(tensor_new_shape.size()) - 1; i >= 0; --i) {
-    prod *= tensor_new_shape[i];
     tensor_new_strides[i] = prod;
+    prod *= tensor_new_shape[i];
   }
 
   return {tensor_new_shape, tensor_new_strides};

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -275,7 +275,8 @@ KernelArgumentHolder allocateOutputs(
     if (output_alias_to_input_map.at(out_idx) == -1) {
       at::Tensor alloc_tensor;
       if (!out_info.shape_info.allocation_sizes.empty()) {
-        // TODO: should allocate based on allocation size & stride and restride with logical size & stride afterwards.
+        // TODO: should allocate based on allocation size & stride and restride
+        // with logical size & stride afterwards.
         alloc_tensor = at::native::empty_strided_cuda(
             out_info.shape_info.allocation_sizes,
             out_info.shape_info.allocation_strides,
@@ -649,7 +650,10 @@ class BackwardTraverseFromAllocToLogical {
       }
     }
 
-    // NOTE: split implies ceilDiv, which means its outputs ID has artificially padded extent. We use expr_eval to slice out the padding session, so that the logical domain would remain the correct extent instead of padding sizes.
+    // NOTE: split implies ceilDiv, which means its outputs ID has artificially
+    // padded extent. We use expr_eval to slice out the padding session, so that
+    // the logical domain would remain the correct extent instead of padding
+    // sizes.
     int64_t in_extent = ee_.evaluate(in->extent()).as<int64_t>();
     if (areDimsToBeMergedContiguous(tensor_, new_shape)) {
       tensor_ = tensor_.view(new_shape);

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -650,7 +650,7 @@ class BackwardTraverseFromAllocToLogical {
     }
 
     // NOTE: split implies ceilDiv, which means tensor_new_shape have artificially padded extent. We use expr_eval to slice out the padding session.
-    int64_t in_extent = ee_.evaluate(in).as<int64_t>();
+    int64_t in_extent = ee_.evaluate(in->extent()).as<int64_t>();
     if (areDimsToBeMergedContiguous(tensor_, new_shape)) {
       tensor_ = tensor_.view(new_shape);
       if (in_extent != tensor_.size(left)) {

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -649,7 +649,7 @@ class BackwardTraverseFromAllocToLogical {
       }
     }
 
-    // NOTE: split implies ceilDiv, which means tensor_new_shape have artificially padded extent. We use expr_eval to slice out the padding session.
+    // NOTE: split implies ceilDiv, which means its outputs ID has artificially padded extent. We use expr_eval to slice out the padding session, so that the logical domain would remain the correct extent instead of padding sizes.
     int64_t in_extent = ee_.evaluate(in->extent()).as<int64_t>();
     if (areDimsToBeMergedContiguous(tensor_, new_shape)) {
       tensor_ = tensor_.view(new_shape);

--- a/csrc/runtime/allocations.cpp
+++ b/csrc/runtime/allocations.cpp
@@ -275,8 +275,8 @@ KernelArgumentHolder allocateOutputs(
     if (output_alias_to_input_map.at(out_idx) == -1) {
       at::Tensor alloc_tensor;
       if (!out_info.shape_info.allocation_sizes.empty()) {
-        // TODO: should allocate based on allocation size & stride and restride
-        // with logical size & stride afterwards.
+        // allocate based on allocation size & stride and restride with logical
+        // size & stride afterwards.
         alloc_tensor = at::native::empty_strided_cuda(
             out_info.shape_info.allocation_sizes,
             out_info.shape_info.allocation_strides,

--- a/tests/cpp/test_layout_op.cpp
+++ b/tests/cpp/test_layout_op.cpp
@@ -27,8 +27,14 @@ bool validateGroupedLayout(
   NVF_ERROR(BlockScalingFactorLayout::Block128x4 == layout);
   int num_group = expert_offsets.size(0) - 1;
 
+  // validate output logical shape
+  EXPECT_EQ(out.sizes(), ref.sizes());
+
   // take length of reference for un-padded k size.
   int k = ref.size(1);
+  int padded_k = (k + 4 - 1) / 4 * 4;
+  int padded_m = sf_offsets[num_group].item().to<int>();
+  out.as_strided_({padded_m, padded_k}, {padded_k, 1});
 
   // We validate each group individually
   for (int i = 0; i < num_group; ++i) {

--- a/tests/cpp/test_layout_op.cpp
+++ b/tests/cpp/test_layout_op.cpp
@@ -165,7 +165,8 @@ TEST_F(LayoutOpTest, LogicalAndAllocationSizes) {
   EXPECT_TRUE(t0.equal(cg_outputs[0].as<at::Tensor>()));
   // output should remain the correct logical size
   EXPECT_EQ(cg_outputs[0].as<at::Tensor>().sizes(), {512, 9});
-  // padding on the inner dimension is represented as stride on the outer dimension
+  // padding on the inner dimension is represented as stride on the outer
+  // dimension
   EXPECT_EQ(cg_outputs[0].as<at::Tensor>().strides(), {16, 1});
 }
 

--- a/tests/cpp/test_layout_op.cpp
+++ b/tests/cpp/test_layout_op.cpp
@@ -163,7 +163,10 @@ TEST_F(LayoutOpTest, LogicalAndAllocationSizes) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
   EXPECT_TRUE(t0.equal(cg_outputs[0].as<at::Tensor>()));
-  // TODO: assert on size and strides as part of the test
+  // output should remain the correct logical size
+  EXPECT_EQ(cg_outputs[0].as<at::Tensor>().sizes(), {512, 9});
+  // padding on the inner dimension is represented as stride on the outer dimension
+  EXPECT_EQ(cg_outputs[0].as<at::Tensor>().strides(), {16, 1});
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_layout_op.cpp
+++ b/tests/cpp/test_layout_op.cpp
@@ -164,10 +164,12 @@ TEST_F(LayoutOpTest, LogicalAndAllocationSizes) {
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
   EXPECT_TRUE(t0.equal(cg_outputs[0].as<at::Tensor>()));
   // output should remain the correct logical size
-  EXPECT_EQ(cg_outputs[0].as<at::Tensor>().sizes(), {512, 9});
+  EXPECT_EQ(
+      cg_outputs[0].as<at::Tensor>().sizes(), std::vector<int64_t>({512, 9}));
   // padding on the inner dimension is represented as stride on the outer
   // dimension
-  EXPECT_EQ(cg_outputs[0].as<at::Tensor>().strides(), {16, 1});
+  EXPECT_EQ(
+      cg_outputs[0].as<at::Tensor>().strides(), std::vector<int64_t>({16, 1}));
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_layout_op.cpp
+++ b/tests/cpp/test_layout_op.cpp
@@ -149,9 +149,11 @@ TEST_F(LayoutOpTest, LogicalAndAllocationSizes) {
   fusion.addInput(inp);
   auto out = set(inp);
   fusion.addOutput(out);
-  // padding output to multiple of 16.
+  // padding output to multiple of 16
   out->split(1, 16);
   out->setAllocationDomain(out->getLoopDomain(), true);
+  // restore loop domain
+  out->merge(1);
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
   int m = 512;
@@ -161,7 +163,7 @@ TEST_F(LayoutOpTest, LogicalAndAllocationSizes) {
   FusionExecutorCache executor_cache(std::move(fusion_ptr));
   auto cg_outputs = executor_cache.runFusionWithInputs({t0});
   EXPECT_TRUE(t0.equal(cg_outputs[0].as<at::Tensor>()));
-  // TODO: assert on size and strides as part of the test.
+  // TODO: assert on size and strides as part of the test
 }
 
 } // namespace nvfuser

--- a/tests/cpp/test_low_precision_recipe.cpp
+++ b/tests/cpp/test_low_precision_recipe.cpp
@@ -168,7 +168,7 @@ TEST_P(NVFP4QuantizeTest, WithoutPerTensorAmax) {
           HeuristicIs(SchedulerType::InnerPersistent)));
 }
 
-TEST_P(NVFP4QuantizeTest, SwizzledOuputAndWithoutPerTensorAmax) {
+TEST_P(NVFP4QuantizeTest, SwizzledOutputAndWithoutPerTensorAmax) {
   auto data_hp_dtype = GetParam();
 
   std::unique_ptr<Fusion> fusion = std::make_unique<Fusion>();


### PR DESCRIPTION
## Motivation:

We want to use allocation domain to represent padding logic. This is/will be used by swizzle layout for block scaling factor in quantization, as well as more complex padding used in grouped matmul.

For a simple example, see the added cpp test `LogicalAndAllocationSizes`

## Context

There are two cases where padding is represented at allocation:

Case 1: non-divisible split:

For a given 2d TensorView with logical domain `[i0, i1]`. If we split i1 to construct its allocation domain as `[i0, ceilDiv(i1, 16), 16]`.
The implication is that we'll be allocating "extra" spaces to have the inner dimension to be padded to an extent of multiple of 16. This means the stride of the TensorView as [ceilDiv(i1, 16) * 16, 1].

However, since the given TensorView still has a logical domain of `[i0, i1]`, which means we should produce a tensor of shape `[i0, i1]` to avoid feeding consumer a tensor with mismatch shapes.

Case 2: unconnected allocation & logical domain:

For `PreprocessGroupedMatmulInputSf`, because the allocation domain and logical domain are not connected via any ID operations, but rather we rely on arithmetic operations on their extent directly to compute the proper buffer size. We cannot project the allocation domain to logical domain to compute its size/stride. In which case, we simply slice a section of the allocated buffer with trivial strides (contiguous) to avoid causing any issue with shape validation. It is safe to do so, since the consumer of this TensorView will not index it through its stride.

## What's in this PR:

#### Fixes in `allocation.cpp`:
1. Existing allocation logic projects allocation domain to logical domain doesn't remove the added extent from ceilDiv, leading to computing wrong logical sizes. e.g. with the above example, we'll be producing logical size of `[i0, ceilDiv(i1, 16) * 16]` instead of `[i0, i1]`.
2. `allocateOutputs` needs to allocate the buffer using allocation sizes and strides (so we'll get enough buffer space) and then slice out the correct extent.
3. A minor bug fix on stride computation.

#### Changes in `vectorize_helper.cpp` and `csrc/multidevice/utils.cpp[.h]`:
Relax the assert on vectorization analysis to allow non-device split.

#### cpp test verify the updated behavior.

