### PR TITLE
Add TensorDomain::kNoBroadcasts and use it throughout

### DIFF
--- a/csrc/device_lower/analysis/tensor_producer_aliases.cpp
+++ b/csrc/device_lower/analysis/tensor_producer_aliases.cpp
@@ -13,8 +13,10 @@
 #include <ir/utils.h>
 #include <kernel_ir_dispatch.h>
 #include <type.h>
+#include <utils.h>
 #include <val_graph.h>
 
+#include <ranges>
 #include <unordered_set>
 #include <vector>
 
@@ -40,39 +42,23 @@ bool isTrivialExpr(Expr* expr) {
   // TODO: support discontiguous inputs. The output should be an intermediate
   // tensor which we would always assume to be contiguous, but the input might
   // not be. This would necessitate using a different linear index.
-  const std::vector<IterDomain*>& in_alloc = TensorDomain::noReductions(
-      TensorDomain::noBroadcasts(in->getMaybeAllocationDomain()));
-  const std::vector<IterDomain*>& out_alloc =
-      TensorDomain::noBroadcasts(out->getMaybeAllocationDomain());
+  auto in_alloc = in->getMaybeAllocationDomain() | TensorDomain::kNoReductions |
+      TensorDomain::kNoBroadcasts;
+  auto out_alloc =
+      out->getMaybeAllocationDomain() | TensorDomain::kNoBroadcasts;
 
-  if (in_alloc.size() != out_alloc.size()) {
-    // Non-trivial allocation domains cannot be in bijective correspondence if
-    // there are different numbers of them
-    return false;
-  }
-
-  std::vector<bool> in_contig;
-  std::vector<bool> out_contig;
-  for (const std::optional<bool>& c : in->getContiguity()) {
-    if (c.has_value()) {
-      in_contig.push_back(c.value());
-    }
-  }
-  for (const std::optional<bool>& c : out->getContiguity()) {
-    if (c.has_value()) {
-      out_contig.push_back(c.value());
-    }
-  }
+  auto in_contig = in->getContiguity() |
+      std::views::filter([](const auto& c) { return c.has_value(); }) |
+      std::views::transform([](const auto& c) { return c.value(); });
+  auto out_contig = out->getContiguity() |
+      std::views::filter([](const auto& c) { return c.has_value(); }) |
+      std::views::transform([](const auto& c) { return c.value(); });
 
   const ValGraph& exact_graph =
       GpuLower::current()->info().idModel().idGraph(IdMappingMode::EXACT);
 
-  for (size_t pos : arange(in_alloc.size())) {
-    // At this point in_pos and out_pos are both in range and point to
-    // non-broadcast IDs
-    IterDomain* in_id = in_alloc.at(pos);
-    IterDomain* out_id = out_alloc.at(pos);
-
+  for (auto [in_id, out_id, in_is_contig, out_is_contig] :
+       zip(in_alloc, out_alloc, in_contig, out_contig)) {
     // If this allocation ID is parallelized such that its loop index is not
     // used, then we can ignore it for this analysis.
     const auto id_is_indexed = [](TensorView* tv, IterDomain* id) {
@@ -85,10 +71,10 @@ bool isTrivialExpr(Expr* expr) {
     }
 
     NVF_ERROR(
-        out_contig.at(pos),
+        out_is_contig,
         "Found discontiguous intermediate global tensor ",
         out->toString());
-    if (in_contig.at(pos) != out_contig.at(pos)) {
+    if (in_is_contig != out_is_contig) {
       return false;
     }
 

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -2206,7 +2206,7 @@ static Val* constructBlackwellMatrixDescriptor(
 ValGroup getInnerMmaLoopGroup(TensorView* tv, const MmaOp* mma) {
   ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
   auto alloc_domain = id_graph.toGroups(
-      TensorDomain::noBroadcasts(tv->getMaybeAllocationDomain()));
+      tv->getMaybeAllocationDomain() | TensorDomain::kNoBroadcasts);
   auto loop_domain =
       id_graph.toGroups(mma->out()->as<TensorView>()->getLoopDomain());
 
@@ -2345,7 +2345,7 @@ Val* getInnerStrideBytes(TensorView* tv, const MmaOp* mma) {
 Val* getOuterStrideBytes(TensorView* tv, const MmaOp* mma) {
   ValGraph& id_graph = GpuLower::current()->tensorIndexer().traversalGraph();
   auto logical_domain =
-      id_graph.toGroups(TensorDomain::noBroadcasts(tv->getLogicalDomain()));
+      id_graph.toGroups(tv->getLogicalDomain() | TensorDomain::kNoBroadcasts);
   auto loop_domain =
       id_graph.toGroups(mma->out()->as<TensorView>()->getLoopDomain());
   auto alloc_domain = id_graph.toGroups(tv->getMaybeAllocationDomain());

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -738,8 +738,10 @@ class NVF_API TensorDomain : public Val {
   // the view.
   inline static constexpr auto kNoDevices =
       std::views::filter([](IterDomain* id) { return !id->isDeviceDim(); });
-  inline static constexpr auto kNoReductions =
-      std::views::filter([](IterDomain* id) { return !id->isReduction(); });
+  inline static constexpr auto kNoReductions = std::views::filter(
+      [](IterDomain* id) { return !id->isReduction() && !id->isStride(); });
+  inline static constexpr auto kNoBroadcasts =
+      std::views::filter([](IterDomain* id) { return !id->isBroadcast(); });
 
   static bool hasBroadcast(const std::vector<IterDomain*>&);
   static bool hasReduction(const std::vector<IterDomain*>&);

--- a/csrc/ir/utils.cpp
+++ b/csrc/ir/utils.cpp
@@ -16,6 +16,7 @@
 #include <scheduler/mma_utils.h>
 
 #include <limits>
+#include <ranges>
 #include <set>
 
 namespace nvfuser::ir_utils {
@@ -1332,8 +1333,10 @@ bool hasTrivialAllocationDomain(const TensorView* tv) {
   }
   const std::vector<IterDomain*>& alloc = tv->getMaybeAllocationDomain();
   const std::vector<IterDomain*>& logical = tv->getLogicalDomain();
-  return TensorDomain::noBroadcasts(TensorDomain::noReductions(logical)) ==
-      TensorDomain::noBroadcasts(TensorDomain::noReductions(alloc));
+
+  return std::ranges::equal(
+      logical | TensorDomain::kNoReductions | TensorDomain::kNoBroadcasts,
+      alloc | TensorDomain::kNoReductions | TensorDomain::kNoBroadcasts);
 }
 bool hasUniformSiblings(Expr* expr) {
   return !expr->isOneOf<SdpaFwdOp, SdpaBwdOp>();

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -14,6 +14,9 @@
 #include <scheduler/registry_utils.h>
 #include <scheduler/runtime_info.h>
 
+#include <algorithm>
+#include <ranges>
+
 namespace nvfuser {
 
 template <typename... Args>
@@ -38,10 +41,9 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
     for (auto output :
          ir_utils::filterByType<TensorView>(reduction->outputs())) {
       auto concrete_dimension =
-          TensorDomain::noReductions(output->getLogicalDomain());
-      auto all_nonzero = std::none_of(
-          concrete_dimension.begin(),
-          concrete_dimension.end(),
+          output->getLogicalDomain() | TensorDomain::kNoReductions;
+      auto all_nonzero = std::ranges::none_of(
+          concrete_dimension,
           [](IterDomain* id) { return id->extent()->isZeroInt(); });
       if (all_nonzero) {
         scheduler_debug_utils::canScheduleRejectReason(
@@ -53,9 +55,9 @@ bool NoOpScheduler::canScheduleCompileTime(Fusion* fusion) {
 
   // Check that all outputs are either broadcast or ignored reduction.
   for (auto out_tv : ir_utils::filterByType<TensorView>(fusion->outputs())) {
-    auto concrete_dimension = TensorDomain::noReductions(
-        TensorDomain::noBroadcasts(out_tv->getLoopDomain()));
-    if (!concrete_dimension.empty()) {
+    auto concrete_dimension = out_tv->getLoopDomain() |
+        TensorDomain::kNoReductions | TensorDomain::kNoBroadcasts;
+    if (!std::ranges::empty(concrete_dimension)) {
       scheduler_debug_utils::canScheduleRejectReason(
           schedulerType(), "output has a concrete dimension");
       return false;

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -22,6 +22,8 @@
 #include <scheduler/utils.h>
 #include <scheduler/vectorize_helper.h>
 
+#include <ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -248,10 +250,9 @@ std::unique_ptr<PointwiseParams> getPointwiseHeuristics(
   }
 
   // If zero dimensional or zero size, return default parameters
-  if (TensorDomain::noDevices(
-          TensorDomain::noReductions(
-              TensorDomain::noBroadcasts(largest_out->getLoopDomain())))
-          .empty() ||
+  if (std::ranges::empty(
+          largest_out->getLoopDomain() | TensorDomain::kNoReductions |
+          TensorDomain::kNoBroadcasts | TensorDomain::kNoDevices) ||
       n_elems == 0) {
     auto vectorizable_inputs_outputs_entry = HeuristicDataCacheEntry<
         HeuristicCompileTime::VectorizableInputsAndOutputs>(data_cache, []() {

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -24,6 +24,7 @@
 #include <val_graph_visitor.h>
 
 #include <memory>
+#include <ranges>
 
 namespace nvfuser {
 
@@ -295,7 +296,7 @@ void prepareForBackwardTransformPropagation(TensorView* ref_tv) {
     }
 
     const auto tv_logical =
-        graph.toGroups(TensorDomain::noBroadcasts(tv->getLogicalDomain()));
+        graph.toGroups(tv->getLogicalDomain() | TensorDomain::kNoBroadcasts);
 
     auto all_visited = ValGraphBFS::getExprGroupsBetween(
                            graph,

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -14,6 +14,7 @@
 #include <scheduler/tools/loop_domain_scheduler.h>
 #include <val_graph_visitor.h>
 
+#include <ranges>
 #include <unordered_set>
 
 namespace nvfuser {
@@ -405,9 +406,10 @@ ValGraphBFS::ExprPath LoopDomainScheduler::getReplayPath(TensorView* tv) const {
   //
   // In the case of the update mode, the target should be just the
   // current loop domain of the tensor.
-  ValGroups tv_target_domains = graph().toGroups(TensorDomain::noBroadcasts(
-      update_loop_domain_only_ ? tv->getLoopDomain()
-                               : tv->getMaybeRootDomain()));
+  ValGroups tv_target_domains = graph().toGroups(
+      (update_loop_domain_only_ ? tv->getLoopDomain()
+                                : tv->getMaybeRootDomain()) |
+      TensorDomain::kNoBroadcasts);
 
   // If all the target domains are an ancestor of the reference
   // domains, just a single backward BFS should be enough to find a

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -12,6 +12,7 @@
 #include <val_graph_nodes.h>
 
 #include <iostream>
+#include <ranges>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -87,21 +88,25 @@ class ValGraph {
   // Convert Val to its ValGroup, assert that it exists.
   const ValGroup& toGroup(Val* val) const;
 
-  // Convert a vector-like container of Val* or Expr* to their
-  // ValGroups or ExprGroups. The vector-like container type must
-  // define the element type as value_type
-  template <
-      typename ContainerType,
-      typename ElementType = typename std::remove_pointer<
-          typename ContainerType::value_type>::type,
-      typename RetType = typename std::conditional<
-          std::is_base_of<Val, ElementType>::value,
-          ValGroups,
-          ExprGroups>::type,
-      typename = std::enable_if_t<
-          std::is_base_of<Val, ElementType>::value ||
-          std::is_base_of<Expr, ElementType>::value>>
-  RetType toGroups(const ContainerType& entries) const {
+  // Convert a range of Val* or Expr* to ValGroups / ExprGroups.
+  template <std::ranges::input_range Range>
+  auto toGroups(Range entries) const {
+    using RawValue = std::ranges::range_value_t<Range>;
+    static_assert(
+        std::is_pointer_v<RawValue>,
+        "toGroups expects a range of pointers to Val or Expr");
+
+    using ElementType = std::remove_pointer_t<RawValue>;
+    static_assert(
+        std::is_base_of_v<Val, ElementType> ||
+            std::is_base_of_v<Expr, ElementType>,
+        "toGroups expects pointers to Val or Expr types");
+
+    using RetType = std::conditional_t<
+        std::is_base_of_v<Val, ElementType>,
+        ValGroups,
+        ExprGroups>;
+
     RetType groups;
     for (auto entry : entries) {
       groups.pushBack(toGroup(entry));


### PR DESCRIPTION
**Summary**
  - Added the TensorDomain::kNoBroadcasts view alongside kNoReductions/kNoDevices, and tightened kNoReductions to skip stride axes so the view pipeline matches the legacy helpers.
  - Refactored the call sites (scheduler, alias analysis, allocation-order inference, utils, tests) to consume the new views directly—dropping ad-hoc filtering vectors, leaning on std::ranges, and using the local
  zip helper where joint iteration is needed.
  - Taught ValGraph::toGroups to accept any input range of Val*/Expr*, eliminating extra materialisation when converting filtered domains to graph groups.