### PR TITLE
Fix missing params in sameAs for reduction/pointwise params

### DIFF
--- a/csrc/scheduler/pointwise_heuristic.h
+++ b/csrc/scheduler/pointwise_heuristic.h
@@ -65,13 +65,14 @@ class PointwiseParams : public HeuristicParams {
       return false;
     }
     bool attr_equal = other->cparams == cparams &&
-        other->vectorization_factor == vectorization_factor &&
         other->break_point == break_point &&
         other->split_block == split_block &&
         other->split_grid_y_dim == split_grid_y_dim &&
+        other->flip_grid_binding == flip_grid_binding &&
+        other->vectorization_factor == vectorization_factor &&
+        other->vectorize_casts == vectorize_casts &&
         other->unroll_factor_outer == unroll_factor_outer &&
-        other->unroll_factor_inner == unroll_factor_inner &&
-        other->flip_grid_binding == flip_grid_binding;
+        other->unroll_factor_inner == unroll_factor_inner;
     return attr_equal;
   }
 

--- a/csrc/scheduler/reduction_heuristic.h
+++ b/csrc/scheduler/reduction_heuristic.h
@@ -198,6 +198,7 @@ class ReductionParams : public HeuristicParams {
         other->cross_grid_inner_reduction == cross_grid_inner_reduction &&
         other->unroll_factor_inner_reduction == unroll_factor_inner_reduction &&
         other->vectorize_inner_reduction == vectorize_inner_reduction &&
+        other->vectorize_casts == vectorize_casts &&
         other->split_grid_dim_inner_reduction ==
             split_grid_dim_inner_reduction &&
         other->pad_inner_reduction_to_warp == pad_inner_reduction_to_warp &&
@@ -220,6 +221,7 @@ class ReductionParams : public HeuristicParams {
         other->combined_inner_outer == combined_inner_outer &&
         other->tidx_for_outer_reduction == tidx_for_outer_reduction &&
         other->pad_outer_reduction_to_warp == pad_outer_reduction_to_warp &&
+        other->computation_warp_groups == computation_warp_groups &&
         other->vectorization_factor_outer == vectorization_factor_outer &&
         other->combined_split_grid_inner_dim == combined_split_grid_inner_dim &&
         other->unroll_factor_top_of_vectorization ==
@@ -227,9 +229,10 @@ class ReductionParams : public HeuristicParams {
         other->vectorization_factor_tmp_gmem_write ==
             vectorization_factor_tmp_gmem_write &&
         other->tma_warp_specialized == tma_warp_specialized &&
-        other->is_non_circular_buffer_gmem_to_regs ==
-            is_non_circular_buffer_gmem_to_regs &&
-        other->is_circular_buffer_regs_cached == is_circular_buffer_regs_cached;
+        other->is_good_ws_heuristic == is_good_ws_heuristic &&
+        other->is_circular_buffer_regs_cached ==
+            is_circular_buffer_regs_cached &&
+        other->circular_buffer_options == circular_buffer_options;
 
     if (other->static_bdimy || static_bdimy) {
       attr_equal = attr_equal && other->lparams.bdimy() == lparams.bdimy();

--- a/csrc/scheduler/reduction_heuristic.h
+++ b/csrc/scheduler/reduction_heuristic.h
@@ -230,6 +230,8 @@ class ReductionParams : public HeuristicParams {
             vectorization_factor_tmp_gmem_write &&
         other->tma_warp_specialized == tma_warp_specialized &&
         other->is_good_ws_heuristic == is_good_ws_heuristic &&
+        other->is_non_circular_buffer_gmem_to_regs ==
+            is_non_circular_buffer_gmem_to_regs &&
         other->is_circular_buffer_regs_cached ==
             is_circular_buffer_regs_cached &&
         other->circular_buffer_options == circular_buffer_options;


### PR DESCRIPTION
This form of bug can lead to inadvertently re-using a suboptimal kernel in dynamic shape contexts.

Note: these were found by Claude Code while I was asking it to summarize all of the heuristic param functionality. I didn't ask it to find these issues.