### PR TITLE
Added TensorDomain::kNoReductions

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -1388,7 +1388,8 @@ static bool hasTrivialReduction(
   p2c_map.mapBroadcast(true);
   auto p2c = p2c_map.mapProducerToConsumer();
   int64_t pos = -1;
-  for (IterDomain* in_id : TensorDomain::noReductions(in->getLogicalDomain())) {
+  for (IterDomain* in_id :
+       in->getLogicalDomain() | TensorDomain::kNoReductions) {
     ++pos;
     auto out_it = p2c.find(in_id);
     if (out_it == p2c.end()) {

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -298,7 +298,8 @@ void SegmentedGroup::finalize() {
     if (auto tv = dynamic_cast<TensorView*>(i)) {
       // We do not need to add scalars which are the extents of already-added
       // input TensorViews
-      for (auto id : TensorDomain::noReductions(tv->getLogicalDomain())) {
+      for (IterDomain* id :
+           tv->getLogicalDomain() | TensorDomain::kNoReductions) {
         input_set.insert(id->getMaybeExpandedExtent());
       }
     }
@@ -4959,7 +4960,8 @@ void SegmentCandidateFinder::resolveScalarsInGroup(SegmentedGroup* group) {
   std::unordered_set<Val*> visited;
 
   const auto processTV = [&to_visit](TensorView* tv) {
-    for (auto id : TensorDomain::noReductions(tv->getMaybeRootDomain())) {
+    for (IterDomain* id :
+         tv->getMaybeRootDomain() | TensorDomain::kNoReductions) {
       to_visit.push_back(id->getMaybeExpandedExtent());
     }
     if (tv->domain()->hasRoot()) {
@@ -4995,7 +4997,8 @@ void SegmentCandidateFinder::resolveScalarsInGroup(SegmentedGroup* group) {
   // we avoid adding them as separate scalar inputs.
   for (auto e : group->producer_edges) {
     if (const auto tv = dynamic_cast<TensorView*>(e->val)) {
-      for (auto id : TensorDomain::noReductions(tv->getLogicalDomain())) {
+      for (IterDomain* id :
+           tv->getLogicalDomain() | TensorDomain::kNoReductions) {
         visited.insert(id->getMaybeExpandedExtent());
       }
     }
@@ -5046,7 +5049,7 @@ void SegmentCandidateFinder::resolveScalarsInGroup(SegmentedGroup* group) {
     input_set.insert(inp);
     if (auto tv = dynamic_cast<TensorView*>(inp)) {
       for (IterDomain* id :
-           TensorDomain::noReductions(tv->getLogicalDomain())) {
+           tv->getLogicalDomain() | TensorDomain::kNoReductions) {
         // Extents of inputs will already be bound. This prevents adding them
         // as redundant inputs.
         input_set.insert(id->getMaybeExpandedExtent());

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -738,6 +738,8 @@ class NVF_API TensorDomain : public Val {
   // the view.
   inline static constexpr auto kNoDevices =
       std::views::filter([](auto* id) { return !id->isDeviceDim(); });
+  inline static constexpr auto kNoReductions =
+      std::views::filter([](auto* id) { return !id->isReduction(); });
 
   static bool hasBroadcast(const std::vector<IterDomain*>&);
   static bool hasReduction(const std::vector<IterDomain*>&);

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -737,9 +737,9 @@ class NVF_API TensorDomain : public Val {
   // returns a view so is more efficient. However, make sure `domain` outlives
   // the view.
   inline static constexpr auto kNoDevices =
-      std::views::filter([](auto* id) { return !id->isDeviceDim(); });
+      std::views::filter([](IterDomain* id) { return !id->isDeviceDim(); });
   inline static constexpr auto kNoReductions =
-      std::views::filter([](auto* id) { return !id->isReduction(); });
+      std::views::filter([](IterDomain* id) { return !id->isReduction(); });
 
   static bool hasBroadcast(const std::vector<IterDomain*>&);
   static bool hasReduction(const std::vector<IterDomain*>&);

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -497,7 +497,8 @@ Allocate::Allocate(
     NVF_ERROR(buffer->isA<TensorView>());
     NVF_ERROR_EQ(buffer->as<TensorView>()->getMemoryType(), memory_type);
     const auto domain = buffer->as<TensorView>()->domain();
-    for (auto axis : TensorDomain::noReductions(domain->maybeAllocation())) {
+    for (IterDomain* axis :
+         domain->maybeAllocation() | TensorDomain::kNoReductions) {
       shape.push_back(axis->extent());
     }
   }

--- a/csrc/preseg_passes/remove_empty.cpp
+++ b/csrc/preseg_passes/remove_empty.cpp
@@ -115,7 +115,8 @@ class EmptyTensorRemover : public DeadCodeRemover {
   //! Gets a vector of extents for noReduction(tv->getLogicalDomain())
   static std::vector<Val*> noReductionShape(TensorView* tv) {
     std::vector<Val*> shape;
-    for (auto id : TensorDomain::noReductions(tv->getLogicalDomain())) {
+    for (IterDomain* id :
+         tv->getLogicalDomain() | TensorDomain::kNoReductions) {
       shape.push_back(id->getMaybeExpandedExtent());
     }
     return shape;

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -1515,7 +1515,8 @@ TensorRolesMapOpt getTensorRoles(
 
   const auto findDims = [&dim_roles, &graph](TensorView* tv) {
     DimPresence has;
-    for (IterDomain* id : TensorDomain::noReductions(tv->getLogicalDomain())) {
+    for (IterDomain* id :
+         tv->getLogicalDomain() | TensorDomain::kNoReductions) {
       if (id->isBroadcast() || id->isDeviceDim()) {
         continue;
       }

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -232,17 +232,19 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
   // cacheBefore, the reference tensor will have all reduction IDs removed.
   ref_loop = TensorDomain::noDevices(TensorDomain::noReductions(ref_loop));
 
-  std::vector<int64_t> elem_counts(ref_loop.size(), 1);
+  std::vector<int64_t> elem_counts;
+  elem_counts.reserve(ref_loop.size());
   int64_t n_elems = 1;
-  for (size_t ref_i = 0; ref_i < ref_loop.size(); ref_i++) {
-    auto inferred_val =
-        runtime_info.expressionEvaluator().evaluate(ref_loop[ref_i]->extent());
+  for (IterDomain* ref_id : ref_loop) {
+    auto extent_pvalue =
+        runtime_info.expressionEvaluator().evaluate(ref_id->extent());
     NVF_ERROR(
-        inferred_val.hasValue(),
+        extent_pvalue.hasValue(),
         "Error inferring size for pointwise scheduler: ",
-        ref_loop[ref_i]->extent()->toInlineString());
-    elem_counts[ref_i] = inferred_val.as<int64_t>();
-    n_elems *= elem_counts[ref_i];
+        ref_id->extent()->toInlineString());
+    auto extent = extent_pvalue.as<int64_t>();
+    elem_counts.push_back(extent);
+    n_elems *= extent;
   }
 
   // If zero dimensional or zero size, return default parameters

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -295,7 +295,7 @@ inferAndValidateAllocationSizesAndStrides(
   std::vector<int64_t> logical_sizes = unshardedSizes(tv, tensor.sizes());
   std::unordered_map<IterDomain*, std::pair<int64_t, int64_t>> active_ids;
   int64_t dim_index = 0;
-  for (IterDomain* id : TensorDomain::noReductions(logical)) {
+  for (IterDomain* id : logical | TensorDomain::kNoReductions) {
     active_ids[id] = {logical_sizes.at(dim_index), tensor.stride(dim_index)};
     dim_index++;
   }
@@ -310,7 +310,7 @@ inferAndValidateAllocationSizesAndStrides(
   std::vector<int64_t> allocation_strides;
   allocation_sizes.reserve(alloc.size());
   allocation_strides.reserve(alloc.size());
-  for (IterDomain* id : TensorDomain::noReductions(alloc)) {
+  for (IterDomain* id : alloc | TensorDomain::kNoReductions) {
     if (id->isDeviceDim()) {
       allocation_sizes.push_back(1);
     } else {


### PR DESCRIPTION
Added TensorDomain::kNoReductions in csrc/ir/internal_base_nodes.h:739 to provide an efficient view-based alternative to TensorDomain::noReductions.

Updated call sites that previously relied solely on noReductions or in tandem with kNoDevices.

For #4571 