### PR TITLE
Allow broadcast and squeeze in the greedy scheduler

### DIFF
--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -764,7 +764,6 @@ class NVF_API TensorView : public Val {
   friend MostInlinedTransformPropagator;
   friend TransformReplay;
   friend OptOutMutator;
-  friend class InlineBatchingGuard;
   friend class ir_utils::TVDomainGuard;
 
   // Inline the computation of this tensor into its consumer at the given
@@ -834,6 +833,10 @@ class NVF_API TensorView : public Val {
   // when we modify producer-consumer relationship of a scheduled tensor, for
   // example, grouping multiple reductions.
   void updateMaxProducerPosition(MaxPosCalculator* calc = nullptr);
+
+  // Initialize compute and prodocuer positions. Fusion can result in
+  // an inconsistent state. Use with extreme care.
+  void clearComputePosition();
 
   // Commit the current changes in loop domain into rFactor domain. This
   // function can be used to do implicit transpose and view, but today, only

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -1370,7 +1370,7 @@ void ComputeAtLogicalDomainMapBuilder::mapPointwiseLikeOp(Expr* expr) {
   if (expr->outputs().size() > 1) {
     NVF_ERROR(
         expr->isA<WelfordOp>() || expr->isA<GroupedReductionOp>() ||
-            expr->isA<GroupedWelfordOp>(),
+            expr->isA<GroupedWelfordOp>() || expr->isA<TopKOp>(),
         "Unknown multi-output Expr type ",
         expr->getOpString(),
         " is found");

--- a/csrc/logical_domain_map.h
+++ b/csrc/logical_domain_map.h
@@ -470,6 +470,10 @@ class ComputeAtLogicalDomainMapBuilder : private BackwardVisitor {
     mapPointwiseLikeOp(op);
   }
 
+  void handle(ScatterOp* op) override {
+    mapPointwiseLikeOp(op);
+  }
+
   void handle(ReductionOp* op) override {
     mapPointwiseLikeOp(op);
   }
@@ -523,6 +527,18 @@ class ComputeAtLogicalDomainMapBuilder : private BackwardVisitor {
   }
 
   void handle(EmbeddingFwdOp* op) override {
+    mapPointwiseLikeOp(op);
+  }
+
+  void handle(ArgsortOp* op) override {
+    mapPointwiseLikeOp(op);
+  }
+
+  void handle(ScanOp* op) override {
+    mapPointwiseLikeOp(op);
+  }
+
+  void handle(TopKOp* op) override {
     mapPointwiseLikeOp(op);
   }
 

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -1120,7 +1120,7 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   }
 
   // If a new copy op is inserted, inlining positions need to be
-  // reset. We could probably fix up only tensours around  those newly
+  // reset. We could probably fix up only tensors around those newly
   // inserted ones, but here's just a quick approach
   if (!tvs_to_upload_to_smem.empty()) {
     resetInlining(fusion);

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -359,8 +359,6 @@ class CompileTimeChecker : private IterVisitor {
     ValGroups constrained_domain;
     ValGroups unconstrained_domain;
 
-    std::vector<IterDomain*> unconstrained_ids;
-
     for (const auto& [i, logical_id] : enumerate(logical_domain)) {
       if (constrained_logical_id_offset_set.contains(i)) {
         const auto& logical_id_group = exact_graph_.toGroup(logical_id);
@@ -373,7 +371,6 @@ class CompileTimeChecker : private IterVisitor {
           continue;
         }
         unconstrained_domain.pushBack(exact_graph_.toGroup(logical_id));
-        unconstrained_ids.push_back(logical_id);
       }
     }
 

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -21,6 +21,7 @@
 #include <scheduler/greedy.h>
 #include <scheduler/mark_aliases.h>
 #include <scheduler/runtime_info.h>
+#include <scheduler/tools/inlining.h>
 #include <scheduler/tools/loop_domain_scheduler.h>
 #include <scheduler/tools/maxinfo_propagator.h>
 #include <scheduler/utils.h>
@@ -185,6 +186,8 @@ class CompileTimeChecker : private IterVisitor {
             FullOp,
             ReshapeOp,
             IotaOp,
+            BroadcastOp,
+            SqueezeOp,
             ArgsortOp,
             ScanOp,
             PadOp,
@@ -355,6 +358,9 @@ class CompileTimeChecker : private IterVisitor {
 
     ValGroups constrained_domain;
     ValGroups unconstrained_domain;
+
+    std::vector<IterDomain*> unconstrained_ids;
+
     for (const auto& [i, logical_id] : enumerate(logical_domain)) {
       if (constrained_logical_id_offset_set.contains(i)) {
         const auto& logical_id_group = exact_graph_.toGroup(logical_id);
@@ -362,7 +368,12 @@ class CompileTimeChecker : private IterVisitor {
         // Keep track of all constrained IDs as well for reshape analysis
         all_constrained_domain_.pushBack(logical_id_group);
       } else {
+        // Broadcast should not matter for scheduling
+        if (logical_id->isBroadcast()) {
+          continue;
+        }
         unconstrained_domain.pushBack(exact_graph_.toGroup(logical_id));
+        unconstrained_ids.push_back(logical_id);
       }
     }
 
@@ -602,16 +613,19 @@ class ConstrainedOpScheduler : public OptOutDispatch {
   static void run(
       Fusion* fusion,
       const std::vector<TensorView*>& constrained_out_tvs,
-      const ValGraph& exact_graph) {
-    ConstrainedOpScheduler scheduler(fusion, constrained_out_tvs, exact_graph);
+      const ValGraph& exact_graph,
+      std::unordered_set<IterDomain*>& uninlinable_ids) {
+    ConstrainedOpScheduler scheduler(
+        fusion, constrained_out_tvs, exact_graph, uninlinable_ids);
   }
 
  private:
   ConstrainedOpScheduler(
       Fusion* fusion,
       const std::vector<TensorView*>& constrained_out_tvs,
-      const ValGraph& exact_graph)
-      : exact_graph_(exact_graph) {
+      const ValGraph& exact_graph,
+      std::unordered_set<IterDomain*>& uninlinable_ids)
+      : exact_graph_(exact_graph), uninlinable_ids_(uninlinable_ids) {
     for (auto constrained_tv : constrained_out_tvs) {
       dispatch(constrained_tv->definition());
     }
@@ -704,6 +718,14 @@ class ConstrainedOpScheduler : public OptOutDispatch {
     const auto& constrained_loop_id_offsets =
         getDependentLoopIds(tv, constrained_logical_id_offsets);
 
+    // Don't inline constrained IDs. For example, like reduction IDs,
+    // argsort'ed IDs should never be inlined into its consumers.
+    for (const auto constrained_logical_id_offset :
+         constrained_logical_id_offsets) {
+      uninlinable_ids_.insert(
+          tv->getLogicalDomain().at(constrained_logical_id_offset));
+    }
+
     // Move the constrained_logical_ids innermost
     std::unordered_map<int64_t, int64_t> old2new;
     for (const auto [i, offset] : enumerate(constrained_loop_id_offsets)) {
@@ -758,6 +780,7 @@ class ConstrainedOpScheduler : public OptOutDispatch {
 
  private:
   const ValGraph& exact_graph_;
+  std::unordered_set<IterDomain*>& uninlinable_ids_;
   ValGroups ref_unconstrained_domain_;
 };
 
@@ -992,8 +1015,11 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   IdModel id_model(fusion);
   const auto& exact_graph = id_model.buildExactGraph();
 
+  std::unordered_set<IterDomain*> uninlinable_ids;
+
   // Schedule all constrained tensors
-  ConstrainedOpScheduler::run(fusion, constrained_tvs, exact_graph);
+  ConstrainedOpScheduler::run(
+      fusion, constrained_tvs, exact_graph, uninlinable_ids);
 
   // Need to fetch constrained ops again as cacheAfter/Before may be used
   // TODO: Cleanup.
@@ -1002,6 +1028,17 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   // Partition the fusion
   auto tv_to_ref_map =
       partitionFusion(fusion, {constrained_tvs.begin(), constrained_tvs.end()});
+  if (isDebugDumpEnabled(DebugDumpOption::SchedulerVerbose)) {
+    std::unordered_map<TensorView*, std::unordered_set<TensorView*>> ref_to_tvs;
+    for (const auto& [tv, ref] : tv_to_ref_map) {
+      ref_to_tvs[ref].insert(tv);
+    }
+    scheduler_debug_utils::log("[Greedy scheduler] partitioned fusion:");
+    for (const auto& [ref, tvs] : ref_to_tvs) {
+      scheduler_debug_utils::log(
+          "Ref: ", ref->toString(), ": ", toDelimitedString(tvs));
+    }
+  }
 
   // Propagate the schedule of each constrained tv to its disjoint set
   for (auto constrained_tv : constrained_tvs) {
@@ -1020,6 +1057,8 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     scheduler_utils::parallelizeAllLike(
         constrained_tv, -1, {tvs_to_transform.begin(), tvs_to_transform.end()});
   }
+
+  inlineMost(uninlinable_ids);
 
   // Resolve conflicts. Find conflicting producer-consumer pairs
   // and insert memory promotion
@@ -1081,6 +1120,14 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
     for (auto tv_use : uses_to_update) {
       ir_utils::replaceValInExprInputs(tv_use, tv, copy);
     }
+  }
+
+  // If a new copy op is inserted, inlining positions need to be
+  // reset. We could probably fix up only tensours around  those newly
+  // inserted ones, but here's just a quick approach
+  if (!tvs_to_upload_to_smem.empty()) {
+    resetInlining(fusion);
+    inlineMost(uninlinable_ids);
   }
 
   markAliases(fusion);

--- a/csrc/scheduler/tools/inlining.cpp
+++ b/csrc/scheduler/tools/inlining.cpp
@@ -461,4 +461,10 @@ void inlineSelectedAt(
   }
 }
 
+void resetInlining(Fusion* fusion) {
+  for (auto tv : fusion->allTvs()) {
+    tv->clearComputePosition();
+  }
+}
+
 } // namespace nvfuser

--- a/csrc/scheduler/tools/inlining.h
+++ b/csrc/scheduler/tools/inlining.h
@@ -113,4 +113,7 @@ NVF_API void inlineSelectedAt(
     bool best_effort = false,
     const std::unordered_set<IterDomain*>& uninlinable_ids = {});
 
+// Reset inlining of all tensors
+void resetInlining(Fusion* fusion);
+
 } // namespace nvfuser

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -231,6 +231,12 @@ void TensorView::updateMaxProducerPosition(MaxPosCalculator* calc) {
   }
 }
 
+void TensorView::clearComputePosition() {
+  compute_at_pos_ = 0;
+  clearComputeWith();
+  max_producer_pos_ = 0;
+}
+
 TensorView* TensorView::computeAt(
     TensorView* consumer,
     int64_t position,

--- a/tests/cpp/test_greedy.cpp
+++ b/tests/cpp/test_greedy.cpp
@@ -507,4 +507,119 @@ TEST_F(GreedySchedulerTest, TopKLlama4) {
           HeuristicIs(SchedulerType::Greedy)));
 }
 
+TEST_F(GreedySchedulerTest, ConstrainedIDAndBroadcast) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape{4, 128};
+
+  auto tv0 = makeContigConcreteTensor({shape[0]});
+  fusion.addInput(tv0);
+  auto tv1 = makeContigConcreteTensor(shape);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0, {false, true});
+  auto tv3 = add(tv2, tv1);
+  auto tv4 = flatten(tv3);
+  auto tv5 = argsort(tv4, -1, /*descending=*/true, /*stable=*/true);
+  auto tv6 = mul(tv5, IrBuilder::create<Val>(100));
+  fusion.addOutput(tv6);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({shape[0]}, options);
+  auto t1 = at::randn(shape, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
+
+  EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
+}
+
+TEST_F(GreedySchedulerTest, ConstrainedIDAndSqueeze) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape{4, 128};
+
+  auto tv0 = makeContigConcreteTensor({shape[0]});
+  fusion.addInput(tv0);
+  auto tv1 = makeContigConcreteTensor(shape);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0, {false, true});
+  auto tv3 = add(tv2, tv1);
+  auto tv4 = flatten(tv3);
+  auto tv5 = argsort(tv4, -1, /*descending=*/true, /*stable=*/true);
+  auto tv6 = mul(tv5, IrBuilder::create<Val>(100));
+  fusion.addOutput(tv6);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({shape[0]}, options);
+  auto t1 = at::randn(shape, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
+
+  EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
+}
+
+TEST_F(GreedySchedulerTest, UnconstrainedIDAndBroadcast) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape{4, 8, 128};
+
+  auto tv0 = makeContigConcreteTensor({shape[0], shape[2]});
+  fusion.addInput(tv0);
+  auto tv1 = makeContigConcreteTensor(shape);
+  fusion.addInput(tv1);
+
+  auto tv2 = broadcast(tv0, {false, true, false});
+  auto tv3 = add(tv2, tv1);
+  auto tv4 = flatten(tv3, 0, 1);
+  auto tv5 = argsort(tv4, -1, /*descending=*/true, /*stable=*/true);
+  auto tv6 = mul(tv5, IrBuilder::create<Val>(100));
+  fusion.addOutput(tv6);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({shape[0], shape[2]}, options);
+  auto t1 = at::randn(shape, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs({t0, t1});
+  testValidate(executor_cache.fusion(), outputs, {t0, t1}, __LINE__, __FILE__);
+
+  EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
+}
+
+TEST_F(GreedySchedulerTest, UnconstrainedIDAndSqueeze) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  Fusion& fusion = *fusion_ptr.get();
+  FusionGuard fg(&fusion);
+
+  std::vector<int64_t> shape{1, 128};
+
+  auto tv0 = makeContigConcreteTensor(shape);
+  fusion.addInput(tv0);
+
+  auto tv1 = argsort(tv0, -1);
+  auto tv2 = squeeze(tv1, {0});
+  auto tv3 = cumsum(tv2, -1);
+  fusion.addOutput(tv3);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn(shape, options);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto outputs = executor_cache.runFusionWithInputs({t0});
+  testValidate(executor_cache.fusion(), outputs, {t0}, __LINE__, __FILE__);
+
+  EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
Closes #5083 

Inlining is now used to uniformly schedule a given fusion with broadcast IDs.