### PR TITLE
Package cutlass header files with NvFuser for NVRTC compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(BUILD_CUTLASS)
     FetchContent_Declare(
       repo-cutlass
       GIT_REPOSITORY https://github.com/NVIDIA/cutlass
-      GIT_TAG        f115c3f85467d5d9619119d1dbeb9c03c3d73864
+      GIT_TAG        f3fde58372d33e9a5650ba7b80fc48b3b49d40c8
       GIT_SHALLOW    OFF
     )
     FetchContent_Populate(repo-cutlass)
@@ -172,6 +172,9 @@ if(BUILD_CUTLASS)
       CUDA_ARCHITECTURES "100a"
     )
     install(TARGETS nvf_cutlass EXPORT NvfuserTargets DESTINATION lib)
+    install(DIRECTORY ${repo-cutlass_SOURCE_DIR}/include/cute DESTINATION include)
+    install(DIRECTORY ${repo-cutlass_SOURCE_DIR}/include/cutlass DESTINATION include)
+    install(DIRECTORY ${repo-cutlass_SOURCE_DIR}/tools/util/include/cutlass DESTINATION include)
 
   endif()
 endif()
@@ -767,9 +770,9 @@ if(BUILD_PYTHON)
   install(TARGETS nvfuser DESTINATION lib)
 
   # ------------------------------------------------
-  # build nvfuser next python library
+  # build nvfuser direct python library
   # ------------------------------------------------
-  # nvfuser next bindings API sources
+  # nvfuser direct bindings API sources
   set(NVFUSER_PYTHON_DIRECT_SRCS)
   list(APPEND NVFUSER_PYTHON_DIRECT_SRCS
     ${NVFUSER_PYTHON_DIRECT_BINDINGS}/extension.cpp

--- a/python/nvfuser_common/__init__.py
+++ b/python/nvfuser_common/__init__.py
@@ -1,3 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
+
+from . import utils  # noqa: F401,F403
+from .utils import find_include_directory  # noqa: F401,F403

--- a/python/nvfuser_common/utils.py
+++ b/python/nvfuser_common/utils.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 import os
+import importlib.util
 
 
 __all__ = [
@@ -16,3 +17,14 @@ cmake_prefix_path = os.path.join(
     "cmake",
     "nvfuser",
 )
+
+
+def find_include_directory():
+    spec = importlib.util.find_spec("nvfuser_common")
+    assert spec is not None, "Unable to find nvfuser_common. Use pip install nvfuser."
+    import nvfuser_common
+
+    module_directory = os.path.dirname(nvfuser_common.__file__)
+    include_directory = os.path.join(module_directory, "include")
+    assert os.path.exists(include_directory)
+    return include_directory

--- a/python/utils.py
+++ b/python/utils.py
@@ -583,6 +583,8 @@ def run(config, version_tag, relative_path):
             "include/nvfuser/flatbuffers/*.h",
             "include/nvfuser/host_ir/*.h",
             "include/nvfuser/id_model/*.h",
+            "include/cute/**/*",
+            "include/cutlass/**/*",
             "share/cmake/nvfuser/NvfuserConfig*",
             # TODO(crcrpar): it'd be better to ship the following two binaries.
             # Would need some change in CMakeLists.txt.


### PR DESCRIPTION
This PR packages the cutlass header files in the NvFuser pip wheel, so they can be used for NVRTC compilation.

### Why?
* Explore using CuTe primitives in NvFuser JIT compilation

### Details
* Update the version of cutlass used in `CMakeLists.txt` to v4.2.1
* Copy `tools/util/include/cutlass`, `include/cutlass`, and `include/cute` to the `include` folder in the installation directory.
* Add `include/cutlass` and `include/cute` to package data for `nvfuser_common`.
* Create `find_include_directory` helper function in `nvfuser_common` module to point to the `include` directory.

### Use case: Set CUTLASS_PATH environment variable
```bash
source <(python -c 'import nvfuser_common; print("export CUTLASS_PATH=" + nvfuser_common.find_include_di
rectory())')
```