### PR TITLE
Migrate Tutorial.Reduction to direct bindings 

### DIFF
--- a/python/python_direct/bindings.cpp
+++ b/python/python_direct/bindings.cpp
@@ -7,8 +7,10 @@
 // clang-format on
 
 #include <bindings.h>
+#include <direct_utils.h>
 #include <multidevice/communicator.h>
 #include <python_common/python_utils.h>
+#include <validator_utils.h>
 
 namespace nvfuser::python {
 
@@ -33,6 +35,55 @@ void initNvFuserPythonBindings(PyObject* module) {
       R"(
     Compute the tensor descriptor for a given shape and stride.
   )");
+  nvfuser.def(
+      "validate_with_auto_inferred_outputs",
+      [](Fusion& fusion,
+         const py::iterable& fusion_outputs,
+         const py::iterable& args) {
+        return testValidate(
+            &fusion, from_pyiterable(fusion_outputs), from_pyiterable(args));
+      },
+      py::arg("fusion"),
+      py::arg("fusion_outputs"),
+      py::arg("args"),
+      R"(
+Validate the fusion outputs with auto inferred outputs.
+
+Parameters
+----------
+fusion : Fusion
+    The fusion to validate.
+fusion_outputs : iterable
+    The fusion outputs to validate.
+args : iterable
+    The arguments to validate the fusion outputs with.
+
+Returns
+-------
+None
+)");
+  nvfuser.def(
+      "get_val_tolerances",
+      [](Fusion& fusion, const py::iterable& args) {
+        return getValTolerances(&fusion, from_pyiterable(args));
+      },
+      py::arg("fusion"),
+      py::arg("args"),
+      R"(
+Get the validation tolerances for the fusion.
+
+Parameters
+----------
+fusion : Fusion
+    The fusion to get the validation tolerances for.
+args : iterable
+    The arguments to get the validation tolerances for.
+
+Returns
+-------
+list of tuple of float
+    The validation tolerances for the fusion.
+)");
 #ifdef NVFUSER_ENABLE_CUTLASS
   bindCutlass(nvfuser);
 #endif

--- a/python/python_direct/runtime.cpp
+++ b/python/python_direct/runtime.cpp
@@ -15,7 +15,6 @@
 #include <runtime/executor_kernel_arg.h>
 #include <runtime/fusion_executor_cache.h>
 #include <runtime/fusion_kernel_runtime.h>
-#include <validator_utils.h>
 
 namespace nvfuser::python {
 
@@ -319,51 +318,6 @@ Returns
 -------
 list of torch.Tensor
     The output tensors produced by the fusion.
-)")
-      .def(
-          "validate_with_auto_inferred_outputs",
-          [](FusionExecutorCache& self,
-             const py::iterable& fusion_outputs,
-             const py::iterable& args) {
-            return testValidate(
-                self.fusion(),
-                from_pyiterable(fusion_outputs),
-                from_pyiterable(args));
-          },
-          py::arg("fusion_outputs"),
-          py::arg("args"),
-          R"(
-Validate the fusion outputs with auto inferred outputs.
-
-Parameters
-----------
-fusion_outputs : iterable
-    The fusion outputs to validate.
-args : iterable
-    The arguments to validate the fusion outputs with.
-
-Returns
--------
-None
-)")
-      .def(
-          "get_val_tolerances",
-          [](FusionExecutorCache& self, const py::iterable& args) {
-            return getValTolerances(self.fusion(), from_pyiterable(args));
-          },
-          py::arg("args"),
-          R"(
-Get the validation tolerances for the fusion.
-
-Parameters
-----------
-args : iterable
-    The arguments to get the validation tolerances for.
-
-Returns
--------
-list of tuple of float
-    The validation tolerances for the fusion.
 )")
       .def(
           "is_compiled",


### PR DESCRIPTION
Move `get_val_tolerances` and `validate_with_auto_inferred_outputs` from `FusionExecutorCache` member functions to `nvfuser_direct` module functions.

* `validate` uses `FusionExecutorCache` with automatic scheduling.
* `manual_validate` uses `KernelExecutor`.
* `_validate` is a helper function used in `validate` and `manual_validate`.

PR Stack:
* #5187    **<<< This PR.**
* #5188
* #5189
* #5190