### PR TITLE
Allow ScatterOp with multiple dimensions as long as extents are the same

### DIFF
--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -372,6 +372,7 @@ void IndexLowering::handle(const ScatterOp* sop) {
       sop->dim(),
       lowered_index,
       lowered_src,
+      sop->exactSizes(),
       sop->accumulate() ? std::optional(sop->accumulateOp()) : std::nullopt));
   GpuLower::current()->propagateExprInfo(sop, back());
 }

--- a/csrc/device_lower/validation.cpp
+++ b/csrc/device_lower/validation.cpp
@@ -1339,12 +1339,10 @@ void validateScatter(Fusion* fusion) {
     auto in_tv = sop->in()->as<TensorView>();
     auto out_tv = sop->out()->as<TensorView>();
 
-    // TensorIndexer currently only supports scatter with 1D tensors
-    // due to the non-exactness of non-indexed IDs.
-    NVF_ERROR_EQ(
-        out_tv->getLogicalDomain().size(),
-        1,
-        "Scatter with multi-dimensional tensors is not yet supported: ",
+    // TensorIndexer currently only supports exact scatter ops
+    NVF_ERROR(
+        sop->exactSizes(),
+        "Non-exact scatter is not yet supported: ",
         sop->toString());
 
     // Scatter is implemented as an in-place op. To lower it safely, it

--- a/csrc/ir/internal_nodes.h
+++ b/csrc/ir/internal_nodes.h
@@ -252,6 +252,9 @@ class GatherOp : public Expr {
 class ScatterOp : public Expr {
  public:
   using Expr::Expr;
+
+  // exact_sizes: true when non-scatter axes of all inputs are
+  // guaranteed to have the same extents
   ScatterOp(
       IrBuilderPasskey,
       Val* out,
@@ -259,6 +262,7 @@ class ScatterOp : public Expr {
       int64_t dim,
       Val* index,
       Val* src,
+      bool exact_sizes,
       std::optional<BinaryOpType> accumulate_op = std::nullopt);
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
@@ -295,13 +299,17 @@ class ScatterOp : public Expr {
 
   IterDomain* getIndexedID() const;
 
-  bool accumulate() const {
+  bool exactSizes() const {
     return attribute<bool>(1);
+  }
+
+  bool accumulate() const {
+    return attribute<bool>(2);
   }
 
   BinaryOpType accumulateOp() const {
     NVF_ERROR(accumulate());
-    return attribute<BinaryOpType>(2);
+    return attribute<BinaryOpType>(3);
   }
 };
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -292,6 +292,7 @@ ScatterOp::ScatterOp(
     int64_t dim,
     Val* index,
     Val* src,
+    bool exact_sizes,
     std::optional<BinaryOpType> accumulate_op)
     : Expr(passkey) {
   addInput(self);
@@ -299,6 +300,7 @@ ScatterOp::ScatterOp(
   addInput(src);
   addOutput(out);
   addDataAttribute(dim);
+  addDataAttribute(exact_sizes);
   // is this accumulate?
   addDataAttribute(accumulate_op.has_value());
   if (accumulate_op.has_value()) {

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -141,6 +141,17 @@ std::pair<std::unordered_set<IterDomain*>, bool> getNonMappingDomainInfo(
       // we are not mapping anything, `has_consumer_id` doesn't matter.
       has_consumer_id = false;
     }
+  } else if (auto sop = dynamic_cast<ScatterOp*>(consumer_tv->definition())) {
+    if (producer_tv != sop->in()) {
+      auto producer_logical =
+          TensorDomain::noReductions(producer_tv->getLogicalDomain());
+      for (const auto& [i, p_id] : enumerate(producer_logical)) {
+        if (i == sop->dim() || !sop->exactSizes()) {
+          non_mapping_ids.insert(p_id);
+        }
+      }
+      has_consumer_id = true;
+    }
   }
 
   return std::make_pair(non_mapping_ids, has_consumer_id);
@@ -153,15 +164,6 @@ std::unordered_map<IterDomain*, IterDomain*> PairwiseLogicalDomainMap::map(
     const TensorDomain* consumer,
     const std::unordered_set<IterDomain*>& dims_to_map,
     bool producer_to_consumer) const {
-  // In the case of scatter, nothing is guaranteed to map except for
-  // the self producer. Note that in PyTorch even non-indexed
-  // dimensions of index and src tensors are not guaranteed to have
-  // the same extent as the self/out tensors.
-  if (auto sop = dynamic_cast<ScatterOp*>(consumer_tv_->definition());
-      sop != nullptr && producer_tv_ != sop->in()) {
-    return {};
-  }
-
   std::vector<bool> broadcast_flags;
   if (auto* bop = dynamic_cast<BroadcastOp*>(consumer_tv_->definition())) {
     broadcast_flags = bop->getBroadcastDimFlags();

--- a/csrc/logical_domain_map.cpp
+++ b/csrc/logical_domain_map.cpp
@@ -146,7 +146,7 @@ std::pair<std::unordered_set<IterDomain*>, bool> getNonMappingDomainInfo(
       auto producer_logical =
           TensorDomain::noReductions(producer_tv->getLogicalDomain());
       for (const auto& [i, p_id] : enumerate(producer_logical)) {
-        if (i == sop->dim() || !sop->exactSizes()) {
+        if ((int64_t)i == sop->dim() || !sop->exactSizes()) {
           non_mapping_ids.insert(p_id);
         }
       }

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -184,7 +184,7 @@ TensorView* scatter(
   dim = wrapDim(dim, (int64_t)self_dom.size());
 
   bool is_exact = true;
-  for (const auto i : arange(self_dom.size())) {
+  for (const auto i : arange(std::ssize(self_dom))) {
     if (i == dim) {
       continue;
     }
@@ -216,7 +216,7 @@ TensorView* scatter(
   std::vector<IterDomain*> out_loop;
   out_loop.reserve(idx_dom.size());
   for (const auto& [i, idx_id] : enumerate(idx_dom)) {
-    if (i == dim || !is_exact) {
+    if ((int64_t)i == dim || !is_exact) {
       out_loop.push_back(IterDomainBuilder(idx_id).build());
     } else {
       out_loop.push_back(out_logical.at(i));

--- a/csrc/ops/indexing.cpp
+++ b/csrc/ops/indexing.cpp
@@ -6,6 +6,7 @@
  */
 // clang-format on
 
+#include <expr_simplifier.h>
 #include <ir/all_nodes.h>
 #include <ir/builder.h>
 #include <ir/iostream.h>
@@ -182,6 +183,22 @@ TensorView* scatter(
       "dimensions in scatter like ops.");
   dim = wrapDim(dim, (int64_t)self_dom.size());
 
+  bool is_exact = true;
+  for (const auto i : arange(self_dom.size())) {
+    if (i == dim) {
+      continue;
+    }
+    Val* self_id_size = self_dom.at(i)->getMaybeExpandedExtent();
+    Val* idx_id_size = idx_dom.at(i)->getMaybeExpandedExtent();
+    auto same_size =
+        simplifyExpr(SimplifyingIrBuilder::eqExpr(self_id_size, idx_id_size));
+    if (same_size->isTrue()) {
+      continue;
+    }
+    is_exact = false;
+    break;
+  }
+
   // The shape of output tensor is same as self tensor.
   std::vector<IterDomain*> out_logical;
   for (const auto i : arange(self_dom.size())) {
@@ -195,13 +212,16 @@ TensorView* scatter(
   }
 
   // Create the loop domain based on the logical domain of the index
-  // tensor.
+  // tensor. For non-scatter axes, reuse the logical IDs if exact.
   std::vector<IterDomain*> out_loop;
   out_loop.reserve(idx_dom.size());
-  std::ranges::transform(
-      idx_dom, std::back_inserter(out_loop), [](IterDomain* id) {
-        return IterDomainBuilder(id).build();
-      });
+  for (const auto& [i, idx_id] : enumerate(idx_dom)) {
+    if (i == dim || !is_exact) {
+      out_loop.push_back(IterDomainBuilder(idx_id).build());
+    } else {
+      out_loop.push_back(out_logical.at(i));
+    }
+  }
 
   // Create the output tensor. The validation of the loop domain needs
   // to be skipped as it is not guaranteed to be equivalent to the
@@ -226,7 +246,7 @@ TensorView* scatter(
   }
 
   IrBuilder::create<ScatterOp>(
-      out_tensor, self, dim, index, src, accumulate_op);
+      out_tensor, self, dim, index, src, is_exact, accumulate_op);
 
   return out_tensor->as<TensorView>();
 }

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -236,10 +236,9 @@ class CompileTimeChecker : private IterVisitor {
     auto inp = scatter->in()->as<TensorView>();
     auto out = scatter->out()->as<TensorView>();
 
-    if (out->getLogicalDomain().size() != 1) {
+    if (!scatter->exactSizes()) {
       can_schedule_ = false;
-      setRejectReason(
-          "Scatter with multi-dimensional tensors is not yet supported");
+      setRejectReason("Non-exact scatter is not yet supported");
       return;
     }
 


### PR DESCRIPTION
Analogous to the exact size attribute of `GatherOp`.