### PR TITLE
Translate ScatterOp + ReductionOp to ScatterOp with accumulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/host_ir/pass/insert_deallocations.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
   ${NVFUSER_SRCS_DIR}/preseg_passes/translate_repeat_to_expand.cpp
+  ${NVFUSER_SRCS_DIR}/preseg_passes/translate_scatter_accumulate.cpp
   ${NVFUSER_SRCS_DIR}/rng.cpp
   ${NVFUSER_SRCS_DIR}/runtime/allocations.cpp
   ${NVFUSER_SRCS_DIR}/runtime/communication_executor.cpp

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -345,24 +345,6 @@ std::vector<PolymorphicValue> ScatterOp::evaluate(
       std::string accumulate_op_str;
       switch (accumulateOp()) {
         case BinaryOpType::Add:
-          accumulate_op_str = "add";
-          break;
-        case BinaryOpType::Mul:
-          accumulate_op_str = "multiply";
-          break;
-        default:
-          NVF_THROW("Unsupported accumulation op: ", accumulateOp());
-      }
-      return {at::scatter(
-          input,
-          dimension,
-          index,
-          PolymorphicValue_functions::toScalar(inputs.at(2)),
-          accumulate_op_str)};
-    } else {
-      std::string accumulate_op_str;
-      switch (accumulateOp()) {
-        case BinaryOpType::Add:
           accumulate_op_str = "sum";
           break;
         case BinaryOpType::Mul:
@@ -382,6 +364,24 @@ std::vector<PolymorphicValue> ScatterOp::evaluate(
           dimension,
           index,
           inputs.at(2).as<at::Tensor>(),
+          accumulate_op_str)};
+    } else {
+      std::string accumulate_op_str;
+      switch (accumulateOp()) {
+        case BinaryOpType::Add:
+          accumulate_op_str = "add";
+          break;
+        case BinaryOpType::Mul:
+          accumulate_op_str = "multiply";
+          break;
+        default:
+          NVF_THROW("Unsupported accumulation op: ", accumulateOp());
+      }
+      return {at::scatter(
+          input,
+          dimension,
+          index,
+          PolymorphicValue_functions::toScalar(inputs.at(2)),
           accumulate_op_str)};
     }
   } else {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -338,35 +338,52 @@ std::vector<PolymorphicValue> ScatterOp::evaluate(
   const auto& index = inputs.at(1).as<at::Tensor>();
   auto dimension = dim();
   if (accumulate()) {
-    std::string accumulate_op_str;
-    switch (accumulateOp()) {
-      case BinaryOpType::Add:
-        accumulate_op_str = "sum";
-        break;
-      case BinaryOpType::Mul:
-        accumulate_op_str = "prod";
-        break;
-      case BinaryOpType::Max:
-        accumulate_op_str = "amax";
-        break;
-      case BinaryOpType::Min:
-        accumulate_op_str = "amin";
-        break;
-      default:
-        NVF_THROW("Unsupported accumulation op: ", accumulateOp());
+    // Use at::scatter if the src is scalar since at::scatter_reduce
+    // doesn't seem to support scalar src. Note that it seems it's
+    // deprecated and only supports add and multiply.
+    if (src()->isA<TensorView>()) {
+      std::string accumulate_op_str;
+      switch (accumulateOp()) {
+        case BinaryOpType::Add:
+          accumulate_op_str = "add";
+          break;
+        case BinaryOpType::Mul:
+          accumulate_op_str = "multiply";
+          break;
+        default:
+          NVF_THROW("Unsupported accumulation op: ", accumulateOp());
+      }
+      return {at::scatter(
+          input,
+          dimension,
+          index,
+          PolymorphicValue_functions::toScalar(inputs.at(2)),
+          accumulate_op_str)};
+    } else {
+      std::string accumulate_op_str;
+      switch (accumulateOp()) {
+        case BinaryOpType::Add:
+          accumulate_op_str = "sum";
+          break;
+        case BinaryOpType::Mul:
+          accumulate_op_str = "prod";
+          break;
+        case BinaryOpType::Max:
+          accumulate_op_str = "amax";
+          break;
+        case BinaryOpType::Min:
+          accumulate_op_str = "amin";
+          break;
+        default:
+          NVF_THROW("Unsupported accumulation op: ", accumulateOp());
+      }
+      return {at::scatter_reduce(
+          input,
+          dimension,
+          index,
+          inputs.at(2).as<at::Tensor>(),
+          accumulate_op_str)};
     }
-    // at::scatter_reduce doesn't seem to support scalar
-    // src. at::scatter does support but it seems it's deprecated and
-    // only supports add and multiply accumulation.
-    NVF_ERROR(
-        src()->isA<TensorView>(),
-        "at::scatter_reduce does not support scalar src argument");
-    return {at::scatter_reduce(
-        input,
-        dimension,
-        index,
-        inputs.at(2).as<at::Tensor>(),
-        accumulate_op_str)};
   } else {
     if (src()->isA<TensorView>()) {
       return {

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -1263,16 +1263,6 @@ TensorView* reductionOpRaw(
       "Cannot create a reduction operation where the initial value is not a "
       "const scalar.");
 
-  NVF_CHECK(
-      TensorDomain::sameAs(tv->getLogicalDomain(), tv->getLoopDomain()),
-      "Reducing a tensor once it's gone under transformations is not permitted "
-      "at this time. \n",
-      "Please set reductions before calling split/merge/computeAt.\n  "
-      "Logical: ",
-      tv->getLogicalDomain(),
-      "\n  Domain: ",
-      tv->domain()->toString());
-
   NVF_CHECK(!axes.empty(), "No reduction axis specified");
 
   // PyTorch allows reduction of 0-dim tensors
@@ -1368,16 +1358,6 @@ TensorView* reductionOp(
       init->isConstScalar(),
       "Cannot create a reduction operation where the initial value is not a "
       "const scalar.");
-
-  NVF_CHECK(
-      TensorDomain::sameAs(tv->getLogicalDomain(), tv->getLoopDomain()),
-      "Reducing a tensor once it's gone under transformations is not permitted "
-      "at this time. \n",
-      "Please set reductions before calling split/merge/computeAt.\n  "
-      "Logical: ",
-      tv->getLogicalDomain(),
-      "\n  Domain: ",
-      tv->domain()->toString());
 
   NVF_CHECK(!axes.empty(), "No reduction axis specified");
 

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -29,6 +29,7 @@
 #include <preseg_passes/segment_inplace_update.h>
 #include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
 #include <preseg_passes/translate_repeat_to_expand.h>
+#include <preseg_passes/translate_scatter_accumulate.h>
 
 namespace nvfuser::preseg_passes {
 
@@ -81,6 +82,7 @@ namespace nvfuser::preseg_passes {
   OptimizationPass<SegmentInplaceUpdatePass>::runPass(fusion);
   OptimizationPass<MoveRepeatForwardPass>::runPass(fusion);
   OptimizationPass<MoveGatherPass>::runPass(fusion);
+  OptimizationPass<TranslateScatterAccumulate>::runPass(fusion);
 
   OptimizationPass<PropagateShardingsPass>::runPass(fusion);
   OptimizationPass<DecomposeReshardingsPass>::runPass(fusion);

--- a/csrc/preseg_passes/translate_scatter_accumulate.cpp
+++ b/csrc/preseg_passes/translate_scatter_accumulate.cpp
@@ -24,34 +24,6 @@ struct ScatterAccumulateInfo {
   IterDomain* scatter_index_id;
 };
 
-// Look for the pattern like below:
-//
-// index = [m, 1];
-// scatter_inp = zeros([m, n]); // [m, n]
-// scatter_out = scatter(scatter_inp, 1, index, src=1);
-// reduction_out = scatter_out.sum(0); // [n]
-//
-// It will be translated as:
-//
-// index = index.squeeze(-1) // [m]
-// scatter_inp = zeros([n]); // [n]
-// scatter_out = scatter(scatter_inp, 0, index, src=1, BinaryOpType::Add)
-//
-// To find if a ScatterOp is a candidate for the above
-// scatter-accumulate pattern, the following conditions are checked:
-//
-// - Scatter input must be 2D
-// - Scatter is not scatter-accumulate
-// - All ops must be exclusively used by the ops of this pattern
-// except for the last output
-// - Full op initializes the scatter input using the same value as
-// the reduction init value
-// - Scatter-accumulate must be deterministic, which means, for
-// example, the data type must be integer
-// - The scatter dimension of the index tensor must be a broadcast
-//
-// Additionally, upcast may be automatically inserted between
-// scatter and reduction. Skip upcast if any
 std::pair<std::optional<ScatterAccumulateInfo>, std::string>
 getMaybeScatterAccumulate(ScatterOp* scatter) {
   auto fail = []<typename... Args>(Args&&... args) {

--- a/csrc/preseg_passes/translate_scatter_accumulate.cpp
+++ b/csrc/preseg_passes/translate_scatter_accumulate.cpp
@@ -1,0 +1,290 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <preseg_passes/translate_scatter_accumulate.h>
+
+#include <ir/utils.h>
+#include <ops/all_ops.h>
+
+#include <sstream>
+
+namespace nvfuser::preseg_passes {
+
+namespace {
+
+struct ScatterAccumulateInfo {
+  ScatterOp* scatter;
+  ReductionOp* reduction;
+  FullOp* full;
+  IterDomain* scatter_out_id;
+  IterDomain* scatter_index_id;
+};
+
+// Look for the pattern like below:
+//
+// index = [m, 1];
+// scatter_inp = zeros([m, n]); // [m, n]
+// scatter_out = scatter(scatter_inp, 1, index, src=1);
+// reduction_out = scatter_out.sum(0); // [n]
+//
+// It will be translated as:
+//
+// index = index.squeeze(-1) // [m]
+// scatter_inp = zeros([n]); // [n]
+// scatter_out = scatter(scatter_inp, 0, index, src=1, BinaryOpType::Add)
+//
+// To find if a ScatterOp is a candidate for the above
+// scatter-accumulate pattern, the following conditions are checked:
+//
+// - Scatter input must be 2D
+// - Scatter is not scatter-accumulate
+// - All ops must be exclusively used by the ops of this pattern
+// except for the last output
+// - Full op initializes the scatter input using the same value as
+// the reduction init value
+// - Scatter-accumulate must be deterministic, which means, for
+// example, the data type must be integer
+// - The scatter dimension of the index tensor must be a broadcast
+//
+// Additionally, upcast may be automatically inserted between
+// scatter and reduction. Skip upcast if any
+std::pair<std::optional<ScatterAccumulateInfo>, std::string>
+getMaybeScatterAccumulate(ScatterOp* scatter) {
+  auto fail = []<typename... Args>(Args&&... args) {
+    std::stringstream reason;
+    ((reason << args << " "), ...);
+    return std::make_pair(std::nullopt, reason.str());
+  };
+
+  auto scatter_in = scatter->in()->as<TensorView>();
+  auto scatter_out = scatter->out()->as<TensorView>();
+
+  if (std::ssize(scatter_out->getLogicalDomain()) != 2) {
+    return fail(
+        "Unsupported scatter + reduction pattern. Invalid scatter: ",
+        scatter->toString());
+  }
+
+  if (scatter->accumulate()) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to: ",
+        scatter->toString());
+  }
+
+  // Scatter output must not be used outside of this op sequence
+  if (scatter_out->uses().size() != 1) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to multiple uses of "
+        "scatter output: ",
+        scatter->toString());
+  }
+
+  // Scatter input must be created by a FullOp with the same value
+  // as the reduction init value
+  auto full = dynamic_cast<FullOp*>(scatter_in->definition());
+  if (full == nullptr) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to missing full op");
+  }
+
+  // The full shape will be replaced with a 1D tensor of the same
+  // size as the scatter dimension, and thus the output must not be
+  // used by anything else.
+  if (full->output(0)->uses().size() > 1) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to multiple uses of full "
+        "output: ",
+        full->toString());
+  }
+
+  auto scatter_out_use = scatter_out->uses().at(0);
+
+  // int32_t is automatically upcast to int64_t before reduction.
+  if (auto cast = dynamic_cast<UnaryOp*>(scatter_out_use); cast != nullptr &&
+      cast->getUnaryOpType() == UnaryOpType::Cast &&
+      cast->in()->dtype() == DataType::Int32 &&
+      cast->out()->dtype() == DataType::Int) {
+    if (cast->output(0)->uses().size() != 1) {
+      return fail(
+          "Unsupported scatter + reduction pattern due to multiple uses of "
+          "cast output: ",
+          cast->toString());
+    }
+    scatter_out_use = cast->output(0)->uses().at(0);
+  }
+
+  auto reduction = dynamic_cast<ReductionOp*>(scatter_out_use);
+
+  if (reduction == nullptr) {
+    return fail("Unsupported scatter + reduction pattern. No reduction found.");
+  }
+
+  auto reduction_type = reduction->getReductionOpType();
+
+  if (reduction_type != BinaryOpType::Add) {
+    // Not strictly required. To relax this condition, need to allow
+    // the other init values that work for other reduction types
+    return fail(
+        "Unsupported scatter + reduction pattern. Not a sum reduction: ",
+        reduction->toString());
+  }
+
+  auto reduction_out = reduction->out()->as<TensorView>();
+
+  if (!full->getFillValue()->isZero()) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to invalid full op: ",
+        full->toString());
+  }
+
+  const bool is_deterministic =
+      !isFloatingPointType(reduction->in()->dtype()) ||
+      reduction_type == BinaryOpType::Max ||
+      reduction_type == BinaryOpType::Min;
+
+  if (!is_deterministic) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to: not deterministic");
+  }
+
+  // Scatter dimension of the index tensor must be a size-one
+  // dimension.
+  auto index_logical = TensorDomain::noReductions(
+      scatter->index()->as<TensorView>()->getLogicalDomain());
+  IterDomain* index_scatter_dim = index_logical.at(scatter->dim());
+  if (!index_scatter_dim->extent()->isOneInt()) {
+    return fail(
+        "Unsupported scatter + reduction pattern due to: invalid index "
+        "tensor: ",
+        scatter->index()->toString());
+  }
+
+  // The non-scatter dimension must must be reduced
+  NVF_ERROR_EQ(
+      scatter_out->getLogicalDomain().size(),
+      reduction_out->getLogicalDomain().size());
+  for (const auto& [scatter_logical_id, reduction_logical_id] :
+       zip(scatter_out->getLogicalDomain(),
+           reduction_out->getLogicalDomain())) {
+    if (scatter_out->getLogicalDomain().at(scatter->dim()) ==
+        scatter_logical_id) {
+      // scatter dimension -> should not be reduced
+      if (reduction_logical_id->isReduction()) {
+        return fail(
+            "Unsupported scatter + reduction pattern due to: scatter dimension "
+            "should not be reduced: ",
+            scatter_out->toString(),
+            ", ",
+            reduction_out->toString());
+      }
+    } else {
+      // Non scatter dimension -> should be reduced
+      if (!reduction_logical_id->isReduction()) {
+        return fail(
+            "Unsupported scatter + reduction pattern due to: non-scatter "
+            "dimension should be reduced: ",
+            scatter_out->toString(),
+            ", ",
+            reduction_out->toString());
+      }
+    }
+  }
+
+  // At this point, it should be safe to translate scatter +
+  // reduction to scatter-accumulate as long as the new
+  // scatter-accumualte is schedulable. Note that both scatter in and
+  // index must be 2D
+  auto scatter_out_id = scatter_out->getLogicalDomain().at(scatter->dim());
+  auto scatter_index_id = index_logical.at(scatter->dim() == 0 ? 1 : 0);
+
+  std::cerr << "Scatter-accumulate detected: " << scatter->toString()
+            << reduction->toString();
+
+  return {
+      ScatterAccumulateInfo{
+          scatter, reduction, full, scatter_out_id, scatter_index_id},
+      ""};
+}
+
+// Translate the scatter and reduciton pattern to
+// scatter-accumulate. See also the comment at
+// getMaybeScatterAccumulate.
+class ScatterAccumulateTranslator : public OptOutMutator {
+ public:
+  static void run(Fusion* fusion) {
+    ScatterAccumulateTranslator translator(fusion);
+  }
+
+ private:
+  ScatterAccumulateTranslator(Fusion* fusion) {
+    for (auto expr : fusion->exprs()) {
+      dispatchMutate(expr);
+    }
+
+    for (auto out : fusion->outputs()) {
+      auto new_out = maybeMutated(out);
+      if (new_out != out) {
+        fusion->replaceOutput(out, new_out);
+      }
+    }
+
+    std::cerr << "After translation\n";
+    fusion->printMath();
+    std::cout << std::endl;
+  }
+
+  void mutate(Expr* expr) final {
+    auto sop = dynamic_cast<ScatterOp*>(expr);
+    if (sop == nullptr) {
+      OptOutMutator::mutate(expr);
+      return;
+    }
+
+    const auto& [info, reason] = getMaybeScatterAccumulate(sop);
+
+    if (!info.has_value()) {
+      OptOutMutator::mutate(expr);
+      return;
+    }
+
+    auto scatter_dim = sop->dim();
+    // Note that the output dtype may be different from the scatter
+    // input as the reduction may automatically upcast from int32_t to int64_t.
+    auto dtype = info->reduction->out()->dtype();
+
+    // Squeeze the broadcast of the index input
+    auto index_tv = sop->index()->as<TensorView>();
+    index_tv = squeeze(index_tv, {scatter_dim});
+
+    // Src can be a scalar. If it's a tensor, squeeze it as well
+    auto src = sop->src();
+    if (auto src_tv = dynamic_cast<TensorView*>(src)) {
+      src = squeeze(src_tv, {scatter_dim});
+    }
+    src = maybeCastOp(dtype, src);
+
+    // Create a new scatter input of size [n]
+    auto scatter_inp = full(
+        {info->scatter_out_id->extent()},
+        info->reduction->init(),
+        info->reduction->output(0)->dtype());
+
+    auto scatter_out = scatter(
+        scatter_inp, 0, index_tv, src, info->reduction->getReductionOpType());
+
+    registerMutation(info->reduction->out(), scatter_out);
+  }
+};
+
+} // namespace
+
+void TranslateScatterAccumulate::runPass(Fusion* fusion) {
+  FusionGuard fg(fusion);
+  ScatterAccumulateTranslator::run(fusion);
+}
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/translate_scatter_accumulate.h
+++ b/csrc/preseg_passes/translate_scatter_accumulate.h
@@ -1,0 +1,25 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+#include <preseg_passes/optimization_pass.h>
+
+namespace nvfuser::preseg_passes {
+
+class TranslateScatterAccumulate
+    : public OptimizationPass<TranslateScatterAccumulate> {
+  friend class OptimizationPass<TranslateScatterAccumulate>;
+
+ protected:
+  static void runPass(Fusion* fusion);
+  static constexpr std::string_view name() {
+    return "TranslateScatterAccumulate";
+  }
+};
+
+} // namespace nvfuser::preseg_passes

--- a/csrc/preseg_passes/translate_scatter_accumulate.h
+++ b/csrc/preseg_passes/translate_scatter_accumulate.h
@@ -11,6 +11,34 @@
 
 namespace nvfuser::preseg_passes {
 
+// Look for the pattern like below:
+//
+// index = [m, 1];
+// scatter_inp = zeros([m, n]); // [m, n]
+// scatter_out = scatter(scatter_inp, 1, index, src=1);
+// reduction_out = scatter_out.sum(0); // [n]
+//
+// It will be translated as:
+//
+// index = index.squeeze(-1) // [m]
+// scatter_inp = zeros([n]); // [n]
+// scatter_out = scatter(scatter_inp, 0, index, src=1, BinaryOpType::Add)
+//
+// To find if a ScatterOp is a candidate for the above
+// scatter-accumulate pattern, the following conditions are checked:
+//
+// - Scatter input must be 2D
+// - Scatter is not scatter-accumulate
+// - All ops must be exclusively used by the ops of this pattern
+// except for the last output
+// - Full op initializes the scatter input using the same value as
+// the reduction init value
+// - Scatter-accumulate must be deterministic, which means, for
+// example, the data type must be integer
+// - The scatter dimension of the index tensor must be a broadcast
+//
+// Additionally, upcast may be automatically inserted between
+// scatter and reduction. Skip upcast if any
 class TranslateScatterAccumulate
     : public OptimizationPass<TranslateScatterAccumulate> {
   friend class OptimizationPass<TranslateScatterAccumulate>;

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -329,7 +329,7 @@ class CompileTimeChecker : private IterVisitor {
     // not be parallelized with TID.
     auto out_tv = ir_utils::getTvOutput(scatter);
     checkDomainConstraints(
-        out_tv->domain()->initialLoop(), {constrained_out_logical_dim});
+        out_tv->domain()->logical(), {constrained_out_logical_dim});
 
     // In addition, the index and src tensors are not allowed to use
     // TID with the scatter dim. Their logical domains are not mapped

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -148,181 +148,6 @@ struct ScatterAccumulateInfo {
   IterDomain* scatter_index_id;
 };
 
-// Look for the pattern like below:
-//
-// index = [m, 1];
-// scatter_inp = zeros([m, n]); // [m, n]
-// scatter_out = scatter(scatter_inp, 1, index, src=1);
-// reduction_out = scatter_out.sum(0); // [n]
-//
-// It will be translated as:
-//
-// index = index.squeeze(-1) // [m]
-// scatter_inp = zeros([n]); // [n]
-// scatter_out = scatter(scatter_inp, 0, index, src=1, BinaryOpType::Add)
-//
-// To find if a ScatterOp is a candidate for the above
-// scatter-accumulate pattern, the following conditions are checked:
-//
-// - Scatter input must be 2D
-// - Scatter is not scatter-accumulate
-// - All ops must be exclusively used by the ops of this pattern
-// except for the last output
-// - Full op initializes the scatter input using the same value as
-// the reduction init value
-// - Scatter-accumulate must be deterministic, which means, for
-// example, the data type must be integer
-// - The scatter dimension of the index tensor must be a broadcast
-//
-// Additionally, upcast may be automatically inserted between
-// scatter and reduction. Skip upcast if any
-std::pair<std::optional<ScatterAccumulateInfo>, std::string>
-getMaybeScatterAccumulate(ScatterOp* scatter) {
-  auto fail = []<typename... Args>(Args&&... args) {
-    std::stringstream reason;
-    ((reason << args << " "), ...);
-    return std::make_pair(std::nullopt, reason.str());
-  };
-
-  auto scatter_in = scatter->in()->as<TensorView>();
-  auto scatter_out = scatter->out()->as<TensorView>();
-
-  if (std::ssize(scatter_out->getLogicalDomain()) != 2) {
-    return fail(
-        "Unsupported scatter + reduction pattern. Invalid scatter: ",
-        scatter->toString());
-  }
-
-  if (scatter->accumulate()) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to: ",
-        scatter->toString());
-  }
-
-  // Scatter output must not be used outside of this op sequence
-  if (scatter_out->uses().size() != 1) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to multiple uses of "
-        "scatter output: ",
-        scatter->toString());
-  }
-
-  // Scatter input must be created by a FullOp with the same value
-  // as the reduction init value
-  auto full = dynamic_cast<FullOp*>(scatter_in->definition());
-  if (full == nullptr) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to missing full op");
-  }
-
-  // The full shape will be replaced with a 1D tensor of the same
-  // size as the scatter dimension, and thus the output must not be
-  // used by anything else.
-  if (full->output(0)->uses().size() > 1) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to multiple uses of full "
-        "output: ",
-        full->toString());
-  }
-
-  auto scatter_out_use = scatter_out->uses().at(0);
-
-  // int32_t is automatically upcast to int64_t before reduction.
-  if (auto cast = dynamic_cast<UnaryOp*>(scatter_out_use); cast != nullptr &&
-      cast->getUnaryOpType() == UnaryOpType::Cast &&
-      cast->in()->dtype() == DataType::Int32 &&
-      cast->out()->dtype() == DataType::Int) {
-    if (cast->output(0)->uses().size() != 1) {
-      return fail(
-          "Unsupported scatter + reduction pattern due to multiple uses of "
-          "cast output: ",
-          cast->toString());
-    }
-    scatter_out_use = cast->output(0)->uses().at(0);
-  }
-
-  auto reduction = dynamic_cast<ReductionOp*>(scatter_out_use);
-
-  if (reduction == nullptr) {
-    return fail("Unsupported scatter + reduction pattern. No reduction found.");
-  }
-
-  auto reduction_out = reduction->out()->as<TensorView>();
-
-  if (!full->getFillValue()->sameAs(reduction->init())) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to invalid full op: ",
-        full->toString());
-  }
-
-  auto reduction_type = reduction->getReductionOpType();
-
-  const bool is_deterministic =
-      !isFloatingPointType(reduction->in()->dtype()) ||
-      reduction_type == BinaryOpType::Max ||
-      reduction_type == BinaryOpType::Min;
-
-  if (!is_deterministic) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to: not deterministic");
-  }
-
-  // Scatter dimension of the index tensor must be a size-one
-  // dimension.
-  auto index_logical = TensorDomain::noReductions(
-      scatter->index()->as<TensorView>()->getLogicalDomain());
-  IterDomain* index_scatter_dim = index_logical.at(scatter->dim());
-  if (!index_scatter_dim->extent()->isOneInt()) {
-    return fail(
-        "Unsupported scatter + reduction pattern due to: invalid index "
-        "tensor: ",
-        scatter->index()->toString());
-  }
-
-  // The non-scatter dimension must must be reduced
-  NVF_ERROR_EQ(
-      scatter_out->getLogicalDomain().size(),
-      reduction_out->getLogicalDomain().size());
-  for (const auto& [scatter_logical_id, reduction_logical_id] :
-       zip(scatter_out->getLogicalDomain(),
-           reduction_out->getLogicalDomain())) {
-    if (scatter_out->getLogicalDomain().at(scatter->dim()) ==
-        scatter_logical_id) {
-      // scatter dimension -> should not be reduced
-      if (reduction_logical_id->isReduction()) {
-        return fail(
-            "Unsupported scatter + reduction pattern due to: scatter dimension "
-            "should not be reduced: ",
-            scatter_out->toString(),
-            ", ",
-            reduction_out->toString());
-      }
-    } else {
-      // Non scatter dimension -> should be reduced
-      if (!reduction_logical_id->isReduction()) {
-        return fail(
-            "Unsupported scatter + reduction pattern due to: non-scatter "
-            "dimension should be reduced: ",
-            scatter_out->toString(),
-            ", ",
-            reduction_out->toString());
-      }
-    }
-  }
-
-  // At this point, it should be safe to translate scatter +
-  // reduction to scatter-accumulate as long as the new
-  // scatter-accumualte is schedulable. Note that both scatter in and
-  // index must be 2D
-  auto scatter_out_id = scatter_out->getLogicalDomain().at(scatter->dim());
-  auto scatter_index_id = index_logical.at(scatter->dim() == 0 ? 1 : 0);
-
-  return {
-      ScatterAccumulateInfo{
-          scatter, reduction, full, scatter_out_id, scatter_index_id},
-      ""};
-}
-
 class CompileTimeChecker : private IterVisitor {
  public:
   static bool run(Fusion* fusion, const ValGraph& exact_graph) {
@@ -502,45 +327,34 @@ class CompileTimeChecker : private IterVisitor {
       return;
     }
 
-    const auto& [scatter_accum_info, reason] =
-        getMaybeScatterAccumulate(scatter);
-
     auto out_tv = ir_utils::getTvOutput(scatter);
 
-    if (!scatter_accum_info.has_value()) {
-      // In the case of scatter, the scatter dimension doesn't need to
-      // be parallelized with TID, but we need to make sure it isn't
-      // parallelized with BID. In that sense, categorizing it as a
-      // constrained ID may be too restrictive.
-      // TODO: Consider introducing another group of IDs that are semi
-      // constrained.
-      auto constrained_out_logical_dim = scatter->dim();
+    // In the case of scatter, the scatter dimension doesn't need to
+    // be parallelized with TID, but we need to make sure it isn't
+    // parallelized with BID. In that sense, categorizing it as a
+    // constrained ID may be too restrictive.
+    // TODO: Consider introducing another group of IDs that are semi
+    // constrained.
+    auto constrained_out_logical_dim = scatter->dim();
 
-      // For the scatter in and out tensors, the scatter dimension must
-      // not be parallelized with BID. Note that the loop domain of the
-      // out tensor is not mapped with the logical domain, we still need
-      // to make sure the logical is also schedulable as the input and
-      // also the consumer of the output need to be schedulable.
-      checkDomainConstraints(
-          out_tv->domain()->logical(), {constrained_out_logical_dim});
+    // For the scatter in and out tensors, the scatter dimension must
+    // not be parallelized with BID. Note that the loop domain of the
+    // out tensor is not mapped with the logical domain, we still need
+    // to make sure the logical is also schedulable as the input and
+    // also the consumer of the output need to be schedulable.
+    checkDomainConstraints(
+        out_tv->domain()->logical(), {constrained_out_logical_dim});
 
-      // In addition, the index and src tensors are not allowed to use
-      // BID with the scatter dim. Their logical domains are not mapped
-      // with the logical domains of the input and output tensors, so
-      // they need to be checked separately.
-      checkDomainConstraints(
-          TensorDomain::noReductions(
-              scatter->index()->as<TensorView>()->getLogicalDomain()),
-          {constrained_out_logical_dim});
-      // Index and src tensors are mapped, so just checking index should
-      // be sufficient.
-    } else {
-      // This will be translated to a 1D scatter-accumulate
-      checkDomainConstraints({scatter_accum_info->scatter_out_id}, {0});
-      checkDomainConstraints({scatter_accum_info->scatter_index_id}, {0});
-
-      scatter_accumulate_reductions_.insert(scatter_accum_info->reduction);
-    }
+    // In addition, the index and src tensors are not allowed to use
+    // BID with the scatter dim. Their logical domains are not mapped
+    // with the logical domains of the input and output tensors, so
+    // they need to be checked separately.
+    checkDomainConstraints(
+        TensorDomain::noReductions(
+            scatter->index()->as<TensorView>()->getLogicalDomain()),
+        {constrained_out_logical_dim});
+    // Index and src tensors are mapped, so just checking index should
+    // be sufficient.
   }
 
   void handle(PadOp* pad) override {
@@ -759,17 +573,10 @@ class RunTimeChecker : private IterVisitor {
     auto out = ir_utils::getTvOutput(scatter);
     auto index = scatter->index()->as<TensorView>();
 
-    const auto& [scatter_accum_info, reason] =
-        getMaybeScatterAccumulate(scatter);
-    if (!scatter_accum_info.has_value()) {
-      checkDomainConstraints(out->getLogicalDomain(), {scatter->dim()});
-      checkDomainConstraints(
-          TensorDomain::noReductions(index->getLogicalDomain()),
-          {scatter->dim()});
-    } else {
-      checkDomainConstraints({scatter_accum_info->scatter_out_id}, {0});
-      checkDomainConstraints({scatter_accum_info->scatter_index_id}, {0});
-    }
+    checkDomainConstraints(out->getLogicalDomain(), {scatter->dim()});
+    checkDomainConstraints(
+        TensorDomain::noReductions(index->getLogicalDomain()),
+        {scatter->dim()});
   }
 
   // Since all constrained IDs are flattened and parallelized with
@@ -889,55 +696,6 @@ void insertCopyAfter(Fusion* fusion) {
     }
   }
 }
-
-// Translate the scatter and reduciton pattern to
-// scatter-accumulate. See also the comment at
-// getMaybeScatterAccumulate.
-class TranslateScatterAccumulate : public OptOutDispatch {
- public:
-  static void run(Fusion* fusion) {
-    TranslateScatterAccumulate translator(fusion);
-  }
-
- private:
-  TranslateScatterAccumulate(Fusion* fusion) {
-    for (auto expr : fusion->exprs()) {
-      dispatch(expr);
-    }
-  }
-
-  void handle(ScatterOp* sop) final {
-    const auto& [info, reason] = getMaybeScatterAccumulate(sop);
-
-    if (!info.has_value()) {
-      return;
-    }
-
-    auto scatter_dim = sop->dim();
-
-    // Squeeze the broadcast of the index input
-    auto index_tv = sop->index()->as<TensorView>();
-    index_tv = squeeze(index_tv, {scatter_dim});
-
-    // Src can be a scalar. If it's a tensor, squeeze it as well
-    auto src = sop->src();
-    if (auto src_tv = dynamic_cast<TensorView*>(src)) {
-      src = squeeze(src_tv, {scatter_dim});
-    }
-
-    // Create a new scatter input of size [n]
-    auto scatter_inp = full(
-        {info->scatter_out_id->extent()},
-        info->full->getFillValue(),
-        info->full->output(0)->dtype());
-
-    auto scatter_out = scatter(
-        scatter_inp, 0, index_tv, src, info->reduction->getReductionOpType());
-
-    ir_utils::replaceValInAllExprInputsAndFusionOutputs(
-        info->reduction->out(), scatter_out);
-  }
-};
 
 class ConstrainedOpScheduler : public OptOutDispatch {
  public:
@@ -1339,8 +1097,6 @@ void GreedyScheduler::schedule(Fusion* fusion, const HeuristicParams* params) {
   auto cached_inputs = scheduler_utils::cacheInputs(fusion, true);
   // Cache and fork outputs
   auto cached_outputs = scheduler_utils::cacheAndForkOutputs(fusion, true);
-
-  TranslateScatterAccumulate::run(fusion);
 
   propagateReshape(fusion);
 

--- a/tests/python/test_moe.py
+++ b/tests/python/test_moe.py
@@ -199,3 +199,5 @@ def test_llama4_moe_thunderfx():
     # print(tmodel.last_traces)
 
     torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+test_llama4_moe_thunderfx()

--- a/tests/python/test_moe.py
+++ b/tests/python/test_moe.py
@@ -178,8 +178,7 @@ def test_llama4_moe_thunderfx():
     # as it doesn't have a grad-rule for the same.
     model.requires_grad_(False)
 
-    #batch_size, seq_len = 1, 2048
-    batch_size, seq_len = 1, 1024
+    batch_size, seq_len = 1, 2048
     inp = torch.randn(
         batch_size, seq_len, config.hidden_size, dtype=torch.bfloat16, device="cuda"
     )
@@ -200,5 +199,3 @@ def test_llama4_moe_thunderfx():
     # print(tmodel.last_traces)
 
     torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
-
-test_llama4_moe_thunderfx()

--- a/tests/python/test_moe.py
+++ b/tests/python/test_moe.py
@@ -178,7 +178,8 @@ def test_llama4_moe_thunderfx():
     # as it doesn't have a grad-rule for the same.
     model.requires_grad_(False)
 
-    batch_size, seq_len = 1, 2048
+    #batch_size, seq_len = 1, 2048
+    batch_size, seq_len = 1, 1024
     inp = torch.randn(
         batch_size, seq_len, config.hidden_size, dtype=torch.bfloat16, device="cuda"
     )


### PR DESCRIPTION
The greedy scheduler does not yet support reductions, but there's one reduction in test_moe.py. Fortunately, it can be translated to a scatter-accumulate.

Example fusion pattern:

```
index = [m, 1];
scatter_inp = zeros([m, n]); // [m, n]
scatter_out = scatter(scatter_inp, 1, index, src=1);
reduction_out = scatter_out.sum(0); // [n]
```

The greedy scheduler translates it to:

```
index = index.squeeze(-1) // [m]
scatter_inp = zeros([n]); // [n]
scatter_out = scatter(scatter_inp, 0, index, src=1, BinaryOpType::Add)
```

~I was originally thinking about doing this as a preseg pass but decided to do it just for a greedy segment.~
Moved to preseg. I realized translation at scheduling time doesn't work well as the segmenter doesn't see the whole pattern until all ops are fused. We could add yet another special pattern matcher in the segmeter, but I think in this case a preseg pass would make more sense.

Closes #5150 

