### PR TITLE
Extend max range in Cuda IPC P2P Benchmark

### DIFF
--- a/benchmarks/cpp/p2p_communication.cpp
+++ b/benchmarks/cpp/p2p_communication.cpp
@@ -24,9 +24,9 @@ namespace nvfuser {
 
 void benchmarkP2PCommunication() {
   // Test powers of 2 tensor sizes from 2^10 to 2^32
-  std::vector<long> tensor_sizes;
+  std::vector<int64_t> tensor_sizes;
   for (int power = 10; power <= 32; power++) {
-    tensor_sizes.push_back(1L << power);
+    tensor_sizes.push_back(1LL << power);
   }
 
   static constexpr int kNumRepetitions = 100;
@@ -106,7 +106,7 @@ void benchmarkP2PCommunication() {
   hir::HostIrEvaluator executor(std::move(container), communicator);
 
   // Test each tensor size
-  for (long current_tensor_size : tensor_sizes) {
+  for (int64_t current_tensor_size : tensor_sizes) {
     // Create tensors
     at::TensorOptions tensor_options =
         at::TensorOptions().device(at::kCUDA, my_rank);

--- a/benchmarks/cpp/p2p_communication.cpp
+++ b/benchmarks/cpp/p2p_communication.cpp
@@ -23,10 +23,10 @@
 namespace nvfuser {
 
 void benchmarkP2PCommunication() {
-  // Test powers of 2 tensor sizes from 2^10 to 2^26
-  std::vector<int> tensor_sizes;
-  for (int power = 10; power <= 26; power++) {
-    tensor_sizes.push_back(1 << power);
+  // Test powers of 2 tensor sizes from 2^10 to 2^32
+  std::vector<long> tensor_sizes;
+  for (int power = 10; power <= 32; power++) {
+    tensor_sizes.push_back(1L << power);
   }
 
   static constexpr int kNumRepetitions = 100;
@@ -106,9 +106,7 @@ void benchmarkP2PCommunication() {
   hir::HostIrEvaluator executor(std::move(container), communicator);
 
   // Test each tensor size
-  for (size_t size_idx = 0; size_idx < tensor_sizes.size(); size_idx++) {
-    const int current_tensor_size = tensor_sizes[size_idx];
-
+  for (long current_tensor_size : tensor_sizes) {
     // Create tensors
     at::TensorOptions tensor_options =
         at::TensorOptions().device(at::kCUDA, my_rank);


### PR DESCRIPTION
I merged the previous PR before realizing that I should extend the max tensor size in the benchmark to saturate NVLink bandwidth. After extending, the BiBW tops out at 748, which is 95% of the SOL measured in the NVBandwidth benchmark performance.

```
root@dgx-gaia-15:/opt/Fuser# mpirun -np 2 -H dgx-gaia-15:2 ./python/build/nvfuser_p2p_communication_bench
Starting P2P communication benchmark...
Repetitions per size: 100
Number of devices: 2

Message Size   Elements    Latency (μs)  BiBandwidth (GB/s)
------------------------------------------------------------
4 KB           1024        61.56          0.13
8 KB           2048        90.05          0.18
16 KB          4096        92.01          0.36
32 KB          8192        75.09          0.87
65 KB          16384       67.61          1.94
131 KB         32768       75.90          3.45
262 KB         65536       67.93          7.72
524 KB         131072      67.47          15.54
1 MB           262144      67.72          30.97
2 MB           524288      68.25          61.45
4 MB           1048576     161.25         52.02
8 MB           2097152     67.40          248.90
16 MB          4194304     88.42          379.49
33 MB          8388608     133.02         504.51
67 MB          16777216    227.31         590.47
134 MB         33554432    464.59         577.79
268 MB         67108864    766.53         700.39
536 MB         134217728   1474.19        728.36
1073 MB        268435456   2900.30        740.44
2147 MB        536870912   5785.90        742.32
4294 MB        1073741824  11472.88       748.72
8589 MB        2147483648  22978.59       747.65
17179 MB       4294967296  45979.86       747.28
------------------------------------------------------------
```