### PR TITLE
cluster reduction IR, lowering, codegen, executor, and manually scheduled fusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -950,7 +950,6 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_outer_reduction.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_overlap.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_persistent_buffer.cpp
-  ${NVFUSER_ROOT}/tests/cpp/test_cluster.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_pointwise.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_polymorphic_value.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_predicate_elimination.cpp
@@ -1124,6 +1123,7 @@ if(BUILD_TEST)
 
   set(CLUSTER_TEST_SRCS)
   list(APPEND CLUSTER_TEST_SRCS
+    ${NVFUSER_ROOT}/tests/cpp/test_cluster.cpp
     ${NVFUSER_ROOT}/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
   )
   add_test(test_cluster "${CLUSTER_TEST_SRCS}" ${CLUSTER_TEST_KERNELS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -950,6 +950,7 @@ list(APPEND JIT_TEST_SRCS
   ${NVFUSER_ROOT}/tests/cpp/test_outer_reduction.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_overlap.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_persistent_buffer.cpp
+  ${NVFUSER_ROOT}/tests/cpp/test_cluster.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_pointwise.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_polymorphic_value.cpp
   ${NVFUSER_ROOT}/tests/cpp/test_predicate_elimination.cpp

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -4132,7 +4132,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                       // actual argument value like T0[i * 4 + j].
                       << (as_utility ? prefix + std::to_string(counter)
                                      : gen(register_))
-                      << "[" << i << "]" << ")";
+                      << "[" << i << "]"
+                      << ")";
                 }
               } else {
                 (*asm_target) << "\"" << constraint << "\"(";

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -471,8 +471,9 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           auto space_type = kernel_summary.largest_smem_data_type;
           indent() << "nvfuser_index_t block_size = "
                       "blockDim.x*blockDim.y*blockDim.z;\n";
-          indent() << space_type << " *shared_mem_var = " << "static_cast<"
-                   << space_type << "*>(" << "shared_mem);\n";
+          indent() << space_type << " *shared_mem_var = "
+                   << "static_cast<" << space_type << "*>("
+                   << "shared_mem);\n";
           indent() << space_type
                    << " *shared_mem_avg = shared_mem_var + block_size;\n";
           indent() << space_type
@@ -1748,7 +1749,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // This is slightly different from getReductionOp
     std::stringstream lambda;
     lambda << "[](const " << input->dtype() << "& a, const " << input->dtype()
-           << "& b) " << "{ return "
+           << "& b) "
+           << "{ return "
            << genBinaryOp(scan->opType(), input->dtype(), "a", "b") << "; }";
     func_args.arg(lambda.str());
 
@@ -2195,7 +2197,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const bool has_grid_reduce = domain->hasGridReduction();
 
     if (!has_block_reduce && !has_grid_reduce) {
-      indent() << "welfordCombine (" << "\n";
+      indent() << "welfordCombine ("
+               << "\n";
       indent() << kTab << gen(out_avg) << ",\n";
       indent() << kTab << gen(out_var) << ",\n";
       indent() << kTab << gen(out_N) << ",\n";

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -471,9 +471,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
           auto space_type = kernel_summary.largest_smem_data_type;
           indent() << "nvfuser_index_t block_size = "
                       "blockDim.x*blockDim.y*blockDim.z;\n";
-          indent() << space_type << " *shared_mem_var = "
-                   << "static_cast<" << space_type << "*>("
-                   << "shared_mem);\n";
+          indent() << space_type << " *shared_mem_var = " << "static_cast<"
+                   << space_type << "*>(" << "shared_mem);\n";
           indent() << space_type
                    << " *shared_mem_avg = shared_mem_var + block_size;\n";
           indent() << space_type
@@ -1749,8 +1748,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // This is slightly different from getReductionOp
     std::stringstream lambda;
     lambda << "[](const " << input->dtype() << "& a, const " << input->dtype()
-           << "& b) "
-           << "{ return "
+           << "& b) " << "{ return "
            << genBinaryOp(scan->opType(), input->dtype(), "a", "b") << "; }";
     func_args.arg(lambda.str());
 
@@ -2197,8 +2195,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     const bool has_grid_reduce = domain->hasGridReduction();
 
     if (!has_block_reduce && !has_grid_reduce) {
-      indent() << "welfordCombine ("
-               << "\n";
+      indent() << "welfordCombine (" << "\n";
       indent() << kTab << gen(out_avg) << ",\n";
       indent() << kTab << gen(out_var) << ",\n";
       indent() << kTab << gen(out_N) << ",\n";
@@ -4132,8 +4129,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
                       // actual argument value like T0[i * 4 + j].
                       << (as_utility ? prefix + std::to_string(counter)
                                      : gen(register_))
-                      << "[" << i << "]"
-                      << ")";
+                      << "[" << i << "]" << ")";
                 }
               } else {
                 (*asm_target) << "\"" << constraint << "\"(";
@@ -4293,6 +4289,10 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     indent() << sync_call << ";\n";
   }
 
+  void handle(const kir::ClusterSync* sync) final {
+    indent() << "cluster::clusterSync();\n";
+  }
+
   void handle(const kir::MBarrierInit* init) final {
     auto call = genCall(
         "mbarrier::init",
@@ -4440,6 +4440,56 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     indent() << "return;\n";
   }
 
+  void handle(const kir::ClusterReductionOp* cluster_reduction) final {
+    const auto output = cluster_reduction->out()->as<kir::TensorIndex>();
+    const auto input = cluster_reduction->in()->as<kir::TensorIndex>();
+    const auto op_type = cluster_reduction->getReductionOpType();
+    const auto init_val = cluster_reduction->init();
+    const auto mbarrier = cluster_reduction->mbarrier();
+
+    const auto par_domains = ir_utils::getParallelDomains(output);
+    const bool tidx =
+        par_domains.find(ParallelType::TIDx) != par_domains.end() &&
+        par_domains.at(ParallelType::TIDx)->isReduction();
+    const bool tidy =
+        par_domains.find(ParallelType::TIDy) != par_domains.end() &&
+        par_domains.at(ParallelType::TIDy)->isReduction();
+    const bool tidz =
+        par_domains.find(ParallelType::TIDz) != par_domains.end() &&
+        par_domains.at(ParallelType::TIDz)->isReduction();
+    NVF_ERROR(
+        tidx && !tidy && !tidz,
+        "Only support reduction in x direction for now");
+    int64_t blocks_per_cluster = lparams_.gdimx();
+    int64_t warps_per_block = lparams_.bdimx() / 32;
+
+    const auto data_type = output->dtype();
+    ArgumentBuilder template_args;
+    template_args.arg("/*blocks_per_cluster=*/")
+        .append(std::to_string(blocks_per_cluster));
+    template_args.arg("/*warps_per_block=*/")
+        .append(std::to_string(warps_per_block));
+
+    ArgumentBuilder func_args;
+    func_args.arg(gen(output));
+    func_args.arg(gen(input));
+    func_args.arg(genStaticCast(output->dtype(), genInline(init_val)));
+    func_args.arg(genInline(mbarrier));
+    if (current_group_reduction_id_ > 0) {
+      func_args.arg(
+          genStaticCast(genPtrType(output->dtype()), "shared_mem") + " + " +
+          std::to_string(
+              blocks_per_cluster * warps_per_block *
+              current_group_reduction_id_));
+    } else {
+      func_args.arg(genStaticCast(genPtrType(output->dtype()), "shared_mem"));
+    }
+    func_args.arg(genReductionOp(op_type, output->dtype()));
+    indent() << genCall("cluster::clusterReduce", template_args, func_args)
+             << ";\n";
+    current_group_reduction_id_++;
+  }
+
   void handle(const PreprocessGroupedMatmulInputSf* layout_op) final {
     const auto output = layout_op->out()->as<kir::TensorIndex>();
     const auto input = layout_op->in()->as<kir::TensorIndex>();
@@ -4550,6 +4600,8 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   int64_t next_barrier_id_ = 1;
   //! Track whether we are generating code for warp specialized computation loop
   bool is_within_warp_specialized_compute_loop_ = false;
+  //! Track current group reduction id
+  int64_t current_group_reduction_id_ = 0;
 };
 
 } // namespace

--- a/csrc/device_lower/analysis/fused_reduction.cpp
+++ b/csrc/device_lower/analysis/fused_reduction.cpp
@@ -107,10 +107,10 @@ class FusionInspector : private IterVisitor {
 
       return reduction_count == 1 && has_valid_tidx_reduction;
     };
+    bool is_cluster_reduction = out->domain()->hasClusterReduction();
     if (out->getMemoryType() == MemoryType::Local &&
         (is_static_warp_reduction(out, has_warp_specialization_) ||
-         out->domain()->hasGridReduction() ||
-         out->domain()->hasClusterReduction() ||
+         out->domain()->hasGridReduction() || is_cluster_reduction ||
          std::any_of(
              out->getLoopDomain().begin(),
              out->getLoopDomain().end(),
@@ -120,7 +120,7 @@ class FusionInspector : private IterVisitor {
       reduction_dep_[out].insert(rop);
     }
 
-    if (out->domain()->hasClusterReduction()) {
+    if (is_cluster_reduction) {
       cluster_reduction_count_++;
     }
   }

--- a/csrc/device_lower/lower2device.h
+++ b/csrc/device_lower/lower2device.h
@@ -298,6 +298,26 @@ class GpuLower : public NonCopyable {
     return id_model_options_;
   }
 
+  //! Get the cluster reduction count if set
+  int64_t clusterReductionCount() const {
+    return cluster_reduction_count_;
+  }
+
+  //! Set the cluster reduction count
+  void setClusterReductionCount(int64_t count) {
+    cluster_reduction_count_ = count;
+  }
+
+  //! Get the cluster reduction mbarrier tensor
+  TensorView* clusterReductionMBarrier() const {
+    return cluster_reduction_mbarrier_tensor_;
+  }
+
+  //! Set the cluster reduction mbarrier tensor
+  void setClusterReductionMBarrier(TensorView* mbarrier) {
+    cluster_reduction_mbarrier_tensor_ = mbarrier;
+  }
+
   //! Define an alias for consumer as producer.
   //!
   //! If producer is already aliased, we chase the alias. If there are tensors
@@ -407,6 +427,13 @@ class GpuLower : public NonCopyable {
 
   // A temporary option set to selectively enable IdModel usage
   IdModelOptions id_model_options_;
+
+  // Cluster reduction count for barrier insertion
+  int64_t cluster_reduction_count_ = -1;
+
+  // The shared cluster reduction mbarrier tensor allocated during allocation
+  // pass
+  TensorView* cluster_reduction_mbarrier_tensor_ = nullptr;
 };
 
 #define NVFUSER_LOWER_VALIDATE(cond, ...) \

--- a/csrc/device_lower/pass/allocation.cpp
+++ b/csrc/device_lower/pass/allocation.cpp
@@ -1231,6 +1231,62 @@ class AllocationInserter : public kir::ExprMutator {
     return alloc_expr;
   }
 
+  // Insert cluster reduction mbarrier allocation and initialization at the
+  // beginning of the kernel for the first top-level expression
+  void insertClusterReductionMBarrier(Expr* expr) {
+    int64_t cluster_reduction_count =
+        GpuLower::current()->clusterReductionCount();
+
+    // mbarrier for cluster reduction
+    // create and allocate a memory barrier
+    TensorView* all_mbarriers =
+        TensorViewBuilder()
+            .shape(std::vector<int64_t>{cluster_reduction_count})
+            .dtype(DataType::UInt64)
+            .contiguity(true)
+            .build();
+    all_mbarriers->setMemoryType(MemoryType::Shared);
+    kir::Allocate* mbarrier_alloc =
+        IrBuilder::create<kir::Allocate>(all_mbarriers, MemoryType::Shared);
+    registerInsertBefore(expr, mbarrier_alloc, nullptr);
+
+    if (cluster_reduction_count == 1) {
+      // For single mbarrier, use TensorView directly without loop
+      auto mbarrier_init = IrBuilder::create<kir::MBarrierInit>(
+          all_mbarriers,
+          simplifyExpr(SimplifyingIrBuilder::maybeCastExpr(
+              DataType::UInt32, GpuLower::current()->kernel()->oneVal())));
+      Expr* pred_mbarrier_init = mbarrier_init->withPredicate(
+          IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
+
+      registerInsertBefore(expr, pred_mbarrier_init, nullptr);
+    } else {
+      // For multiple mbarriers, create a for loop using the utility function
+      auto fl = ir_utils::createRangeLoop(cluster_reduction_count);
+      kir::TensorIndex* indexed_mbarrier =
+          IrBuilder::create<kir::TensorIndex>(all_mbarriers, fl->index());
+
+      auto mbarrier_init = IrBuilder::create<kir::MBarrierInit>(
+          indexed_mbarrier,
+          simplifyExpr(SimplifyingIrBuilder::maybeCastExpr(
+              DataType::UInt32, GpuLower::current()->kernel()->oneVal())));
+      Expr* pred_mbarrier_init = mbarrier_init->withPredicate(
+          IrBuilder::create<kir::Predicate>(PredicateType::ElectSync));
+
+      fl->body().push_back(pred_mbarrier_init);
+
+      registerInsertBefore(expr, fl, nullptr);
+    }
+
+    // Store the mbarrier in GpuLower for later use in cluster reduction ops
+    GpuLower::current()->setClusterReductionMBarrier(all_mbarriers);
+
+    // Insert clusterSync after mbarrier initialization to ensure mbarrier is
+    // visible to other CTAs
+    auto cluster_sync = IrBuilder::create<kir::ClusterSync>();
+    registerInsertBefore(expr, cluster_sync, nullptr);
+  }
+
   void dispatch(Expr* expr) override {
     if (!ir_utils::isTvOp(expr) || expr->isA<kir::Allocate>() ||
         expr->isA<kir::AllocTMem>()) {
@@ -1619,6 +1675,10 @@ class AllocationInserter : public kir::ExprMutator {
 
   AllocationInserter(const std::vector<Expr*>& exprs)
       : gpu_lower_(GpuLower::current()) {
+    // insert cluster reduction mbarrier at top-level scope
+    if (GpuLower::current()->clusterReductionCount() >= 1) {
+      insertClusterReductionMBarrier(exprs.at(0));
+    }
     kir::ExprMutator::traverseAndInsert(exprs);
   }
 

--- a/csrc/device_lower/pass/index.cpp
+++ b/csrc/device_lower/pass/index.cpp
@@ -8,6 +8,7 @@
 #include <device_lower/analysis/index_compute.h>
 #include <device_lower/analysis/tma.h>
 #include <device_lower/lower2device.h>
+#include <device_lower/utils.h>
 #include <id_model/schedule.h>
 #include <index_compute.h>
 #include <ir/iostream.h>
@@ -628,6 +629,7 @@ void IndexLowering::handle(const ReductionOp* rop) {
   const auto out_domain = out_tv->domain();
 
   const bool has_block_reduce = out_domain->hasBlockReduction();
+  const bool has_cluster_reduce = out_domain->hasClusterReduction();
   const bool has_grid_reduce = out_domain->hasGridReduction();
 
   const auto out = lowerDstIndex(rop->out());
@@ -635,6 +637,8 @@ void IndexLowering::handle(const ReductionOp* rop) {
 
   if (has_grid_reduce) {
     handleGridReduction(rop, out, in);
+  } else if (has_cluster_reduce) {
+    handleClusterReduction(rop, out, in);
   } else if (has_block_reduce) {
     handleBlockReduction(rop, out, in);
   } else {
@@ -662,6 +666,44 @@ void IndexLowering::handleBlockReduction(
   }
 
   pushBack(indexed_rop);
+  GpuLower::current()->propagateExprInfo(rop, back());
+}
+
+void IndexLowering::handleClusterReduction(
+    const ReductionOp* rop,
+    Val* out,
+    Val* in) {
+  NVF_ERROR(ir_utils::isTvOp(rop));
+
+  // cluster reduction is only supported for all-reduce
+  NVF_ERROR(
+      rop->isAllreduce(), "Cluster reduction is only supported for all-reduce");
+
+  // Get mbarrier allocated during allocation pass
+  auto cluster_mbarrier_tv = GpuLower::current()->clusterReductionMBarrier();
+  NVF_CHECK(
+      cluster_mbarrier_tv != nullptr,
+      "Cluster mbarrier must be allocated for cluster reductions");
+
+  // Index into mbarrier array for this reduction
+  auto mbarrier = IrBuilder::create<kir::TensorIndex>(
+      cluster_mbarrier_tv,
+      IrBuilder::create<Val>(current_cluster_index_, DataType::Index));
+  current_cluster_index_++;
+
+  // Convert mbarrier to shared memory address (similar to MBarrierInit)
+  Val* mbarrier_addr = lower_utils::u32IndexScalarSmemTv(mbarrier);
+
+  // Create ClusterReductionOp with lowered indices
+  auto cluster_reduction = IrBuilder::create<kir::ClusterReductionOp>(
+      out,
+      in,
+      rop->getReductionOpType(),
+      lowerSrcIndex(rop->init(), rop->out()),
+      mbarrier_addr,
+      /*is_all_reduce=*/true);
+
+  pushBack(cluster_reduction);
   GpuLower::current()->propagateExprInfo(rop, back());
 }
 
@@ -2667,6 +2709,11 @@ void IndexLowering::handle(const kir::BlockSync* sync) {
 void IndexLowering::handle(const kir::GridSync* sync) {
   // TODO(kir): remove the need for const_cast
   pushBack(const_cast<kir::GridSync*>(sync)); // NOLINT
+}
+
+void IndexLowering::handle(const kir::ClusterSync* sync) {
+  // TODO(kir): remove the need for const_cast
+  pushBack(const_cast<kir::ClusterSync*>(sync)); // NOLINT
 }
 
 void IndexLowering::handle(const kir::AsyncWait* wait) {

--- a/csrc/device_lower/pass/index.h
+++ b/csrc/device_lower/pass/index.h
@@ -78,6 +78,7 @@ class IndexLowering : private OptOutConstDispatch {
   void handle(const kir::AllocTMem*) final;
   void handle(const kir::BlockSync*) final;
   void handle(const kir::GridSync*) final;
+  void handle(const kir::ClusterSync*) final;
   void handle(const kir::FenceAsyncProxy*) final;
   void handle(const kir::WgMmaFence*) final;
   void handle(const kir::SetMaxNReg*) final;
@@ -134,6 +135,7 @@ class IndexLowering : private OptOutConstDispatch {
   //! Called by handleGridReduction, this returns true if rop is lowered as a
   //! serial grid reduction.
   void handleSerialGridReduction(const ReductionOp* rop, Val* out, Val* in);
+  void handleClusterReduction(const ReductionOp* rop, Val* out, Val* in);
 
   void handleBlockReduction(
       const GroupedReductionOp* rop,
@@ -203,6 +205,9 @@ class IndexLowering : private OptOutConstDispatch {
   std::unordered_map<TensorView*, kir::Allocate*> work_buffer_map_;
   std::unordered_map<TensorView*, kir::AllocateFusedReduction*>
       fused_reduction_map_;
+
+  // Track mbarrier index assignment for cluster reductions
+  int64_t current_cluster_index_ = 0;
 };
 
 } // namespace nvfuser

--- a/csrc/device_lower/utils.cpp
+++ b/csrc/device_lower/utils.cpp
@@ -791,7 +791,8 @@ bool hasBlockSync(const Expr* expr, const ThreadPredicateMap& pred_map) {
   auto tv = ir_utils::getTvOutput(expr);
 
   if (ir_utils::isReductionOp(expr) &&
-      (tv->hasBlockReduction() || tv->hasGridReduction())) {
+      (tv->hasBlockReduction() || tv->hasGridReduction() ||
+       tv->hasClusterReduction())) {
     return true;
   }
 

--- a/csrc/dispatch.h
+++ b/csrc/dispatch.h
@@ -128,6 +128,7 @@ class Val;
   f(Asm);                             \
   f(BlockSync);                       \
   f(GridSync);                        \
+  f(ClusterSync);                     \
   f(FenceAsyncProxy);                 \
   f(WgMmaFence);                      \
   f(SetMaxNReg);                      \
@@ -143,6 +144,7 @@ class Val;
   f(BlockSerializeRelease);           \
   f(AsyncWait);                       \
   f(AsyncCommit);                     \
+  f(ClusterReductionOp);              \
   f(ForLoop);                         \
   f(IfThenElse);                      \
   f(GridReduction);                   \

--- a/csrc/driver_api.h
+++ b/csrc/driver_api.h
@@ -77,7 +77,8 @@ namespace nvfuser {
 
 #if (CUDA_VERSION >= 11080)
 #define NVF_DRIVER_API_WRAPPER_CUDA_118(fn) \
-  fn(cuOccupancyMaxActiveClusters, 11080)
+  fn(cuOccupancyMaxActiveClusters, 11080);  \
+  fn(cuLaunchKernelEx, 11080)
 #else
 #define NVF_DRIVER_API_WRAPPER_CUDA_118(fn)
 #endif

--- a/csrc/ir/interface_nodes.h
+++ b/csrc/ir/interface_nodes.h
@@ -427,6 +427,10 @@ class NVF_API TensorView : public Val {
     return domain()->hasGridReduction();
   }
 
+  bool hasClusterReduction() const {
+    return domain()->hasClusterReduction();
+  }
+
   bool hasBroadcast() const {
     return domain()->hasBroadcast();
   }

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -58,7 +58,6 @@ class IterDomainBuilder {
   IterDomainBuilder& iter_type(IterType _iter_type);
   IterDomainBuilder& is_rfactor_domain(bool _is_rfactor_domain);
   IterDomainBuilder& is_padded_dimension(bool _is_padded_dimension);
-  IterDomainBuilder& is_clustered_blocks(bool _is_clustered_blocks);
   IterDomainBuilder& padded_to_size(std::optional<int64_t> _padded_to_size);
 
   IterDomain* build() const;

--- a/csrc/ir/internal_base_nodes.h
+++ b/csrc/ir/internal_base_nodes.h
@@ -309,11 +309,11 @@ class NVF_API IterDomain : public Val {
   }
 
   //! Sets whether this IterDomain uses CUDA thread block clusters (Hopper+).
-  void setClusteredBlocks(bool is_clustered_blocks) {
+  void setClusteredBlocks() {
     NVF_CHECK(
         parallel_type_ == ParallelType::BIDx,
         "setClusteredBlocks: only support set BIDx parallel type");
-    is_clustered_dimension_ = is_clustered_blocks;
+    is_clustered_dimension_ = true;
   }
 
   //! Returns whether this IterDomain uses clustered blocks.

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4745,8 +4745,7 @@ namespace {
 // Unsqueeze the rfactored DID axis to correctly bind with the logical domain.
 // See tests/python/test_multidevice.py/test_matmul_allreduce_loop_split
 int64_t getRFactorDeviceDimensionIndex(const TensorView* tv) {
-  // Filter out reduction dimensions so the index to `logical` directly maps
-  // to an at::Tensor axis.
+  // Filter out reduction dimensions so the index to `logical` directly maps to an at::Tensor axis.
   auto logical = TensorDomain::noReductions(tv->getLogicalDomain());
   int64_t rfactor_did_idx = -1;
   for (auto idx : arange(static_cast<int64_t>(logical.size()))) {

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4456,7 +4456,7 @@ std::string PadOp::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << out()->toString() << "\n";
   indent(ss, indent_size) << "   = pad( " << in()->toString() << ", {"
-                          << toDelimitedString(getPadWidths()) << "}" << " )\n";
+                          << toDelimitedString(getPadWidths()) << "} )\n";
   return ss.str();
 }
 

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -2573,12 +2573,6 @@ IterDomainBuilder& IterDomainBuilder::padded_to_size(
   return *this;
 }
 
-IterDomainBuilder& IterDomainBuilder::is_clustered_blocks(
-    bool _is_clustered_blocks) {
-  is_clustered_dimension_ = _is_clustered_blocks;
-  return *this;
-}
-
 IterDomain* IterDomainBuilder::build() const {
   NVF_ERROR(
       start_ != nullptr && extent_ != nullptr,

--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -4745,7 +4745,8 @@ namespace {
 // Unsqueeze the rfactored DID axis to correctly bind with the logical domain.
 // See tests/python/test_multidevice.py/test_matmul_allreduce_loop_split
 int64_t getRFactorDeviceDimensionIndex(const TensorView* tv) {
-  // Filter out reduction dimensions so the index to `logical` directly maps to an at::Tensor axis.
+  // Filter out reduction dimensions so the index to `logical` directly maps to
+  // an at::Tensor axis.
   auto logical = TensorDomain::noReductions(tv->getLogicalDomain());
   int64_t rfactor_did_idx = -1;
   for (auto idx : arange(static_cast<int64_t>(logical.size()))) {

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -167,6 +167,7 @@ class KernelIrScanner : private IrVisitor {
 
     // Update the largest smem data type
     if (domain->hasBlockReduction() || domain->hasGridReduction() ||
+        domain->hasClusterReduction() ||
         tv->getMemoryType() == MemoryType::Shared) {
       const auto data_type = tv->dtype();
       const size_t type_size = dataTypeSizeByte(data_type, index_type_);
@@ -216,6 +217,11 @@ class KernelIrScanner : private IrVisitor {
 
   void handle(ReductionOp* rop) final {
     checkWarpReduction(rop->out(), rop->in());
+  }
+
+  void handle(ClusterReductionOp* cop) final {
+    summary_.has_cluster_reduction = true;
+    summary_.all_block_reductions_are_warp_reduction = false;
   }
 
   void handle(GridReduction* grid_reduction) final {

--- a/csrc/kernel.h
+++ b/csrc/kernel.h
@@ -151,6 +151,8 @@ struct KernelSummary {
   //! Do we have any scan op?
   bool has_scan = false;
 
+  //! Do we have any clustered blocks?
+  bool has_cluster_reduction = false;
   //! Do the kernel need streamIdx?
   bool stream_parallelized = false;
 };

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -297,9 +297,10 @@ std::string disassembleBinary(
     // so I have to dump the stdin to a temp file and let nvdisasm read it. I am
     // hoping that nvdisasm will support reading from stdin one day.
     std::stringstream ss;
-    ss << "export PATH=$PATH:/usr/local/cuda/bin;" << "TMPFILE=$(mktemp);"
-       << "cat>$TMPFILE;" << "nvdisasm $TMPFILE " << nvdisasm_args
-       << "; rm $TMPFILE";
+    ss << "export PATH=$PATH:/usr/local/cuda/bin;"
+       << "TMPFILE=$(mktemp);"
+       << "cat>$TMPFILE;"
+       << "nvdisasm $TMPFILE " << nvdisasm_args << "; rm $TMPFILE";
     auto command = ss.str();
     execl("/bin/bash", "bash", "-c", command.c_str(), NULL);
 

--- a/csrc/runtime/compiled_kernel.cpp
+++ b/csrc/runtime/compiled_kernel.cpp
@@ -297,10 +297,9 @@ std::string disassembleBinary(
     // so I have to dump the stdin to a temp file and let nvdisasm read it. I am
     // hoping that nvdisasm will support reading from stdin one day.
     std::stringstream ss;
-    ss << "export PATH=$PATH:/usr/local/cuda/bin;"
-       << "TMPFILE=$(mktemp);"
-       << "cat>$TMPFILE;"
-       << "nvdisasm $TMPFILE " << nvdisasm_args << "; rm $TMPFILE";
+    ss << "export PATH=$PATH:/usr/local/cuda/bin;" << "TMPFILE=$(mktemp);"
+       << "cat>$TMPFILE;" << "nvdisasm $TMPFILE " << nvdisasm_args
+       << "; rm $TMPFILE";
     auto command = ss.str();
     execl("/bin/bash", "bash", "-c", command.c_str(), NULL);
 
@@ -1079,12 +1078,12 @@ std::string _getStructuredCode(
 
   code += defineStdComplex();
   code += std::string("namespace ") + CompiledKernel::kernelNamespace() +
-      "{\n" + defineTypes() + defineIndexType(index_type) + kernelPreamble();
+      "{\n" + defineTypes() + defineIndexType(index_type) + kernelPreamble() +
+      "} // namespace " + CompiledKernel::kernelNamespace() + "\n";
 
   if (has_cluster_reduction) {
     code += nvfuser_resources::cluster_cu;
   }
-  code += "} // namespace " + CompiledKernel::kernelNamespace() + "\n";
 
   // The following runtime namespaces are already nested in `nvf` namespace
   if (has_argsort || has_topk || has_scan) {

--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -1270,6 +1270,7 @@ KernelArgumentHolder KernelExecutor::run(
     const auto& kernel_summary = compiled_kernel_->kernel()->summary();
 
     // cluster reduction uses DSMEM
+    // TODO: CUDA11-CLEANUP, use cuLaunchKernelEx for cuLaunchCooperativeKernel
     if (kernel_summary.has_cluster_reduction) {
       FUSER_PERF_SCOPE("ExecutorRunFusion::cuLaunchKernelEx");
       CUlaunchConfig config = {};
@@ -1289,8 +1290,8 @@ KernelArgumentHolder KernelExecutor::run(
       attribute.value.clusterDim.z = 1;
       config.attrs = &attribute;
       config.numAttrs = 1;
-      // TO request more than 8 clusters, need to set non-portable cluster size
-      // allowed
+      // To request more than 8 CTAs per cluster, need to set non-portable
+      // cluster size allowed
       if (attribute.value.clusterDim.x > 8) {
         NVFUSER_CUDA_SAFE_CALL(cuFuncSetAttribute(
             compiled_kernel_->cudaExecutable()->function,

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -340,7 +340,7 @@ std::vector<IterDomain*> replayDomain(
     }
     if (propagate_clustered_blocks) {
       if (replay_id->isClusteredBlockDim()) {
-        target_id->setClusteredBlocks(true);
+        target_id->setClusteredBlocks();
       }
     }
     target_domain.push_back(target_id);

--- a/csrc/transform_rfactor.cpp
+++ b/csrc/transform_rfactor.cpp
@@ -311,7 +311,8 @@ std::vector<IterDomain*> replayDomain(
     const std::unordered_map<IterDomain*, IterDomain*>& replay_to_target_map,
     const std::unordered_set<IterDomain*>& ignore_ids = {},
     bool propagate_padding = false,
-    bool propagate_parallelization = false) {
+    bool propagate_parallelization = false,
+    bool propagate_clustered_blocks = false) {
   std::vector<IterDomain*> target_domain;
   target_domain.reserve(replay_domain.size());
   for (const auto& replay_id :
@@ -335,6 +336,11 @@ std::vector<IterDomain*> replayDomain(
     if (propagate_padding) {
       if (replay_id->hasPaddingToMultipleOfWarp()) {
         target_id->padToMultipleOfWarp(replay_id->getMaybeSizeAfterPadding());
+      }
+    }
+    if (propagate_clustered_blocks) {
+      if (replay_id->isClusteredBlockDim()) {
+        target_id->setClusteredBlocks(true);
       }
     }
     target_domain.push_back(target_id);
@@ -461,7 +467,8 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
       original_to_producer_id_map,
       /*ignore_ids=*/{},
       /*propagate_padding=*/true,
-      /*propagate_parallelization=*/true);
+      /*propagate_parallelization=*/true,
+      /*propagate_clustered_blocks=*/true);
 
   // Specify the logical domain of the producer which will match the consumer
   // root domain.
@@ -472,7 +479,8 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
       original_to_producer_id_map,
       /*ignore_ids=*/{},
       /*propagate_padding=*/false,
-      /*propagate_parallelization=*/false);
+      /*propagate_parallelization=*/false,
+      /*propagate_clustered_blocks=*/false);
 
   auto* producer_domain = IrBuilder::createInContainer<TensorDomain>(
       original_td->container(),
@@ -534,7 +542,8 @@ std::pair<TensorDomain*, TensorDomain*> TransformRFactor::runReplay(
       original_to_consumer_map,
       /*ignore_ids=*/rfactor_axes,
       /*propagate_padding=*/true,
-      /*propagate_parallelization=*/true);
+      /*propagate_parallelization=*/true,
+      /*propagate_clustered_blocks=*/true);
 
   auto consumer_domain = IrBuilder::createInContainer<TensorDomain>(
       original_td->container(),

--- a/runtime/cluster.cu
+++ b/runtime/cluster.cu
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+namespace nvf {
 namespace cluster {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
@@ -200,3 +201,4 @@ __device__ __forceinline__ void clusterReduce(
 }
 #endif // Arch 90
 } // namespace cluster
+} // namespace nvf

--- a/tests/cpp/test_cluster.cpp
+++ b/tests/cpp/test_cluster.cpp
@@ -54,7 +54,7 @@ TEST_F(ClusterReductionTest, ManusalScheduledSimpleFusion) {
   tv2->axis(-2)->parallelize(ParallelType::TIDx);
   tv2->axis(-3)->parallelize(ParallelType::BIDx);
   // set clustered blocks to use cluster reduction
-  tv2->axis(-3)->setClusteredBlocks(true);
+  tv2->axis(-3)->setClusteredBlocks();
   tv2->axis(0)->parallelize(ParallelType::BIDy);
 
   auto reference = tv2->rFactor({-1, -4});

--- a/tests/cpp/test_cluster.cpp
+++ b/tests/cpp/test_cluster.cpp
@@ -1,0 +1,78 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <gtest/gtest.h>
+
+#include <logical_domain_map.h>
+#include <ops/all_ops.h>
+#include <scheduler/all_schedulers.h>
+#include <scheduler/utils.h>
+#include <tests/cpp/utils.h>
+#include <tests/cpp/validator.h>
+#include "type.h"
+
+namespace nvfuser {
+
+class ClusterReductionTest : public NVFuserTest {
+ protected:
+  void SetUp() override {
+    NVFuserTest::SetUp();
+    NVFUSER_TEST_CUDA_ARCH_GUARD(9, 0);
+  }
+};
+
+TEST_F(ClusterReductionTest, ManusalScheduledSimpleFusion) {
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto& fusion = *fusion_ptr;
+  FusionGuard fg(fusion_ptr.get());
+  const int64_t vect = 8, bdimx = 128, persistent_batch = 2;
+  const int64_t cluster_size = 8;
+  const int64_t reduction_size = vect * bdimx * persistent_batch * cluster_size;
+  DataType dtype = DataType::BFloat16;
+  auto tv0 = makeContigTensor(2, dtype);
+  fusion.addInput(tv0);
+  auto tv1 = maybeCastOp(DataType::Float, tv0);
+  auto tv2 = sum(tv1, {1});
+  auto tv3 = broadcast(tv2, {false, true});
+  auto tv4 = add(tv1, tv3);
+  auto tv5 = maybeCastOp(DataType::BFloat16, tv4);
+  fusion.addOutput(tv5);
+  auto unscheduled_fusion_copy = fusion;
+
+  // [I, R]
+  tv2->split(1, 8);
+  // [I, R/8, 8]
+  tv2->split(1, 128);
+  // [I, R/8/128, 128, 8]
+  tv2->split(1, 2, false);
+  // [I, 2, R/8/128/2, 128, 8]
+  // [BIDy, Serial, BIDx(cluster), TIDx, Vectorize for IO]
+  tv2->axis(-2)->parallelize(ParallelType::TIDx);
+  tv2->axis(-3)->parallelize(ParallelType::BIDx);
+  tv2->axis(-3)->setClusteredBlocks(true);
+  tv2->axis(0)->parallelize(ParallelType::BIDy);
+
+  auto reference = tv2->rFactor({-1, -4});
+
+  TransformPropagatorWithCheck propagator(reference);
+  MaxLogicalDomainInfoSpanningTree(reference).traverse(&propagator);
+  scheduler_utils::parallelizeAllLike(reference);
+
+  tv1->axis(-1)->parallelize(ParallelType::Vectorize);
+  tv5->axis(-1)->parallelize(ParallelType::Vectorize);
+
+  auto options =
+      at::TensorOptions().dtype(data_type_to_aten(dtype)).device(at::kCUDA, 0);
+  auto t0 = at::randn({256, reduction_size}, options);
+
+  KernelExecutor ke;
+  ke.compile(fusion_ptr.get(), {t0});
+  auto outputs = ke.run({t0});
+  testValidate(&unscheduled_fusion_copy, outputs, {t0});
+}
+
+} // namespace nvfuser

--- a/tests/cpp/test_cluster.cpp
+++ b/tests/cpp/test_cluster.cpp
@@ -25,7 +25,7 @@ class ClusterReductionTest : public NVFuserTest {
   }
 };
 
-TEST_F(ClusterReductionTest, ManusalScheduledSimpleFusion) {
+TEST_F(ClusterReductionTest, ManualScheduledSimpleFusion) {
   auto fusion_ptr = std::make_unique<Fusion>();
   auto& fusion = *fusion_ptr;
   FusionGuard fg(fusion_ptr.get());

--- a/tests/cpp/test_cluster.cpp
+++ b/tests/cpp/test_cluster.cpp
@@ -4,8 +4,11 @@
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  */
-// clang-format on
+// clang-format off
 #include <gtest/gtest.h>
+#include <memory>
+#include <tuple>
+#include <sstream>
 
 #include <logical_domain_map.h>
 #include <ops/all_ops.h>
@@ -17,7 +20,11 @@
 
 namespace nvfuser {
 
-class ClusterReductionTest : public NVFuserTest {
+using TestParam = std::tuple<int64_t, DataType>;
+
+class ClusterReductionTest
+    : public NVFuserTest,
+      public ::testing::WithParamInterface<TestParam> {
  protected:
   void SetUp() override {
     NVFuserTest::SetUp();
@@ -25,21 +32,24 @@ class ClusterReductionTest : public NVFuserTest {
   }
 };
 
-TEST_F(ClusterReductionTest, ManualScheduledSimpleFusion) {
+TEST_P(ClusterReductionTest, ManualScheduledSimpleFusion) {
   auto fusion_ptr = std::make_unique<Fusion>();
   auto& fusion = *fusion_ptr;
   FusionGuard fg(fusion_ptr.get());
-  const int64_t vect = 8, bdimx = 128, persistent_batch = 2;
-  const int64_t cluster_size = 8;
+  const int64_t vect = 2, bdimx = 128, persistent_batch = 2;
+  const auto [cluster_size, dtype] = GetParam();
   const int64_t reduction_size = vect * bdimx * persistent_batch * cluster_size;
-  DataType dtype = DataType::BFloat16;
   auto tv0 = makeContigTensor(2, dtype);
   fusion.addInput(tv0);
-  auto tv1 = maybeCastOp(DataType::Float, tv0);
+  auto tv1 = set(tv0);
+  const DataType compute_dtype =
+      (dtype == DataType::Double) ? DataType::Double : DataType::Float;
+  tv1 = maybeCastOp(compute_dtype, tv1);
   auto tv2 = sum(tv1, {1});
   auto tv3 = broadcast(tv2, {false, true});
   auto tv4 = add(tv1, tv3);
-  auto tv5 = maybeCastOp(DataType::BFloat16, tv4);
+  tv4 = maybeCastOp(dtype, tv4);
+  auto tv5 = set(tv4);
   fusion.addOutput(tv5);
   auto unscheduled_fusion_copy = fusion;
 
@@ -76,5 +86,19 @@ TEST_F(ClusterReductionTest, ManualScheduledSimpleFusion) {
   EXPECT_TRUE(ke.compiledKernel()->kernel()->summary().has_cluster_reduction);
   testValidate(&unscheduled_fusion_copy, outputs, {t0});
 }
-
+INSTANTIATE_TEST_SUITE_P(
+    ,
+    ClusterReductionTest,
+    ::testing::Combine(
+        ::testing::Range<int64_t>(2, 17),
+        ::testing::Values(
+            DataType::BFloat16,
+            DataType::Float,
+            DataType::Double)),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      std::stringstream ss;
+      ss << "cluster_" << std::get<0>(info.param);
+      ss << "_dtype_" << std::get<1>(info.param);
+      return sanitizeTestName(ss.str());
+    });
 } // namespace nvfuser


### PR DESCRIPTION
### Cluster reductions: IR, lowering, codegen, and runtime support

**Summary**

- End-to-end support for clustered (multi-block) reductions across IR, lowering, codegen, and runtime. 
- Not pluged into scheduler yet, can only be used by manual schedule, see test.

**Key changes**
- IR: Extend `IterDomain` to represent clustered blocks.
- Lowering: Detect and convert `ReductionOp` to `ClusterReductionOp`, allocate and plug `mbarriers` and `cluster syncs`
- Codegen: translate `ClusterReductionOp` to runtime function call.
- Runtime:  launch via `cuLaunchKernelEx`

**Tests**
- Add `tests/cpp/test_cluster.cpp` to test scheduling, lowering, codegen, and execution.

**Follow ups**
(1) revise scheduler to auto select cluster reduction
(2) More tests with auto schedule
(3) Python API test