### PR TITLE
Add AG+GEMM with p2p decomposition python test

### DIFF
--- a/tests/python/multidevice/test_overlap.py
+++ b/tests/python/multidevice/test_overlap.py
@@ -95,3 +95,85 @@ def test_overlap_allgather_matmul_stream_outermost(
 
     # benchmark
     benchmark.pedantic(lambda: fd.execute(ins), rounds=N_ITERATIONS)
+
+
+class OverlapAGMatmulShardOutermost(FusionDefinition):
+    def __init__(self, m, k, n, num_devices, communication_backend):
+        super().__init__(
+            use_multidevice_executor=True, backend_type=communication_backend
+        )
+        self.m = m
+        self.k = k
+        self.n = n
+        self._num_devices = num_devices
+
+    def definition(self) -> None:
+        m, k, n, d = (
+            self.m,
+            self.k,
+            self.n,
+            self._num_devices,
+        )
+        self.x = self.define_tensor(
+            shape=[d, m // d, k], contiguity=True, dtype=DataType.BFloat16
+        )
+        self.weight = self.define_tensor(
+            shape=[n, k], contiguity=True, dtype=DataType.BFloat16
+        )
+        self.bias = self.define_tensor(
+            shape=[n], contiguity=True, dtype=DataType.BFloat16
+        )
+
+        self.out = self.ops.linear(self.x, self.weight, self.bias)  # [d, m//d, n]
+
+        self.add_output(self.out)
+
+    def multidevice_schedule(self):
+        mesh = nvfuser.DeviceMesh(range(self._num_devices))
+        for tv in [
+            self.x,
+            self.weight,
+            self.bias,
+            self.out,
+        ]:
+            self.sched._set_device_mesh(tv, mesh)
+
+        self.sched.parallelize(self.x, 0, nvfuser.ParallelType.mesh_x)
+        self.sched.parallelize(self.out, 0, nvfuser.ParallelType.stream)
+
+
+@pytest.mark.mpi
+@pytest.mark.parametrize("backend_type", [CommunicatorBackend.nccl])
+def test_overlap_allgather_matmul_shard_outermost(
+    multidevice_test, benchmark, backend_type
+):
+    N_WARMUPS, N_ITERATIONS = 5, 25
+    m, k, n, d = 2**10, 2**10, 2**10, multidevice_test.size
+    assert m % d == 0
+
+    os.environ["UCC_CL_BASIC_TLS"] = "nccl"
+
+    torch.cuda.set_device(multidevice_test.local_rank)
+    x_unsharded = torch.testing.make_tensor(
+        d, m // d, k, dtype=torch.bfloat16, device="cpu"
+    )
+    x = multidevice_test.shard_tensor(
+        x_unsharded, 0, nvfuser.DeviceMesh(range(multidevice_test.size))
+    )
+    weight = torch.testing.make_tensor(n, k, dtype=torch.bfloat16, device="cuda")
+    bias = torch.testing.make_tensor(n, dtype=torch.bfloat16, device="cuda")
+    ins = [x, weight, bias]
+    out_ref = torch.nn.functional.linear(x_unsharded, weight.cpu(), bias.cpu())
+
+    fd = OverlapAGMatmulShardOutermost(m, k, n, d, backend_type)
+
+    # warmup
+    for _ in range(N_WARMUPS):
+        outputs, _ = fd.execute(ins)
+        out = outputs[0].cpu()
+        assert out.dtype == torch.bfloat16
+        assert out.shape == torch.Size([d, m // d, n])
+        torch.testing.assert_close(out, out_ref, rtol=1e-1, atol=1e-1)
+
+    # benchmark
+    benchmark.pedantic(lambda: fd.execute(ins), rounds=N_ITERATIONS)


### PR DESCRIPTION
Add a python test to exercise the p2p decomposition of AG+GEMM, with nccl backend.

dumped host ir program :
```
%HostIrContainer { (T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), T1_g___bfloat[iS3{1024}, iS4{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), T2_g___bfloat[iS5{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})) -> (T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})) :
  T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}) = ALLOCATE(buffer=T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), mem_type=global, size=1048576, zero_init=false, resets_to_zero=false)
  T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}) = ALLOCATE(buffer=T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), mem_type=global, size=1048576, zero_init=false, resets_to_zero=false)
  GetCurrentStream into Stream 0
  FOR streamIdx in istreamIdx10{8}:
    SetCurrentStream to Stream ( streamIdx % numberOfStreams )
    Synchronize Stream 0
  FOR streamIdx in istreamIdx10{8}:
    SetCurrentStream to Stream ( streamIdx % numberOfStreams )
    T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = HirAliasSelect( T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = istreamIdx10{8}, index = streamIdx )
    IF Manual ( streamIdx == rank ):
      T5_l___bfloat[iS13{128}, iS14{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
         = HirAliasSelect( T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = ideviceIdx.x0{8}, index = 0 )
      T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
         = Set( T5_l___bfloat[iS13{128}, iS14{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), cache_op=Streaming )
    ELSE:
      StartCoalescing
      P2PCommunication 33 (type=recv, buffer=T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=streamIdx, backend=NCCL)
      P2PCommunication 34 (type=send, buffer=T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=streamIdx, backend=NCCL)
      EndCoalescing 35
      Wait Communication 35
    T7_l___bfloat[iS17{128}, iS18{1024}, rS19{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = HirAliasSelect( T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = istreamIdx6{8}, index = streamIdx )
    T7_l___bfloat[iS17{128}, iS18{1024}, rS19{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = linear(T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}),
                T1_g___bfloat[iS3{1024}, iS4{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})      ,
          T2_g___bfloat[iS5{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})      )
    SetCurrentStream to Stream 0
    Synchronize Stream ( streamIdx % numberOfStreams )
} // %HostIrContainer
```