### PR TITLE
Adopt Signed Axes

### DIFF
--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -97,7 +97,7 @@ NVF_API TensorView* binaryOp(
 // Return a new TensorView consistent with reducing `tv` on specified `axes`
 NVF_API TensorView* newForReduction(
     TensorView* tv,
-    const std::vector<unsigned int>& axes,
+    const std::vector<int64_t>& axes,
     DataType data_type = DataType::Null);
 
 // Perform a reduction operation on v1, initial value for reduction is init,

--- a/csrc/ops/utils.cpp
+++ b/csrc/ops/utils.cpp
@@ -620,16 +620,17 @@ Val* getMaximumValue(DataType v) {
   return nullptr;
 }
 
-std::vector<unsigned int> canonicalizeAxes(
+std::vector<int64_t> canonicalizeAxes(
     const std::vector<int64_t>& axes,
     int64_t ndims) {
-  std::vector<unsigned int> uint_axes;
-  uint_axes.reserve(axes.size());
+  std::vector<int64_t> canonicalized_axes;
+  canonicalized_axes.reserve(axes.size());
   std::transform(
-      axes.begin(), axes.end(), std::back_inserter(uint_axes), [&](int axis) {
-        return (unsigned int)wrapDim(axis, ndims);
-      });
-  return uint_axes;
+      axes.begin(),
+      axes.end(),
+      std::back_inserter(canonicalized_axes),
+      [&](int64_t axis) { return wrapDim(axis, ndims); });
+  return canonicalized_axes;
 }
 
 Val* binOpIdentity(BinaryOpType op_type, DataType dtype) {

--- a/csrc/ops/utils.h
+++ b/csrc/ops/utils.h
@@ -125,7 +125,7 @@ Val* getMinimumValue(DataType v);
 //   true for bool.
 Val* getMaximumValue(DataType v);
 
-std::vector<unsigned int> canonicalizeAxes(
+std::vector<int64_t> canonicalizeAxes(
     const std::vector<int64_t>& axes,
     int64_t ndims);
 


### PR DESCRIPTION
https://google.github.io/styleguide/cppguide.html#Integer_Types => "On Unsigned Integers"

Summary

- Retool canonicalizeAxes and all reduction/Welford/MMA helpers to operate on std::vector<int64_t> so axis handling stays in signed space.
- Update API signatures and call sites to the new canonicalized_axes, replacing unsigned casts with std::ssize/arange loops and tightening the helper logic.
- Simplify broadcast/reduction bookkeeping (e.g., Welford, MMA) to consume the signed axes directly while keeping existing safety guarantees.