### PR TITLE
Refactor TensorDomain helpers to use lazy views and tidy includes

### DIFF
--- a/csrc/dynamic_transform.cpp
+++ b/csrc/dynamic_transform.cpp
@@ -156,8 +156,8 @@ class DynamicTransformInitialInfoBuilder : public IterVisitor {
       info_.dynamic_reshaped_tvs_.push_back(out_tv);
 
       // Input and output extent expressions both affect concretization
-      for (const auto& id :
-           TensorDomain::noReductions(inp_tv->getLogicalDomain())) {
+      for (IterDomain* id :
+           inp_tv->getLogicalDomain() | TensorDomain::kNoReductions) {
         loop_dynamic_vals_.push_back(id->getMaybeExpandedExtent());
       }
       for (const auto& id : out_tv->getLogicalDomain()) {

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -6,12 +6,15 @@
  */
 // clang-format on
 
+#include <expr_evaluator.h>
+
 #include <functional>
 #include <iostream>
+#include <iterator>
+#include <ranges>
 
 #include <debug.h>
 #include <evaluator_common.h>
-#include <expr_evaluator.h>
 #include <instrumentation.h>
 #include <ir/all_nodes.h>
 #include <ir/iostream.h>
@@ -19,6 +22,7 @@
 #include <logical_domain_map.h>
 #include <multidevice/utils.h>
 #include <polymorphic_value.h>
+#include <utils.h>
 
 namespace nvfuser {
 
@@ -60,8 +64,8 @@ void validateValWithConcreteValue(
         ", to be an at::Tensor but got scalar ",
         concrete_value);
     const auto& t = concrete_value.as<at::Tensor>();
-    int64_t expect_dim =
-        std::ssize(TensorDomain::noReductions(tv->getLogicalDomain()));
+    const auto expect_dim = std::ranges::distance(
+        tv->getLogicalDomain() | TensorDomain::kNoReductions);
     NVF_CHECK(
         t.dim() == expect_dim,
         "Expected ",
@@ -134,22 +138,22 @@ void ExpressionEvaluator::bindTensorDomain(
     const TensorView* tv,
     const at::Tensor& t,
     const bool evaluate_validate) {
-  auto logical_domain = TensorDomain::noReductions(tv->getLogicalDomain());
+  auto logical_domain = tv->getLogicalDomain() | TensorDomain::kNoReductions;
+  const auto logical_rank = std::ranges::distance(logical_domain);
   NVF_ERROR(
-      t.dim() == (int64_t)logical_domain.size(),
+      t.dim() == logical_rank,
       "Expected ",
       getInputPosString(tv),
       tv->toString(),
       ", to be bound to a tensor of rank ",
-      logical_domain.size(),
+      logical_rank,
       ", but got a tensor of rank ",
       t.dim());
 
   std::vector<int64_t> logical_sizes = unshardedSizes(tv, t.sizes());
   adjustEvaluatorSizes(tv, logical_sizes);
 
-  for (auto i : arange(t.dim())) {
-    auto id = logical_domain[i];
+  for (const auto& [i, id] : enumerate(logical_domain)) {
     if (id->isBroadcast()) {
       bind_(id->extent(), 1, evaluate_validate);
       if (id->hasExpandedExtent()) {

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -140,15 +140,13 @@ void ExpressionEvaluator::bindTensorDomain(
     const bool evaluate_validate) {
   auto logical_domain = tv->getLogicalDomain() | TensorDomain::kNoReductions;
   const auto logical_rank = std::ranges::distance(logical_domain);
-  NVF_ERROR(
-      t.dim() == logical_rank,
+  NVF_ERROR_EQ(
+      t.dim(),
+      logical_rank,
       "Expected ",
       getInputPosString(tv),
       tv->toString(),
-      ", to be bound to a tensor of rank ",
-      logical_rank,
-      ", but got a tensor of rank ",
-      t.dim());
+      ", to be bound to a tensor of equal rank.");
 
   std::vector<int64_t> logical_sizes = unshardedSizes(tv, t.sizes());
   adjustEvaluatorSizes(tv, logical_sizes);

--- a/csrc/fusion_segmenter.cpp
+++ b/csrc/fusion_segmenter.cpp
@@ -5365,7 +5365,7 @@ RuntimeWorkSpace prepareRuntimeOrder(const SegmentedFusion& segmented_fusion) {
   for (auto* input_tv :
        ir_utils::filterByType<TensorView>(segmented_fusion.inputs())) {
     for (IterDomain* logical_id :
-         TensorDomain::noReductions(input_tv->getLogicalDomain())) {
+         input_tv->getLogicalDomain() | TensorDomain::kNoReductions) {
       runtime_workspace.group_extent_binding_order.push_back(
           logical_id->getMaybeExpandedExtent());
     }

--- a/csrc/host_ir/jit.cpp
+++ b/csrc/host_ir/jit.cpp
@@ -36,6 +36,8 @@
 #include <runtime/fusion_kernel_runtime.h>
 #include <val_graph_visitor.h>
 
+#include <ranges>
+
 namespace nvfuser {
 
 // cacheId, inputTensors, outputTensors
@@ -488,9 +490,10 @@ void inferTensorShapesAndStrides(
   }
 
   // Check if sizes and strides are the same size as logical domain
-  NVF_ERROR_EQ(sizes.size(), TensorDomain::noReductions(logical_domain).size());
-  NVF_ERROR_EQ(
-      strides.size(), TensorDomain::noReductions(logical_domain).size());
+  const auto logical_ndims =
+      std::ranges::distance(logical_domain | TensorDomain::kNoReductions);
+  NVF_ERROR_EQ(sizes.size(), logical_ndims);
+  NVF_ERROR_EQ(strides.size(), logical_ndims);
 }
 
 void unpackInputs(

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -18,6 +18,7 @@
 #include <type_promotion.h>
 
 #include <cfloat>
+#include <ranges>
 
 namespace nvfuser {
 
@@ -1545,11 +1546,11 @@ TensorView* min(
 }
 
 std::vector<Val*> shape(TensorView* inp) {
-  auto iter_domains = TensorDomain::noReductions(inp->getLogicalDomain());
+  auto logical_domain = inp->getLogicalDomain() | TensorDomain::kNoReductions;
   std::vector<Val*> shape;
 
-  shape.reserve(iter_domains.size());
-  for (auto id : iter_domains) {
+  shape.reserve(std::ranges::distance(logical_domain));
+  for (IterDomain* id : logical_domain) {
     shape.push_back(id->getMaybeExpandedExtent());
   }
 

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -6,6 +6,11 @@
  */
 // clang-format on
 
+#include <scheduler/mma_utils.h>
+
+#include <ranges>
+#include <variant>
+
 #include <ATen/cuda/CUDAContext.h>
 
 #include <device_lower/utils.h>
@@ -18,14 +23,11 @@
 #include <ops/all_ops.h>
 #include <ops/utils.h>
 #include <options.h>
-#include <scheduler/mma_utils.h>
 #include <scheduler/tools/abstract_tensor.h>
 #include <scheduler/utils.h>
 #include <type.h>
 #include <utils.h>
 #include <val_graph.h>
-#include <ranges>
-#include <variant>
 
 namespace nvfuser {
 
@@ -1925,7 +1927,8 @@ class MatmulTranslator : public OptInDispatch {
   }
 
   TensorView* getBroadcastInnerToRank(TensorView* tv, int64_t rank) {
-    size_t tv_rank = TensorDomain::noReductions(tv->getLogicalDomain()).size();
+    const auto tv_rank = std::ranges::distance(
+        tv->getLogicalDomain() | TensorDomain::kNoReductions);
 
     // broadcast inner on inp to match rank with other.
     if ((int64_t)tv_rank < rank) {
@@ -1939,7 +1942,8 @@ class MatmulTranslator : public OptInDispatch {
   }
 
   TensorView* getUnsqueeze(TensorView* tv, int64_t dim) {
-    size_t tv_rank = TensorDomain::noReductions(tv->getLogicalDomain()).size();
+    const auto tv_rank = std::ranges::distance(
+        tv->getLogicalDomain() | TensorDomain::kNoReductions);
     std::vector<bool> bcast_dims(tv_rank + 1, false);
     if (dim < 0) {
       dim += (int64_t)tv_rank + 1;

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -5,10 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/normalization_utils.h>
-#include <scheduler/registry.h>
 #include <scheduler/utils.h>
-#include <scheduler/vectorize_helper.h>
+
+#include <algorithm>
+#include <queue>
+#include <ranges>
+
+#include <ATen/cuda/CUDAContext.h>
 
 #include <bfs.h>
 #include <contiguity.h>
@@ -17,24 +20,21 @@
 #include <id_model/schedule.h>
 #include <instrumentation.h>
 #include <ir/builder.h>
+#include <ir/interface_nodes.h>
 #include <ir/utils.h>
 #include <logical_domain_map.h>
 #include <multidevice/utils.h>
 #include <ops/all_ops.h>
 #include <scheduler/mma_utils.h>
+#include <scheduler/normalization_utils.h>
+#include <scheduler/registry.h>
 #include <scheduler/runtime_info.h>
+#include <scheduler/tools/loop_domain_scheduler.h>
+#include <scheduler/vectorize_helper.h>
 #include <transform_iter.h>
 #include <transform_replay.h>
+#include <type.h>
 #include <val_graph_visitor.h>
-
-#include <ATen/cuda/CUDAContext.h>
-
-#include <algorithm>
-#include <queue>
-#include <ranges>
-#include "ir/interface_nodes.h"
-#include "scheduler/tools/loop_domain_scheduler.h"
-#include "type.h"
 
 namespace nvfuser {
 namespace scheduler_utils {
@@ -1768,8 +1768,13 @@ BroadcastMultipleInformation getBroadcastMultiples(
 
   // We always cacheBefore output at the beginning of the scheduling. And after
   // cacheBefore, the reference tensor will have all reduction IDs removed.
-  auto ref_root_domain = TensorDomain::noDevices(
-      TensorDomain::noReductions(reference_tv->getLogicalDomain()));
+  auto ref_root_domain_view = reference_tv->getLogicalDomain() |
+      TensorDomain::kNoReductions | TensorDomain::kNoDevices;
+  std::vector<IterDomain*> ref_root_domain;
+  ref_root_domain.reserve(std::ranges::distance(ref_root_domain_view));
+  for (IterDomain* id : ref_root_domain_view) {
+    ref_root_domain.push_back(id);
+  }
 
   if (!logical_reorder_map.empty()) {
     ref_root_domain =

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1768,13 +1768,12 @@ BroadcastMultipleInformation getBroadcastMultiples(
 
   // We always cacheBefore output at the beginning of the scheduling. And after
   // cacheBefore, the reference tensor will have all reduction IDs removed.
-  auto ref_root_domain_view = reference_tv->getLogicalDomain() |
-      TensorDomain::kNoReductions | TensorDomain::kNoDevices;
-  std::vector<IterDomain*> ref_root_domain;
-  ref_root_domain.reserve(std::ranges::distance(ref_root_domain_view));
-  for (IterDomain* id : ref_root_domain_view) {
-    ref_root_domain.push_back(id);
-  }
+  std::vector<IterDomain*> ref_root_domain = [&]() {
+    auto ref_root_domain_view = reference_tv->getLogicalDomain() |
+        TensorDomain::kNoReductions | TensorDomain::kNoDevices;
+    return std::vector<IterDomain*>(
+        ref_root_domain_view.begin(), ref_root_domain_view.end());
+  }();
 
   if (!logical_reorder_map.empty()) {
     ref_root_domain =

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -225,13 +225,11 @@ void validateAllocationSizesAndStrides(
     const std::vector<std::optional<bool>>& contiguity,
     c10::IntArrayRef sizes,
     c10::IntArrayRef strides) {
-  NVF_ERROR(alloc_dom.size() == contiguity.size());
-  const int64_t sizes_ndims = std::ssize(sizes);
-  const int64_t strides_ndims = std::ssize(strides);
+  NVF_ERROR_EQ(alloc_dom.size(), contiguity.size());
   checkAllEqual(
       {std::ranges::distance(alloc_dom | TensorDomain::kNoReductions),
-       sizes_ndims,
-       strides_ndims});
+       std::ssize(sizes),
+       std::ssize(strides)});
 
   int64_t expected_stride_if_contiguous = 1;
   auto dim_index = static_cast<int64_t>(sizes.size());

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -17,6 +17,9 @@
 #include <polymorphic_value.h>
 #include <tensor_metadata.h>
 
+#include <iterator>
+#include <ranges>
+
 namespace nvfuser {
 
 namespace {
@@ -223,10 +226,12 @@ void validateAllocationSizesAndStrides(
     c10::IntArrayRef sizes,
     c10::IntArrayRef strides) {
   NVF_ERROR(alloc_dom.size() == contiguity.size());
+  const int64_t sizes_ndims = std::ssize(sizes);
+  const int64_t strides_ndims = std::ssize(strides);
   checkAllEqual(
-      {TensorDomain::noReductions(alloc_dom).size(),
-       sizes.size(),
-       strides.size()});
+      {std::ranges::distance(alloc_dom | TensorDomain::kNoReductions),
+       sizes_ndims,
+       strides_ndims});
 
   int64_t expected_stride_if_contiguous = 1;
   auto dim_index = static_cast<int64_t>(sizes.size());

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -1205,13 +1205,10 @@ TensorView* TensorView::cacheFork() {
       "computeAt");
 
   // This domain will be the producer, so create the consumer
-  std::vector<IterDomain*> logical_domain;
-  logical_domain.reserve(getLogicalDomain().size());
-  for (IterDomain* id : getLogicalDomain() | TensorDomain::kNoReductions) {
-    logical_domain.push_back(id);
-  }
+  std::vector<IterDomain*> logical_domain =
+      TensorDomain::noReductions(getLogicalDomain());
 
-  TensorView* new_output = IrBuilder::createInContainer<TensorView>(
+  auto* new_output = IrBuilder::createInContainer<TensorView>(
       container(),
       IrBuilder::createInContainer<TensorDomain>(
           container(),

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -5,6 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <iterator>
+#include <ranges>
+
 #include <compute_at.h>
 #include <device_lower/analysis/circular_buffer.h>
 #include <device_lower/lower2device.h>
@@ -1124,13 +1127,10 @@ TensorView* TensorView::cacheBefore(LoadStoreOpType op_type) {
   // Set domain of consumer
   TensorView* consumer = this;
 
-  size_t i = 0;
-  auto no_reduction_logical_domain =
-      TensorDomain::noReductions(getLogicalDomain());
-  std::vector<IterDomain*> new_logical_domain(
-      no_reduction_logical_domain.size());
-  for (const auto& dom : no_reduction_logical_domain) {
-    new_logical_domain[i++] = dom->cloneWithoutRFactor();
+  std::vector<IterDomain*> new_logical_domain;
+  new_logical_domain.reserve(getLogicalDomain().size());
+  for (IterDomain* dom : getLogicalDomain() | TensorDomain::kNoReductions) {
+    new_logical_domain.push_back(dom->cloneWithoutRFactor());
   }
 
   // Warning: allocation domain is temporarily discarded. It will be recovered
@@ -1205,7 +1205,11 @@ TensorView* TensorView::cacheFork() {
       "computeAt");
 
   // This domain will be the producer, so create the consumer
-  auto logical_domain = TensorDomain::noReductions(getLogicalDomain());
+  std::vector<IterDomain*> logical_domain;
+  logical_domain.reserve(getLogicalDomain().size());
+  for (IterDomain* id : getLogicalDomain() | TensorDomain::kNoReductions) {
+    logical_domain.push_back(id);
+  }
 
   TensorView* new_output = IrBuilder::createInContainer<TensorView>(
       container(),
@@ -1299,13 +1303,10 @@ TensorView* TensorView::cacheAfter(
   // Create Consumer Domain
   // Keep Broadcast Axis (Permanent)
   // Remove Reduction Axis
-  size_t i = 0;
-  auto no_reduction_logical_domain =
-      TensorDomain::noReductions(getLogicalDomain());
-  std::vector<IterDomain*> new_logical_domain(
-      no_reduction_logical_domain.size());
-  for (const auto& dom : no_reduction_logical_domain) {
-    new_logical_domain[i++] = dom->cloneWithoutRFactor();
+  std::vector<IterDomain*> new_logical_domain;
+  new_logical_domain.reserve(getLogicalDomain().size());
+  for (IterDomain* dom : getLogicalDomain() | TensorDomain::kNoReductions) {
+    new_logical_domain.push_back(dom->cloneWithoutRFactor());
   }
 
   // This domain will be the producer, so create the consumer

--- a/csrc/transform_replay.cpp
+++ b/csrc/transform_replay.cpp
@@ -1436,7 +1436,7 @@ Expr* replayExprWithNewInput(Expr* e, Val* new_in) {
     new_out_root.reserve(old_domain->maybeRoot().size());
     int64_t i = 0;
     for (IterDomain* in_logical_id :
-         TensorDomain::noReductions(new_in_tv->getLogicalDomain())) {
+         new_in_tv->getLogicalDomain() | TensorDomain::kNoReductions) {
       // Copy the `rf` flag from `old_domain` and everything else from
       // `in_logical_id`.
       new_out_root.push_back(

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -781,7 +781,7 @@ AnalyzeViewResult analyzeView(
 
   const auto logical_rank = std::ranges::distance(
       original_view_tv->getLogicalDomain() | TensorDomain::kNoReductions);
-  NVF_ERROR(logical_rank == original_sizes.size());
+  NVF_ERROR_EQ(logical_rank, std::ssize(original_sizes));
 
   // Fill -1 dimension in new_std::vector<int64_t> with size infered from all
   // other values

--- a/csrc/transform_view.cpp
+++ b/csrc/transform_view.cpp
@@ -7,6 +7,8 @@
 // clang-format on
 #include <transform_view.h>
 
+#include <ranges>
+
 #include <fusion.h>
 #include <instrumentation.h>
 #include <ir/builder.h>
@@ -777,9 +779,9 @@ AnalyzeViewResult analyzeView(
     return {std::vector<bool>(new_sizes.size(), true), {}, {}};
   }
 
-  NVF_ERROR(
-      TensorDomain::noReductions(original_view_tv->getLogicalDomain()).size() ==
-      original_sizes.size());
+  const auto logical_rank = std::ranges::distance(
+      original_view_tv->getLogicalDomain() | TensorDomain::kNoReductions);
+  NVF_ERROR(logical_rank == original_sizes.size());
 
   // Fill -1 dimension in new_std::vector<int64_t> with size infered from all
   // other values

--- a/csrc/type.cpp
+++ b/csrc/type.cpp
@@ -7,6 +7,7 @@
 // clang-format on
 #include <type.h>
 
+#include <ranges>
 #include <sstream>
 #include <unordered_set>
 
@@ -76,9 +77,10 @@ DataType metaDataTypeOf(const Val* v) {
     return PointerType{std::make_shared<DataType>(tv->dtype())};
   }
 
-  size_t dim = TensorDomain::noReductions(tv->getLogicalDomain()).size();
-  size_t alloc_dim =
-      TensorDomain::noReductions(tv->getMaybeAllocationDomain()).size();
+  const auto dim = std::ranges::distance(
+      tv->getLogicalDomain() | TensorDomain::kNoReductions);
+  const auto alloc_dim = std::ranges::distance(
+      tv->getMaybeAllocationDomain() | TensorDomain::kNoReductions);
   return globalTensorMetaData(tv->dtype().type, dim, alloc_dim);
 }
 

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -365,9 +365,8 @@ void testValidate(
 
       const auto logical_ndims = std::ranges::distance(
           fusion_input_tv->getLogicalDomain() | TensorDomain::kNoReductions);
-      NVF_ERROR(
-          at_tensor.dim() == logical_ndims,
-          "Dimensionality mismatch in inputs.");
+      NVF_ERROR_EQ(
+          at_tensor.dim(), logical_ndims, "Dimensionality mismatch in inputs.");
     }
   }
 

--- a/csrc/validator_utils.cpp
+++ b/csrc/validator_utils.cpp
@@ -7,6 +7,8 @@
 // clang-format on
 #include <validator_utils.h>
 
+#include <iterator>
+#include <ranges>
 #include <unordered_map>
 
 #include <ATen/cuda/CUDAContext.h>
@@ -361,11 +363,10 @@ void testValidate(
       auto fusion_input_tv = fusion->inputs()[i]->as<TensorView>();
       auto at_tensor = aten_inputs[i].as<at::Tensor>();
 
+      const auto logical_ndims = std::ranges::distance(
+          fusion_input_tv->getLogicalDomain() | TensorDomain::kNoReductions);
       NVF_ERROR(
-          at_tensor.dim() ==
-              static_cast<int64_t>(TensorDomain::noReductions(
-                                       fusion_input_tv->getLogicalDomain())
-                                       .size()),
+          at_tensor.dim() == logical_ndims,
           "Dimensionality mismatch in inputs.");
     }
   }
@@ -389,12 +390,11 @@ void testValidate(
 
     int64_t reduction_size = reduction_sizes.at(out_tv);
 
+    const auto output_ndims = std::ranges::distance(
+        out_tv->getLogicalDomain() | TensorDomain::kNoReductions);
     NVF_ERROR(
         aten_output_tensor.dim() == fusion_output_tensor.dim() &&
-            fusion_output_tensor.dim() ==
-                static_cast<int64_t>(
-                    TensorDomain::noReductions(out_tv->getLogicalDomain())
-                        .size()),
+            fusion_output_tensor.dim() == output_ndims,
         "Dimensionality mismatch in outputs: ",
         aten_output_tensor.sizes(),
         " vs ",

--- a/python/python_direct/ir.cpp
+++ b/python/python_direct/ir.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <ranges>
+
 #include <bindings.h>
 #include <python_utils.h>
 
@@ -120,7 +122,8 @@ void bindInterfaceNodes(py::module& nvfuser) {
       .def_property_readonly(
           "ndim",
           [](TensorView* self) {
-            return TensorDomain::noReductions(self->getLogicalDomain()).size();
+            return std::ranges::distance(
+                self->getLogicalDomain() | TensorDomain::kNoReductions);
           },
           R"(
 Get the number of dimensions in this tensor.

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <ranges>
+
 #include <bindings.h>
 #include <ops/all_ops.h>
 #include <ops/arith.h>
@@ -2484,7 +2486,8 @@ TensorView* slice_fn(
     }
   }
 
-  size_t num_dims = TensorDomain::noReductions(arg->getLogicalDomain()).size();
+  const auto num_dims = std::ranges::distance(
+      arg->getLogicalDomain() | TensorDomain::kNoReductions);
   NVF_CHECK(
       num_dims == start_vec.size(),
       "Number of tensor dimensions does not match slice dimensions! "
@@ -2625,8 +2628,8 @@ TensorView
   ops.def(
       "permute",
       [](TensorView* arg, std::vector<int64_t>& dims) -> TensorView* {
-        size_t num_dims =
-            TensorDomain::noReductions(arg->getLogicalDomain()).size();
+        const auto num_dims = std::ranges::distance(
+            arg->getLogicalDomain() | TensorDomain::kNoReductions);
         NVF_CHECK(
             num_dims == dims.size(),
             "Operator permute expects `dims` argument to have the same length "
@@ -2796,8 +2799,8 @@ list of Val
         if (stride_order.empty()) {
           return output;
         }
-        size_t ndims =
-            TensorDomain::noReductions(arg->getLogicalDomain()).size();
+        const auto ndims = std::ranges::distance(
+            arg->getLogicalDomain() | TensorDomain::kNoReductions);
         NVF_CHECK(
             ndims == stride_order.size(),
             "Operator stride_order expects `stride_order` argument to have the "

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -2488,13 +2488,10 @@ TensorView* slice_fn(
 
   const auto num_dims = std::ranges::distance(
       arg->getLogicalDomain() | TensorDomain::kNoReductions);
-  NVF_CHECK(
-      num_dims == start_vec.size(),
-      "Number of tensor dimensions does not match slice dimensions! "
-      "Tensor-dims: ",
+  NVF_CHECK_EQ(
       num_dims,
-      " Slice-dims: ",
-      start_vec.size());
+      std::ssize(start_vec),
+      "Number of tensor dimensions does not match slice dimensions!");
   NVF_CHECK(
       start_vec.size() == end_vec.size(),
       "Slice indexing attribute dimensions don't match! Start Indices: ",
@@ -2630,8 +2627,9 @@ TensorView
       [](TensorView* arg, std::vector<int64_t>& dims) -> TensorView* {
         const auto num_dims = std::ranges::distance(
             arg->getLogicalDomain() | TensorDomain::kNoReductions);
-        NVF_CHECK(
-            num_dims == dims.size(),
+        NVF_CHECK_EQ(
+            num_dims,
+            std::ssize(dims),
             "Operator permute expects `dims` argument to have the same length "
             "as input!");
         return permute(arg, dims);
@@ -2801,8 +2799,9 @@ list of Val
         }
         const auto ndims = std::ranges::distance(
             arg->getLogicalDomain() | TensorDomain::kNoReductions);
-        NVF_CHECK(
-            ndims == stride_order.size(),
+        NVF_CHECK_EQ(
+            ndims,
+            std::ssize(stride_order),
             "Operator stride_order expects `stride_order` argument to have the "
             "same length as input!");
         std::vector<IterDomain*> allocation_domain =

--- a/tests/python/direct/test_high_complexity.py
+++ b/tests/python/direct/test_high_complexity.py
@@ -245,11 +245,11 @@ def test_slice_error_checks(nvfuser_direct_test):
     checks = [
         (
             check_start_indices,
-            "Slice operation start_indices must be greater than or equal to 0. .*",
+            "Slice operation start_indices must be greater than or equal to 0..*",
         ),
         (
             check_end_indices,
-            "Slice operation end_indices must be greater than or equal to start_indices. .*",
+            "Slice operation end_indices must be greater than or equal to start_indices..*",
         ),
         (
             check_strides,
@@ -257,19 +257,19 @@ def test_slice_error_checks(nvfuser_direct_test):
         ),
         (
             check_tensor_dims,
-            "Number of tensor dimensions does not match slice dimensions! .*",
+            "Number of tensor dimensions does not match slice dimensions!.*",
         ),
         (
             check_slice_dims_start,
-            "Slice start_indices and strides don't match! .*",
+            "Slice start_indices and strides don't match!.*",
         ),
         (
             check_slice_dims_end,
-            "Slice indexing attribute dimensions don't match! .*",
+            "Slice indexing attribute dimensions don't match!.*",
         ),
         (
             check_slice_dims_stride,
-            "Slice start_indices and strides don't match! .*",
+            "Slice start_indices and strides don't match!.*",
         ),
         (check_nostrides, None),
         (legal, None),


### PR DESCRIPTION
  Summary:

  - Iteration and rank checks in evaluators, fusion utilities, tensor-view caching, schedulers, validator logic, and Python bindings now walk TensorDomain::kNo* views directly (ranges/enumerate) so we avoid materializing temporary vectors while keeping behavior unchanged.
  - Reordered includes across the touched translation units to follow the Google C++ style guide and converted remaining project includes in scheduler/utils.cpp to angle brackets.