### PR TITLE
add runtime function for cluster reduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1039,6 +1039,24 @@ if(BUILD_TEST)
     ${NVFUSER_ROOT}/third_party/googletest/googletest/include
     ${NVFUSER_ROOT}/third_party/googletest/googlemock/include
   )
+
+  set(CLUSTER_TEST_KERNELS "cluster_test_kernels")
+  add_library(${CLUSTER_TEST_KERNELS} SHARED
+    ${NVFUSER_ROOT}/tests/cpp/cluster_runtime_test/cluster_test_kernels.cu
+    ${NVFUSER_ROOT}/tests/cpp/cluster_runtime_test/cluster_test_helper.cpp
+  )
+
+  # CUDA 11 does not support C++20, so hard code C++17 here
+  set_property(TARGET ${CLUSTER_TEST_KERNELS} PROPERTY CXX_STANDARD 17)
+  target_link_libraries(${CLUSTER_TEST_KERNELS} PRIVATE torch ${TORCH_LIBRARIES})
+  target_include_directories(${CLUSTER_TEST_KERNELS} PRIVATE "${NVFUSER_ROOT}")
+  target_include_directories(${CLUSTER_TEST_KERNELS} PRIVATE
+    ${CMAKE_SOURCE_DIR}/csrc
+  )
+  target_include_directories(${CLUSTER_TEST_KERNELS} SYSTEM PRIVATE
+    ${NVFUSER_ROOT}/third_party/googletest/googletest/include
+    ${NVFUSER_ROOT}/third_party/googletest/googlemock/include
+  )
 endif()
 
 function(add_test_without_main TEST_NAME TEST_SRC ADDITIONAL_LINK)
@@ -1102,6 +1120,13 @@ if(BUILD_TEST)
   )
   add_test(test_scan "${SCAN_TEST_SRCS}" ${SCAN_TEST_KERNELS})
   list(APPEND TEST_BINARIES test_scan)
+
+  set(CLUSTER_TEST_SRCS)
+  list(APPEND CLUSTER_TEST_SRCS
+    ${NVFUSER_ROOT}/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
+  )
+  add_test(test_cluster "${CLUSTER_TEST_SRCS}" ${CLUSTER_TEST_KERNELS})
+  list(APPEND TEST_BINARIES test_cluster)
 
   set(TOPK_TEST_SRCS)
   list(APPEND TOPK_TEST_SRCS

--- a/runtime/cluster.cu
+++ b/runtime/cluster.cu
@@ -145,7 +145,7 @@ __device__ __forceinline__ T warpReduce(T val, Func reduction_op) {
 // memories
 // 3. All warps read from its CTA's shared memory and do a warp reduction
 // TODO: we can represent this cluster reduction in fusion IR after we have new
-// parallel types to represent warp reduction
+// parallel types to represent warp reduction.
 template <int CLUSTER_SIZE, int WARPS_PER_BLOCK, typename T, typename Func>
 __device__ __forceinline__ void clusterReduce(
     T& res,
@@ -177,7 +177,11 @@ __device__ __forceinline__ void clusterReduce(
     storeSharedRemote<T>(
         warp_sum, buffer_addr, barrier_smem_addr, peer_cta_rank_in_cluster);
   }
+
+  // mbarrier is not repeatedly used, parity phase is set to 0. Otherwise,
+  // should flip parity phase, e.g. when used in persistent CTA kernels.
   mbarrier::waitParity(barrier_smem_addr, 0);
+
   // 3. Each CTA has a copy of the warp reduction results from all warps in the
   // cluster
   // Finish reduction with a warp reduction

--- a/runtime/cluster.cu
+++ b/runtime/cluster.cu
@@ -5,37 +5,36 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#pragma once
-
+namespace cluster {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
 // The optional .relaxed qualifier on barrier.cluster.arrive specifies that
 // there are no memory ordering and visibility guarantees provided for the
 // memory accesses performed prior to barrier.cluster.arrive.
-void clusterArriveRelaxed() {
+__device__ void clusterArriveRelaxed() {
   asm volatile("barrier.cluster.arrive.relaxed.aligned;" : :);
 }
 
 // A thread arrives at barrier but it does not have to wait for threads in other
 // participating warps.
-void clusterArrive() {
+__device__ void clusterArrive() {
   asm volatile("barrier.cluster.arrive.aligned;" : :);
 }
 
 // A thread waits for all non-exited threads of the cluster to perform
 // cluster_arrive.
-void clusterWait() {
+__device__ void clusterWait() {
   asm volatile("barrier.cluster.wait.aligned;" : :);
 }
 
 // Synchronize threads in cluster
-void clusterSync() {
+__device__ void clusterSync() {
   clusterArrive();
   clusterWait();
 }
 
 // Returns the dim3 grid size in terms of number of clusters.
-dim3 clusterGridDims() {
+__device__ dim3 clusterGridDims() {
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%nclusterid.x;" : "=r"(x) :);
   asm volatile("mov.u32 %0, %%nclusterid.y;" : "=r"(y) :);
@@ -44,7 +43,7 @@ dim3 clusterGridDims() {
 }
 
 // Returns the dim3 cluster rank in the grid.
-dim3 clusterIdInGrid() {
+__device__ dim3 clusterIdInGrid() {
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%clusterid.x;" : "=r"(x) :);
   asm volatile("mov.u32 %0, %%clusterid.y;" : "=r"(y) :);
@@ -53,7 +52,7 @@ dim3 clusterIdInGrid() {
 }
 
 // Returns the relative dim3 block rank local to the cluster.
-dim3 blockIdInCluster() {
+__device__ dim3 blockIdInCluster() {
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%cluster_ctaid.x;" : "=r"(x) :);
   asm volatile("mov.u32 %0, %%cluster_ctaid.y;" : "=r"(y) :);
@@ -62,7 +61,7 @@ dim3 blockIdInCluster() {
 }
 
 // Returns the dim3 cluster shape.
-dim3 clusterShape() {
+__device__ dim3 clusterShape() {
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%cluster_nctaid.x;" : "=r"(x) :);
   asm volatile("mov.u32 %0, %%cluster_nctaid.y;" : "=r"(y) :);
@@ -71,14 +70,14 @@ dim3 clusterShape() {
 }
 
 // Get 1D ctaid in a cluster.
-uint32_t blockRankInCluster() {
+__device__ uint32_t blockRankInCluster() {
   uint32_t rank;
   asm volatile("mov.u32 %0, %%cluster_ctarank;" : "=r"(rank) :);
   return rank;
 }
 
 // Set the destination block-ID in cluster for a given SMEM Address
-uint32_t mapSharedRank(uint32_t smemAddr, uint32_t rank) {
+__device__ uint32_t mapSharedRank(uint32_t smemAddr, uint32_t rank) {
   uint32_t result;
   asm volatile("mapa.shared::cluster.u32  %0, %1, %2;"
                : "=r"(result)
@@ -86,4 +85,114 @@ uint32_t mapSharedRank(uint32_t smemAddr, uint32_t rank) {
   return result;
 }
 
+// Async store operations - only supports float and double types
+template <typename T>
+__device__ __forceinline__ void storeSharedRemote(
+    T value,
+    uint32_t smem_addr,
+    uint32_t mbarrier_addr,
+    uint32_t dst_cta_rank) {
+  static_assert(
+      sizeof(T) == 0, "storeSharedRemote only supports float and double types");
+}
+
+// Specialization for float (32-bit)
+template <>
+__device__ __forceinline__ void storeSharedRemote<float>(
+    float value,
+    uint32_t smem_addr,
+    uint32_t mbarrier_addr,
+    uint32_t dst_cta_rank) {
+  uint32_t dsmem_addr = mapSharedRank(smem_addr, dst_cta_rank);
+  uint32_t remote_barrier_addr = mapSharedRank(mbarrier_addr, dst_cta_rank);
+  asm volatile(
+      "st.async.shared::cluster.mbarrier::complete_tx::bytes.f32 [%0], %1, "
+      "[%2];"
+      :
+      : "r"(dsmem_addr), "f"(value), "r"(remote_barrier_addr));
+}
+
+// Specialization for double (64-bit)
+template <>
+__device__ __forceinline__ void storeSharedRemote<double>(
+    double value,
+    uint32_t smem_addr,
+    uint32_t mbarrier_addr,
+    uint32_t dst_cta_rank) {
+  uint32_t dsmem_addr = mapSharedRank(smem_addr, dst_cta_rank);
+  uint32_t remote_barrier_addr = mapSharedRank(mbarrier_addr, dst_cta_rank);
+  asm volatile(
+      "st.async.shared::cluster.mbarrier::complete_tx::bytes.f64 [%0], %1, "
+      "[%2];"
+      :
+      : "r"(dsmem_addr), "d"(value), "r"(remote_barrier_addr));
+}
+
+template <typename T, typename Func>
+__device__ __forceinline__ T warpReduce(T val, Func reduction_op) {
+  T reduce_val = val;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset /= 2) {
+    reduction_op(reduce_val, __shfl_xor_sync(0xffffffff, reduce_val, offset));
+  }
+  return reduce_val;
+}
+
+// Cluster reduction in x direction
+// Algorithm:
+// 1. Each warp does a warp reduction
+// 2. All warps async store reduction results to its and clustered CTA's shared
+// memories
+// 3. All warps read from its CTA's shared memory and do a warp reduction
+// TODO: we can represent this cluster reduction in fusion IR after we have new
+// parallel types to represent warp reduction
+template <int CLUSTER_SIZE, int WARPS_PER_BLOCK, typename T, typename Func>
+__device__ __forceinline__ void clusterReduce(
+    T& res,
+    T inp,
+    T init,
+    uint32_t barrier_smem_addr,
+    T* reduction_buffer,
+    Func reduction_op) {
+  uint32_t my_block_rank = blockIdInCluster().x;
+  uint32_t lane_idx = threadIdx.x % 32;
+  uint32_t warp_idx = threadIdx.x / 32;
+
+  T thread_val = inp;
+
+  // 1. Perform warp reduction
+  T warp_sum = warpReduce(thread_val, reduction_op);
+
+  // 2. All warps store their results to distributed shared memory
+  // Each warp uses N threads to write to N CTAs, e.g. thread-i write to CTA-i
+  // Buffer layout: reduction_buffer[CLUSTER_SIZE][WARPS_PER_BLOCK]
+  if (warp_idx == 0 && Hopper::electSync(4294967295U)) {
+    uint32_t expected_bytes = WARPS_PER_BLOCK * CLUSTER_SIZE * sizeof(T);
+    mbarrier::arriveExpectTX(barrier_smem_addr, expected_bytes);
+  }
+  if (lane_idx < CLUSTER_SIZE) {
+    uint32_t peer_cta_rank_in_cluster = lane_idx;
+    uint32_t buffer_offset = my_block_rank * WARPS_PER_BLOCK + warp_idx;
+    uint32_t buffer_addr = toSmem(&reduction_buffer[buffer_offset]);
+    storeSharedRemote<T>(
+        warp_sum, buffer_addr, barrier_smem_addr, peer_cta_rank_in_cluster);
+  }
+  mbarrier::waitParity(barrier_smem_addr, 0);
+  // 3. Each CTA has a copy of the warp reduction results from all warps in the
+  // cluster
+  // Finish reduction with a warp reduction
+  T block_reduce_val = init;
+  constexpr int num_iter = (WARPS_PER_BLOCK * CLUSTER_SIZE + 31) / 32;
+#pragma unroll
+  for (int i = 0; i < num_iter; i++) {
+    int idx = lane_idx + i * 32;
+    if (idx < CLUSTER_SIZE * WARPS_PER_BLOCK) {
+      reduction_op(block_reduce_val, reduction_buffer[idx]);
+    }
+  }
+  // 4. Each CTA performs a warp reduction on its shared memory
+  // Get final result using warp reduction
+  res = warpReduce(block_reduce_val, reduction_op);
+}
 #endif // Arch 90
+} // namespace cluster

--- a/tests/cpp/cluster_runtime_test/cluster_test_helper.cpp
+++ b/tests/cpp/cluster_runtime_test/cluster_test_helper.cpp
@@ -1,0 +1,76 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <tests/cpp/cluster_runtime_test/cluster_test_helper.h>
+
+#include <ATen/ATen.h>
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+#include <string>
+
+namespace nvfuser {
+
+void validateClusterStoreResult(
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    int cluster_size) {
+  const int64_t in_dim = static_cast<int64_t>(input_tensor.dim());
+  const int64_t out_dim = static_cast<int64_t>(output_tensor.dim());
+  ASSERT_TRUE(in_dim == out_dim);
+
+  const int64_t in_numel = input_tensor.numel();
+  const int64_t out_numel = output_tensor.numel();
+  ASSERT_TRUE(in_numel == out_numel);
+
+  // Current kernel with CLUSTER_SIZE=2 writes peer CTA values,
+  // so the expected output is the input with halves swapped.
+  ASSERT_TRUE(cluster_size == 2)
+      << "This validation currently assumes cluster_size == 2";
+
+  // Convert to CPU for comparison
+  auto input_cpu = input_tensor.cpu();
+  auto output_cpu = output_tensor.cpu();
+
+  const auto numel = input_cpu.numel();
+  ASSERT_TRUE(numel % 2 == 0)
+      << "Number of elements must be even to swap halves";
+  const auto half = numel / 2;
+
+  auto expected = at::empty_like(input_cpu);
+  expected.narrow(0, 0, half).copy_(input_cpu.narrow(0, half, half));
+  expected.narrow(0, half, half).copy_(input_cpu.narrow(0, 0, half));
+
+  ASSERT_TRUE(at::allclose(output_cpu, expected, /*rtol=*/1e-7, /*atol=*/1e-8))
+      << "Cluster store validation failed: output is not input with halves "
+         "swapped";
+}
+
+void validateClusterReduceResult(
+    at::Tensor input_tensor,
+    at::Tensor output_tensor) {
+  const int64_t in_dim = static_cast<int64_t>(input_tensor.dim());
+  const int64_t out_dim = static_cast<int64_t>(output_tensor.dim());
+  ASSERT_TRUE(in_dim == out_dim);
+
+  const int64_t in_numel = input_tensor.numel();
+  const int64_t out_numel = output_tensor.numel();
+  ASSERT_TRUE(in_numel == out_numel);
+
+  auto input_cpu = input_tensor.cpu();
+  auto output_cpu = output_tensor.cpu();
+
+  // Expect every element to be the global sum of the input tensor
+  const double expected_scalar = input_cpu.sum().item<double>();
+  auto expected = at::empty_like(input_cpu);
+  expected.fill_(expected_scalar);
+
+  ASSERT_TRUE(at::allclose(output_cpu, expected, /*rtol=*/1e-6, /*atol=*/1e-7))
+      << "Cluster reduce validation failed: output is not the global sum";
+}
+
+} // namespace nvfuser

--- a/tests/cpp/cluster_runtime_test/cluster_test_helper.h
+++ b/tests/cpp/cluster_runtime_test/cluster_test_helper.h
@@ -1,0 +1,32 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#pragma once
+
+#include <ATen/Tensor.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+
+namespace nvfuser {
+
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE>
+void launchStoreSharedRemoteTestKernel(T* input, T* output);
+
+void validateClusterStoreResult(
+    at::Tensor input_tensor,
+    at::Tensor output_tensor,
+    int cluster_size);
+
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE>
+void launchClusterReduceTestKernel(T* input, T* output);
+
+void validateClusterReduceResult(
+    at::Tensor input_tensor,
+    at::Tensor output_tensor);
+
+} // namespace nvfuser

--- a/tests/cpp/cluster_runtime_test/cluster_test_kernels.cu
+++ b/tests/cpp/cluster_runtime_test/cluster_test_kernels.cu
@@ -1,0 +1,183 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <cuda_utils.h>
+#include <tests/cpp/cluster_runtime_test/cluster_test_helper.h>
+
+namespace nvfuser {
+// copied from runtime/memory.cu to avoid too many includes
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+__device__ inline unsigned toSmem(const void* raw_ptr) {
+  unsigned smem_ptr_uint;
+  asm("{ .reg .u64 smem_ptr; cvta.to.shared.u64 smem_ptr, %1; cvt.u32.u64 %0, "
+      "smem_ptr; }\n"
+      : "=r"(smem_ptr_uint)
+      : "l"(raw_ptr));
+
+  return smem_ptr_uint;
+}
+namespace Hopper {
+__device__ inline bool electSync(const uint32_t& membermask) {
+  uint32_t is_elected;
+  asm volatile(
+      "{\n\t .reg .pred P_OUT; \n\t"
+      "elect.sync _|P_OUT, %1;\n\t"
+      "selp.b32 %0, 1, 0, P_OUT; \n"
+      "}"
+      : "=r"(is_elected)
+      : "r"(membermask)
+      :);
+  return static_cast<bool>(is_elected);
+}
+} // namespace Hopper
+#endif
+// must include mbarrier.cu before cluster.cu
+// since mbarrier is used in cluster.cu
+// clang-format off
+#include <runtime/mbarrier.cu>
+#include <runtime/cluster.cu>
+// clang-format on
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE>
+__global__ void storeSharedRemoteTestKernel(T* input, T* output) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  // load from input to register
+  int global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  T value = input[global_tid];
+
+  // Shared memory for data exchange between CTAs in cluster
+  __shared__ T shared_data[BLOCK_SIZE];
+  __shared__ uint64_t mbarrier;
+  uint32_t mbarrier_addr = toSmem(&mbarrier);
+
+  // Initialize barrier
+  if (threadIdx.x == 0) {
+    mbarrier::init(mbarrier_addr, 1);
+  }
+  cluster::clusterSync();
+
+  // Each thread writes to its peer CTA's shared memory
+  auto cluster_id = cluster::blockIdInCluster().x;
+  if (threadIdx.x == 0) {
+    uint32_t expected_bytes = BLOCK_SIZE * sizeof(T);
+    mbarrier::arriveExpectTX(mbarrier_addr, expected_bytes);
+  }
+  uint32_t peer_cta_rank_in_cluster = (cluster_id + 1) % CLUSTER_SIZE;
+  uint32_t buffer_addr = toSmem(&shared_data[threadIdx.x]);
+  cluster::storeSharedRemote<T>(
+      value, buffer_addr, mbarrier_addr, peer_cta_rank_in_cluster);
+
+  // wait for all writings are done, then write from shared memory to output
+  mbarrier::waitParity(mbarrier_addr, 0);
+  output[global_tid] = shared_data[threadIdx.x];
+#endif
+}
+
+template <typename T>
+struct AddOp {
+  __device__ __forceinline__ void operator()(T& a, const T& b) const {
+    a += b;
+  }
+};
+
+// Reduce BLOCK_SIZE x CLUSTER_SIZE values across a cluster of CLUSTER_SIZE CTAs
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE, int WARPS_PER_BLOCK>
+__global__ void clusterReduceTestKernel(T* input, T* output) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  const int global_tid = blockIdx.x * blockDim.x + threadIdx.x;
+  T value = input[global_tid];
+
+  __shared__ uint64_t mbarrier;
+  __shared__ T reduction_buffer[CLUSTER_SIZE * WARPS_PER_BLOCK];
+  uint32_t mbarrier_addr = toSmem(&mbarrier);
+
+  if (threadIdx.x == 0) {
+    mbarrier::init(mbarrier_addr, 1);
+  }
+  cluster::clusterSync();
+
+  T result;
+  cluster::clusterReduce<CLUSTER_SIZE, WARPS_PER_BLOCK, T, AddOp<T>>(
+      result,
+      value,
+      static_cast<T>(0),
+      mbarrier_addr,
+      reduction_buffer,
+      AddOp<T>());
+
+  // After clusterReduce, each thread in each block has the same reduced value
+  output[global_tid] = result;
+#endif
+}
+
+//============================================================================
+// Launch function implementations
+//============================================================================
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE>
+void launchStoreSharedRemoteTestKernel(T* input, T* output) {
+  // Configure cluster launch
+  cudaLaunchConfig_t config = {};
+  config.gridDim = dim3(CLUSTER_SIZE, 1, 1);
+  config.blockDim = dim3(BLOCK_SIZE, 1, 1);
+
+  // Set cluster dimensions
+  cudaLaunchAttribute cluster_attr = {};
+  cluster_attr.id = cudaLaunchAttributeClusterDimension;
+  cluster_attr.val.clusterDim.x = CLUSTER_SIZE;
+  cluster_attr.val.clusterDim.y = 1;
+  cluster_attr.val.clusterDim.z = 1;
+  config.attrs = &cluster_attr;
+  config.numAttrs = 1;
+
+  // Launch kernel with cluster configuration
+  NVFUSER_CUDA_RT_SAFE_CALL(cudaLaunchKernelEx(
+      &config,
+      storeSharedRemoteTestKernel<T, BLOCK_SIZE, CLUSTER_SIZE>,
+      input,
+      output));
+}
+
+template <typename T, int BLOCK_SIZE, int CLUSTER_SIZE>
+void launchClusterReduceTestKernel(T* input, T* output) {
+  constexpr int WARPS_PER_BLOCK = (BLOCK_SIZE + 31) / 32;
+
+  cudaLaunchConfig_t config = {};
+  config.gridDim = dim3(CLUSTER_SIZE, 1, 1);
+  config.blockDim = dim3(BLOCK_SIZE, 1, 1);
+
+  cudaLaunchAttribute cluster_attr = {};
+  cluster_attr.id = cudaLaunchAttributeClusterDimension;
+  cluster_attr.val.clusterDim.x = CLUSTER_SIZE;
+  cluster_attr.val.clusterDim.y = 1;
+  cluster_attr.val.clusterDim.z = 1;
+  config.attrs = &cluster_attr;
+  config.numAttrs = 1;
+
+  NVFUSER_CUDA_RT_SAFE_CALL(cudaLaunchKernelEx(
+      &config,
+      clusterReduceTestKernel<T, BLOCK_SIZE, CLUSTER_SIZE, WARPS_PER_BLOCK>,
+      input,
+      output));
+}
+
+// explicit template instantiations
+template void launchStoreSharedRemoteTestKernel<float, 32, 2>(
+    float* input,
+    float* output);
+
+template void launchStoreSharedRemoteTestKernel<double, 32, 2>(
+    double* input,
+    double* output);
+
+template void launchClusterReduceTestKernel<float, 128, 2>(
+    float* input,
+    float* output);
+
+template void launchClusterReduceTestKernel<double, 128, 2>(
+    double* input,
+    double* output);
+} // namespace nvfuser

--- a/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
+++ b/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
@@ -1,0 +1,114 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+#include <ATen/TensorOptions.h>
+#include <tests/cpp/cluster_runtime_test/cluster_test_helper.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+
+#include <ATen/cuda/CUDAContext.h>
+
+namespace nvfuser {
+
+using ClusterDeviceFuncTest = NVFuserTest;
+
+// Basic functionality test for storeSharedRemote<float>
+TEST_F(ClusterDeviceFuncTest, BasicStoreSharedRemoteFloat) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  constexpr int num_blocks = 2;
+  constexpr int threads_per_block = 32;
+  constexpr int total_elements = num_blocks * threads_per_block;
+
+  // Create input tensor with sequential values for easy verification
+  auto input_tensor = at::arange(
+      1.0f,
+      total_elements + 1.0f,
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+
+  // Launch test kernel with cluster configuration (2x1x1 cluster)
+  launchStoreSharedRemoteTestKernel<float, threads_per_block, num_blocks>(
+      input_tensor.data_ptr<float>(), output_tensor.data_ptr<float>());
+  // Validate the results
+  validateClusterStoreResult(input_tensor, output_tensor, 2);
+}
+
+// Basic functionality test for storeSharedRemote<double>
+TEST_F(ClusterDeviceFuncTest, BasicStoreSharedRemoteDouble) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  constexpr int num_blocks = 2;
+  constexpr int threads_per_block = 32;
+  constexpr int total_elements = num_blocks * threads_per_block;
+
+  // Create input tensor with sequential values for easy verification
+  auto input_tensor = at::arange(
+      1.0,
+      total_elements + 1.0,
+      at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+
+  // Launch test kernel with cluster configuration (2x1x1 cluster)
+  launchStoreSharedRemoteTestKernel<double, threads_per_block, num_blocks>(
+      input_tensor.data_ptr<double>(), output_tensor.data_ptr<double>());
+  // Validate the results
+  validateClusterStoreResult(input_tensor, output_tensor, 2);
+}
+
+// Cluster reduction test for float
+TEST_F(ClusterDeviceFuncTest, ClusterReduceFloat) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  constexpr int num_blocks = 2;
+  constexpr int threads_per_block = 128;
+  constexpr int total_elements = num_blocks * threads_per_block;
+
+  auto input_tensor = at::arange(
+      1.0f,
+      total_elements + 1.0f,
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0));
+
+  launchClusterReduceTestKernel<float, threads_per_block, num_blocks>(
+      input_tensor.data_ptr<float>(), output_tensor.data_ptr<float>());
+
+  validateClusterReduceResult(input_tensor, output_tensor);
+}
+
+// Cluster reduction test for double
+TEST_F(ClusterDeviceFuncTest, ClusterReduceDouble) {
+  NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  constexpr int num_blocks = 2;
+  constexpr int threads_per_block = 128;
+  constexpr int total_elements = num_blocks * threads_per_block;
+
+  auto input_tensor = at::arange(
+      1.0,
+      total_elements + 1.0,
+      at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+
+  auto output_tensor = at::empty(
+      {total_elements},
+      at::TensorOptions().dtype(at::kDouble).device(at::kCUDA, 0));
+
+  launchClusterReduceTestKernel<double, threads_per_block, num_blocks>(
+      input_tensor.data_ptr<double>(), output_tensor.data_ptr<double>());
+
+  validateClusterReduceResult(input_tensor, output_tensor);
+}
+} // namespace nvfuser


### PR DESCRIPTION
## Cluster reduction runtime functions and tests

### Summary
- Adds device-side cluster runtime helpers and a reusable cluster-wide reduction primitive for Hopper (SM90+).
- Provides tests validating remote shared-memory stores and cluster reductions for `float`/`double`.

### What’s in this PR
- Runtime:
  - `runtime/cluster.cu`:`storeSharedRemote` and `clusterReduce`.

- Tests:
  - Both are tested with float and double data types.


### Implementation details
- Cluster utilities expose:
  -  `storeSharedRemote<T>` using `st.async.shared::cluster.mbarrier::complete_tx::bytes.{f32,f64}`
- `clusterReduce<...>` algorithm:
  - Per-warp reduction → asynchronous remote writes of warp results to all CTAs’ shared memory (DSMEM) with `mbarrier::arriveExpectTX` → `mbarrier::waitParity` → final warp reduction over the aggregated buffer to produce the per-thread result.
