### PR TITLE
Enable NVFUSER_EXTERNAL_SRC for CutlassCompiledKernel

### DIFF
--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -990,58 +990,6 @@ static const std::string& defineStdComplex() {
   return result;
 }
 
-// When executing nvFuser with: NVFUSER_EXTERNAL_SRC=file1.cu,file2.cu
-// This function retrieves structured code from the specified files.
-// The files should be comma-separated, and their order corresponds to the
-// fusion_id order. If the provided number of files is fewer than the fusion
-// segments, the function will resort to the available files in sequence
-// and issue a warning.
-std::string getStructuredCodeFromExternalFiles(const int64_t fusion_id) {
-  auto external_code_path = getNvFuserEnv("EXTERNAL_SRC");
-  if (!external_code_path) {
-    return "";
-  }
-  std::string all_external_code_paths(external_code_path);
-  if (all_external_code_paths.empty() || fusion_id < 1) {
-    return "";
-  }
-  auto getExternalCodeFile =
-      [fusion_id](const std::string& input) -> std::string {
-    std::stringstream ss(input);
-    std::string token;
-    int64_t count = 0;
-    while (std::getline(ss, token, ',')) {
-      if (++count == fusion_id) {
-        return token;
-      }
-    }
-    debug() << "Didn't find requested external source code. Will use generated "
-               "code!\n"
-            << "Number of source code files should equal the number of fusion "
-               "segments.\n"
-            << "External source code filenames should be delineated with "
-               "commas, e.g.: file1.cu,file2.cu.\n";
-    return "";
-  };
-
-  std::string single_code_path = getExternalCodeFile(all_external_code_paths);
-  if (single_code_path.empty()) {
-    return "";
-  }
-  std::ifstream cuda_src(single_code_path);
-  if (!cuda_src.is_open()) {
-    debug() << "Failed to open external source file: " << single_code_path
-            << std::endl;
-    return "";
-  }
-  debug() << "--------> Compiling external CUDA code: " << single_code_path
-          << std::endl;
-
-  std::stringstream buffer;
-  buffer << cuda_src.rdbuf();
-  return buffer.str();
-}
-
 bool requiresDisabledParamCache(const kir::Kernel* kernel) {
   std::vector<Val*> output_extents;
   for (auto out : kernel->outputs()) {
@@ -1176,6 +1124,58 @@ std::string _getStructuredCode(
 }
 
 } // namespace
+
+// When executing nvFuser with: NVFUSER_EXTERNAL_SRC=file1.cu,file2.cu
+// This function retrieves structured code from the specified files.
+// The files should be comma-separated, and their order corresponds to the
+// fusion_id order. If the provided number of files is fewer than the fusion
+// segments, the function will resort to the available files in sequence
+// and issue a warning.
+std::string getStructuredCodeFromExternalFiles(const int64_t fusion_id) {
+  auto external_code_path = getNvFuserEnv("EXTERNAL_SRC");
+  if (!external_code_path) {
+    return "";
+  }
+  std::string all_external_code_paths(external_code_path);
+  if (all_external_code_paths.empty() || fusion_id < 1) {
+    return "";
+  }
+  auto getExternalCodeFile =
+      [fusion_id](const std::string& input) -> std::string {
+    std::stringstream ss(input);
+    std::string token;
+    int64_t count = 0;
+    while (std::getline(ss, token, ',')) {
+      if (++count == fusion_id) {
+        return token;
+      }
+    }
+    debug() << "Didn't find requested external source code. Will use generated "
+               "code!\n"
+            << "Number of source code files should equal the number of fusion "
+               "segments.\n"
+            << "External source code filenames should be delineated with "
+               "commas, e.g.: file1.cu,file2.cu.\n";
+    return "";
+  };
+
+  std::string single_code_path = getExternalCodeFile(all_external_code_paths);
+  if (single_code_path.empty()) {
+    return "";
+  }
+  std::ifstream cuda_src(single_code_path);
+  if (!cuda_src.is_open()) {
+    debug() << "Failed to open external source file: " << single_code_path
+            << std::endl;
+    return "";
+  }
+  debug() << "--------> Compiling external CUDA code: " << single_code_path
+          << std::endl;
+
+  std::stringstream buffer;
+  buffer << cuda_src.rdbuf();
+  return buffer.str();
+}
 
 void queryTargetGPUVersion(
     const cudaDeviceProp* const prop,

--- a/csrc/runtime/compiled_kernel.h
+++ b/csrc/runtime/compiled_kernel.h
@@ -323,6 +323,9 @@ class CompiledKernel : public CompiledKernelBase {
   bool launch_param_cache_disabled_ = false;
 };
 
+// Look for NVFUSER_EXTERNAL_SRC, parse it, and load code if given
+std::string getStructuredCodeFromExternalFiles(const int64_t fusion_id);
+
 // Query the target GPU version number NVRTC compiles CUDA kernels for
 void queryTargetGPUVersion(
     const cudaDeviceProp* const prop,

--- a/csrc/runtime/cutlass_compiled_kernel.cpp
+++ b/csrc/runtime/cutlass_compiled_kernel.cpp
@@ -168,6 +168,13 @@ void CutlassCompiledKernel::run(
 void CutlassCompiledKernel::generateCode() {
   FUSER_PERF_SCOPE("CutlassCompiledKernel::generateCode");
 
+  cutlass_code_ = getStructuredCodeFromExternalFiles(getGlobalFusionCount());
+  if (!cutlass_code_.empty()) {
+    debug() << "Found external cutlass code:\n";
+    debug() << cutlass_code_ << std::endl;
+    return;
+  }
+
   // Generate CUTLASS kernel code using the code generator
   cutlass_code_ = cutlass_codegen::generateCode(fusion_, params_);
 
@@ -289,6 +296,8 @@ std::string getCompileCommand(
 
 void CutlassCompiledKernel::compileWithNVCC() {
   FUSER_PERF_SCOPE("CutlassCompiledKernel::compileWithNVCC");
+
+  NVF_ERROR(!cutlass_code_.empty());
 
   // Create temporary directory for compilation
   temp_dir_ = std::filesystem::temp_directory_path() /


### PR DESCRIPTION
This functionality was currently missing but I'm adding it because it's useful for developing the EVT translation.