### PR TITLE
Scheduling support for grouped argsort

### DIFF
--- a/csrc/scheduler/greedy.h
+++ b/csrc/scheduler/greedy.h
@@ -145,6 +145,31 @@ class HeuristicDataCache;
 //
 // There are still a number of limitations. For a full list of issues
 // we plan to address, see https://github.com/NVIDIA/Fuser/issues/5030.
+
+class GreedyParams : public HeuristicParams {
+ public:
+  GreedyParams();
+
+  using HeuristicParams::HeuristicParams;
+
+  bool sameAs(const HeuristicParams* other_base) const override;
+
+  std::string toString() const override;
+
+  size_t hash() const override;
+
+  std::unique_ptr<HeuristicParams> clone() const override;
+
+  // Updates mappings by transferring parameters for old_tv to
+  // new_tv. Mappings for old_tv are removed.
+  void transferParams(TensorView* old_tv, TensorView* new_tv);
+
+  // Number of items per thread for constrained tensors. If not
+  // mapped, a single item should be assigned to each thread. Map from
+  // tensor names as pointers may not be kept the same
+  std::unordered_map<StmtNameType, int64_t> tv_to_item_per_thread;
+};
+
 class GreedyScheduler : public SchedulerEntry {
  public:
   bool canScheduleCompileTime(Fusion* fusion) override;

--- a/tests/cpp/test_greedy.cpp
+++ b/tests/cpp/test_greedy.cpp
@@ -30,6 +30,19 @@ class GreedySchedulerTest : public NVFuserTest {
   }
 };
 
+class GreedySchedulerTestConstraintSize
+    : public GreedySchedulerTest,
+      public ::testing::WithParamInterface<int64_t> {
+ protected:
+  void SetUp() override {
+    GreedySchedulerTest::SetUp();
+    size = GetParam();
+  }
+
+ protected:
+  int64_t size = 0;
+};
+
 // Scan, followed by pad. Same fusion as
 // SgLangMoETest.ComputeExpertOffsets
 TEST_F(GreedySchedulerTest, ScanPad1D) {
@@ -617,12 +630,12 @@ TEST_F(GreedySchedulerTest, UnconstrainedIDAndSqueeze) {
   EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
 }
 
-TEST_F(GreedySchedulerTest, ArgsortLargeConstrainedIDs) {
+TEST_P(GreedySchedulerTestConstraintSize, ArgsortLargeConstrainedIDs) {
   auto fusion_ptr = std::make_unique<Fusion>();
   Fusion& fusion = *fusion_ptr.get();
   FusionGuard fg(&fusion);
 
-  std::vector<int64_t> shape = {10, 2048};
+  std::vector<int64_t> shape = {10, size};
   auto tv0 = makeContigConcreteTensor(shape);
   fusion.addInput(tv0);
 
@@ -639,5 +652,15 @@ TEST_F(GreedySchedulerTest, ArgsortLargeConstrainedIDs) {
 
   EXPECT_FALSE(executor_cache.getMostRecentKernelRuntime()->isSegmented());
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    GreedySchedulerTestConstraintSize,
+    testing::Values(1024, 2048, 4096),
+    [](const testing::TestParamInfo<int64_t>& info) {
+      std::ostringstream os;
+      os << info.param;
+      return os.str();
+    });
 
 } // namespace nvfuser


### PR DESCRIPTION
For #5192. Follow-up for #5193. Also depends on #5176.

Enables grouped argsort with the greedy scheduler. The scheduler automatically choses to do grouping for large problem sizes. The grouping factor is currently just determined as the smallest size to accommodate a given problem size. Performance tuning is out of scope for now.

