### PR TITLE
Migrate `Tutorial.BasicTMA` to direct bindings

### DIFF
--- a/python/python_direct/enum.cpp
+++ b/python/python_direct/enum.cpp
@@ -68,6 +68,27 @@ void bindEnums(py::module& nvfuser) {
       .value("expr_eval", SchedulerType::ExprEval)
       .value("resize", SchedulerType::Resize);
 
+  //! LoadStoreOpType used for scheduling
+  py::enum_<LoadStoreOpType>(nvfuser, "LoadStoreOpType")
+      .value("set", LoadStoreOpType::Set)
+      .value("load_matrix", LoadStoreOpType::LdMatrix)
+      .value("cp_async", LoadStoreOpType::CpAsync)
+      .value("tma", LoadStoreOpType::CpAsyncBulkTensorTile);
+
+  //! MemoryType used for scheduling
+  py::enum_<MemoryType>(nvfuser, "MemoryType")
+      .value("tensor", MemoryType::Tensor)
+      .value("local", MemoryType::Local)
+      .value("shared", MemoryType::Shared)
+      .value("global", MemoryType::Global);
+
+  //! CacheOp used for scheduling
+  py::enum_<CacheOp>(nvfuser, "CacheOp")
+      .value("unspecified", CacheOp::Unspecified)
+      .value("all_levels", CacheOp::AllLevels)
+      .value("streaming", CacheOp::Streaming)
+      .value("global", CacheOp::Global);
+
   py::enum_<IdMappingMode>(nvfuser, "IdMappingMode")
       .value("exact", IdMappingMode::EXACT)
       .value("almost_exact", IdMappingMode::ALMOSTEXACT)

--- a/python/python_direct/heuristic_params.cpp
+++ b/python/python_direct/heuristic_params.cpp
@@ -16,6 +16,7 @@ namespace nvfuser::python {
 void bindHeuristicParams(py::module& nvfuser) {
   py::class_<LaunchParams> launch_parameters(
       nvfuser, "LaunchParams", py::module_local());
+  launch_parameters.def(py::init<>());
   launch_parameters.def(
       py::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>());
   launch_parameters.def(
@@ -25,56 +26,132 @@ void bindHeuristicParams(py::module& nvfuser) {
       [](LaunchParams& self) { return self.bdimx(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::TIDx);
-      });
+      },
+      R"(
+          The number of threads in the x dimension of the block.
+      )");
   launch_parameters.def_property(
       "bdimy",
       [](LaunchParams& self) { return self.bdimy(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::TIDy);
-      });
+      },
+      R"(
+          The number of threads in the y dimension of the block.
+      )");
   launch_parameters.def_property(
       "bdimz",
       [](LaunchParams& self) { return self.bdimz(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::TIDz);
-      });
+      },
+      R"(
+          The number of threads in the z dimension of the block.
+      )");
   launch_parameters.def_property(
       "gdimx",
       [](LaunchParams& self) { return self.gdimx(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::BIDx);
-      });
+      },
+      R"(
+          The number of threads in the x dimension of the grid.
+      )");
   launch_parameters.def_property(
       "gdimy",
       [](LaunchParams& self) { return self.gdimy(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::BIDy);
-      });
+      },
+      R"(
+          The number of threads in the y dimension of the grid.
+      )");
   launch_parameters.def_property(
       "gdimz",
       [](LaunchParams& self) { return self.gdimz(); },
       [](LaunchParams& self, int64_t val) {
         self.bindUnsafe(val, ParallelType::BIDz);
-      });
+      },
+      R"(
+          The number of threads in the z dimension of the grid.
+      )");
 
-#define DEFINECLASS(type) py::class_<type>(nvfuser, #type, py::module_local())
+  py::class_<CompileParams> compile_parameters(
+      nvfuser, "CompileParams", py::module_local());
+  compile_parameters.def(
+      py::init([](std::optional<PrimDataType> index_type,
+                  int64_t maxrregcount,
+                  bool enable_magic_zero,
+                  bool enable_ptxas_verbose,
+                  std::optional<c10::Device> device,
+                  std::vector<std::string> include_paths) {
+        return CompileParams(
+            index_type,
+            maxrregcount,
+            enable_magic_zero,
+            enable_ptxas_verbose,
+            device,
+            include_paths);
+      }),
+      py::kw_only(),
+      py::arg("index_type") = py::none(),
+      py::arg("maxrregcount") = 255,
+      py::arg("enable_magic_zero") = true,
+      py::arg("enable_ptxas_verbose") = false,
+      py::arg("device") = py::none(),
+      py::arg("include_paths") = py::list(),
+      R"(
+              Parameters
+              ----------
+              index_type : PrimDataType, optional
+                The index type to use for the kernel.
+              maxrregcount : int, optional
+                The maximum number of registers to use for the kernel.
+              enable_magic_zero : bool, optional
+                Whether to enable magic zero for the kernel.
+              enable_ptxas_verbose : bool, optional
+                Whether to enable verbose output for the kernel.
+              device : c10::Device, optional
+                The device to use for the kernel.
+              include_paths : list of str, optional
+                The additional include paths to use for the kernel.
 
-#define TOSTRINGTOPLEVEL(type) \
-  def("__repr__", [](const type& self) { return toString(self); })
-#define TOSTRINGMETHOD(type) \
-  def("__repr__", [](const type& self) { return self.toString(); })
-
-#define PARAM(internal_type, name) def_readwrite(#name, &internal_type::name)
-
-  DEFINECLASS(CompileParams)
-      .PARAM(CompileParams, index_type)
-      .PARAM(CompileParams, maxrregcount)
-      .PARAM(CompileParams, enable_magic_zero)
-      .PARAM(CompileParams, enable_ptxas_verbose)
-      .TOSTRINGMETHOD(CompileParams);
-
-#undef PARAM
-#undef INITPARAMS
+              Returns
+              -------
+              CompileParams
+                The parameters used to compile a kernel with NVRTC.
+            )");
+  compile_parameters.def(
+      "__repr__", [](const CompileParams& self) { return self.toString(); });
+  compile_parameters.def_readwrite("index_type", &CompileParams::index_type, R"(
+                The index type to use for the kernel.
+              )");
+  compile_parameters.def_readwrite(
+      "maxrregcount", &CompileParams::maxrregcount, R"(
+                The maximum number of registers to use for the kernel.
+              )");
+  compile_parameters.def_readwrite(
+      "enable_magic_zero", &CompileParams::enable_magic_zero, R"(
+                Whether to enable magic zero for the kernel.
+              )");
+  compile_parameters.def_readwrite(
+      "enable_ptxas_verbose", &CompileParams::enable_ptxas_verbose, R"(
+                Whether to enable verbose output for the kernel.
+              )");
+  compile_parameters.def_readwrite("device", &CompileParams::device, R"(
+                The device to use for the kernel.
+              )");
+  compile_parameters.def_readwrite(
+      "include_paths", &CompileParams::include_paths, R"(
+                The additional include paths to use for the kernel.
+              )");
+  compile_parameters.def_readwrite("device", &CompileParams::device, R"(
+                The device to use for the kernel.
+              )");
+  compile_parameters.def_readwrite(
+      "include_paths", &CompileParams::include_paths, R"(
+                The additional include paths to use for the kernel.
+              )");
 }
 
 } // namespace nvfuser::python

--- a/python/python_direct/ir.cpp
+++ b/python/python_direct/ir.cpp
@@ -385,6 +385,26 @@ TensorView
     A TensorView with the merged axes in its loop domain.
 )")
       .def(
+          "reorder",
+          [](TensorView* self, std::unordered_map<int64_t, int64_t>& old2new) {
+            return self->reorder(old2new);
+          },
+          py::arg("old2new") = py::dict(),
+          py::return_value_policy::reference,
+          R"(
+Reorder the axes of this tensor.
+
+Parameters
+----------
+old2new : dict of int to int
+    The new order of the axes.
+
+Returns
+-------
+TensorView
+    A TensorView with the reordered axes in its loop domain.
+)")
+      .def(
           "rfactor",
           static_cast<TensorView* (TensorView::*)(const std::vector<int64_t>&)>(
               &TensorView::rFactor),

--- a/python/python_direct/ir.cpp
+++ b/python/python_direct/ir.cpp
@@ -279,6 +279,63 @@ list of IterDomain
     The root iteration domains.
 )")
       .def(
+          "cache_after",
+          &TensorView::cacheAfter,
+          py::arg("op_type") = LoadStoreOpType::Set,
+          py::arg("cache_op") = CacheOp::Unspecified,
+          py::arg("propagate_allocation_domain") = true,
+          py::arg("cached_uses") = py::list(),
+          py::return_value_policy::reference,
+          R"(
+      Cache the TensorView after the specified operation.
+
+      Parameters
+      ----------
+      op_type : LoadStoreOpType, optional
+          The type of load/store operation (default: Set).
+      cache_op : CacheOp, optional
+          The type of cache operation (default: Unspecified).
+
+      Returns
+      -------
+      TensorView
+          The new cached TensorView.
+    )")
+      .def(
+          "cache_before",
+          &TensorView::cacheBefore,
+          py::arg("op_type") = LoadStoreOpType::Set,
+          py::return_value_policy::reference,
+          R"(
+      Cache the TensorView before the specified operation.
+
+      Parameters
+      ----------
+      op_type : LoadStoreOpType, optional
+          The type of load/store operation (default: Set).
+
+      Returns
+      -------
+      TensorView
+          The new cached TensorView.
+    )")
+      .def(
+          "set_memory_type",
+          &TensorView::setMemoryType,
+          py::arg("memory_type"),
+          R"(
+      Set the memory type for the TensorView.
+
+      Parameters
+      ----------
+      memory_type : MemoryType
+          The memory type to set.
+
+      Returns
+      -------
+      None
+    )")
+      .def(
           "split",
           static_cast<TensorView* (TensorView::*)(int64_t, int64_t, bool)>(
               &TensorView::split),

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -755,3 +755,88 @@ def test_tutorial_basic_tma_example2(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0], compile_params=index32bit)
     outputs = ke.run([t0])
     assert outputs[0].equal(t0)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_basic_tma_example3(nvfuser_direct_test):
+    """
+    Example 3:
+     Similar to example 2, we treat the fusion as 1D and use 1D TMA to load data
+     to shared memory. 4 TMA instructions are used to load the entire CTA tile.
+     However, instead of using a for loop to launch these 4 instructions, we
+     parallelize these 4 instructions to TIDx.
+     CTA tile size = 4 * TMA tile size = 1024
+    """
+
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True])
+        output = fd.ops.set(input)
+        fd.add_output(output)
+
+        smem_cache = input.cache_after(LoadStoreOpType.tma)
+        smem_cache.set_memory_type(MemoryType.shared)
+
+        # For TMA load, both the shared memory layout and the loop nest and
+        # parallelization of TMA are specified by the consumer: smem_cache
+
+        # Step 1: define TMA domain
+        # Because we want to treat the entire tensor as 1D, we define the TMA
+        # domain as [I0*I1*I2]
+        smem_cache.merge(0, 1)
+        smem_cache.merge(0, 1)
+        # Note that the TMA domain only exist in people's mind, there is no need to
+        # set anything here.
+
+        # Step 2: define box
+        smem_cache.split(0, 256)
+        # [I0*I1*I2/256, 256]
+        # partitioned IterDomain: I0*I1*I2
+        # coordinate IterDomain: I0*I1*I2/256
+        # box IterDomain: 256
+
+        # Step 3: define tile
+        # We use dense tile here, so tile == box. Nothing to do here.
+
+        # Step 4: schedule the shared memory tensor
+        # By default, the allocation domain is the logical domain, which is already
+        # in good shape for this case.
+
+        # Step 5: schedule the consumer tensor
+        smem_cache.split(0, 4)
+        # [I0*I1*I2/256/4, 4, 256]
+        smem_cache.axis(0).parallelize(ParallelType.grid_x)
+        smem_cache.axis(1).parallelize(ParallelType.block_x)
+        smem_cache.axis(2).parallelize(ParallelType.tma)
+        # [BIDx, TIDx, Bulk]
+
+        # Schedule the smem->gmem part
+        output.merge(0, 1)
+        output.merge(0, 1)
+        output.split(0, 256)
+        output.split(0, 4)
+        output.axis(0).parallelize(ParallelType.grid_x)
+        output.axis(2).parallelize(ParallelType.block_x)
+
+        if verbose_:
+            print(fd.fusion.print_math())
+            print(fd.fusion.print_kernel())
+            # TMA will be generated like:
+            # Note that the coordinate is in number of items, smem address is in
+            # bytes
+            #
+            # if (threadIdx.x < 4) {
+            #   Hopper::cpAsyncBulkTensorTileG2S(
+            #       coordinate = {1024 * blockIdx.x + 256 * threadIdx.x},
+            #       smem_addr = (toSmem(T2) + 1024 * threadIdx.x));
+            # }
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(5, 3, 300, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0)

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -670,3 +670,88 @@ def test_tutorial_basic_tma_example1(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0], compile_params=index32bit)
     outputs = ke.run([t0])
     assert outputs[0].equal(t0)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_basic_tma_example2(nvfuser_direct_test):
+    """
+    Example 2:
+     Similar to example 1, we treat the fusion as 1D and uses 1D TMA to load
+     data to shared memory. But this time, instead of using 1 TMA instruction
+     to load the entire CTA tile, we use 4 TMA instructions. We use a for loop
+     to launch these 4 instructions
+     CTA tile size = 4 * TMA tile size = 1024
+    """
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True])
+        output = fd.ops.set(input)
+        fd.add_output(output)
+
+        smem_cache = input.cache_after(LoadStoreOpType.tma)
+        smem_cache.set_memory_type(MemoryType.shared)
+
+        # For TMA load, both the shared memory layout and the loop nest and
+        # parallelization of TMA are specified by the consumer: smem_cache
+
+        # Step 1: define TMA domain
+        # We want to treat the entire tensor as 1D, so define the TMA domain as
+        # [I0*I1*I2]
+        smem_cache.merge(0, 1)
+        smem_cache.merge(0, 1)
+        # Note that the TMA domain only exist in people's mind, there is no need to
+        # set anything here.
+
+        # Step 2: define box
+        smem_cache.split(0, 256)
+        # [I0*I1*I2/256, 256]
+        # partitioned IterDomain: I0*I1*I2
+        # coordinate IterDomain: I0*I1*I2/256
+        # box IterDomain: 256
+
+        # Step 3: define tile
+        # We use dense tile here, so tile == box. Nothing to do here.
+
+        # Step 4: schedule the shared memory tensor
+        # By default, the allocation domain is the logical domain, which is already
+        # in good shape for this case.
+
+        # Step 5: schedule the consumer tensor
+        smem_cache.split(0, 4)
+        # [I0*I1*I2/256/4, 4, 256]
+        smem_cache.axis(0).parallelize(ParallelType.grid_x)
+        smem_cache.axis(2).parallelize(ParallelType.tma)
+        # [BIDx, Serial, Bulk]
+
+        # Schedule the smem->gmem part
+        output.merge(0, 1)
+        output.merge(0, 1)
+        output.split(0, 256)
+        output.split(0, 4)
+        output.axis(0).parallelize(ParallelType.grid_x)
+        output.axis(2).parallelize(ParallelType.block_x)
+
+    if verbose_:
+        print(fd.fusion.print_math())
+        print(fd.fusion.print_kernel())
+        # TMA will be generated like:
+        # Note that the coordinate is in number of items, smem address is in
+        # bytes
+        #
+        # for (nvfuser_index_t i8 = 0; i8 < 4; ++i8) {
+        #   if (threadIdx.x == 0) {
+        #     Hopper::cpAsyncBulkTensorTileG2S(
+        #         coordinate = {1024 * blockIdx.x + 256 * i8},
+        #         smem_addr = (toSmem(T2) + 1024 * i8));
+        #   }
+        # }
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(5, 3, 300, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0)

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -840,3 +840,85 @@ def test_tutorial_basic_tma_example3(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0], compile_params=index32bit)
     outputs = ke.run([t0])
     assert outputs[0].equal(t0)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_basic_tma_example4(nvfuser_direct_test):
+    """
+    Example 4: Similar to example 3, except that we are using TMA for store
+    instead of load.
+    """
+
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True])
+        output = fd.ops.set(input)
+        fd.add_output(output)
+
+        smem_cache = output.cache_before(LoadStoreOpType.tma)
+        smem_cache.set_memory_type(MemoryType.shared)
+
+        # For TMA store, the loop nest and parallelization is specified in the
+        # consumer `output`, and the shared memory layout is specified in the
+        # allocation dimain of `smem_cache`.
+
+        # Step 1: define TMA domain
+        # Because we want to treat the entire tensor as 1D, we define the TMA
+        # domain as [I0*I1*I2]
+        output.merge(0, 1)
+        output.merge(0, 1)
+        # Note that the TMA domain only exist in people's mind, there is no need to
+        # set anything here.
+
+        # Step 2: define box
+        output.split(0, 256)
+        # [I0*I1*I2/256, 256]
+        # partitioned IterDomain: I0*I1*I2
+        # coordinate IterDomain: I0*I1*I2/256
+        # box IterDomain: 256
+
+        # Step 3: define tile
+        # We use dense tile here, so tile == box. Nothing to do here.
+
+        # Step 4: schedule the shared memory tensor
+        # By default, the allocation domain is the logical domain, which is already
+        # in good shape for this case.
+
+        # Step 5: schedule the consumer tensor
+        output.split(0, 4)
+        # [I0*I1*I2/256/4, 4, 256]
+        output.axis(0).parallelize(ParallelType.grid_x)
+        output.axis(1).parallelize(ParallelType.block_x)
+        output.axis(2).parallelize(ParallelType.tma)
+        # [BIDx, TIDx, Bulk]
+
+        # Schedule the gmem->smem part
+        smem_cache.merge(0, 1)
+        smem_cache.merge(0, 1)
+        smem_cache.split(0, 256)
+        smem_cache.split(0, 4)
+        smem_cache.axis(0).parallelize(ParallelType.grid_x)
+        smem_cache.axis(2).parallelize(ParallelType.block_x)
+
+        if verbose_:
+            print(fd.fusion.print_math())
+            print(fd.fusion.print_kernel())
+            # TMA will be generated like:
+            # Note that the coordinate is in number of items, smem address is in
+            # bytes
+            #
+            # if (threadIdx.x < 4) {
+            #   Hopper::cpAsyncBulkTensorTileS2G(
+            #       coordinate = {1024 * blockIdx.x + 256 * threadIdx.x},
+            #       smem_addr = (toSmem(T2) + 1024 * threadIdx.x));
+            # }
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(5, 3, 300, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0)

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -1031,3 +1031,113 @@ def test_tutorial_basic_tma_example5(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0], compile_params=index32bit)
     outputs = ke.run([t0])
     assert outputs[0].equal(t0)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_basic_tma_example6(nvfuser_direct_test):
+    """
+    Example 6: Similar to example 5, but we are using TMA for store instead
+    of load.
+    """
+
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True])
+        output = fd.ops.set(input)
+        fd.add_output(output)
+
+        smem_cache = output.cache_before(LoadStoreOpType.tma)
+        smem_cache.set_memory_type(MemoryType.shared)
+
+        # For TMA store, the loop nest and parallelization is specified in the
+        # consumer `output`, and the shared memory layout is specified in the
+        # allocation dimain of `smem_cache`.
+
+        # Step 1: define TMA domain
+        # For this case, we want to treat all three dimensions separately.
+        # TMA domain: [I0, I1, I2]
+        # Note that the TMA domain only exist in people's mind, there is no need to
+        # set anything here.
+
+        # Step 2: define box
+        output.split(2, 32)
+        output.split(1, 32)
+        # [I0, I1/32, 32, I2/32', 32']
+        # Box dimensions defined by partitioning: I1 and I2
+        #   partitioned IterDomain: I1, I2
+        #   coordinate IterDomain: I1/32, I2/32'
+        #   box IterDomain: 32, 32'
+        # Box dimension defined by compositing: I0
+        #   coordinate IterDomain: I0
+        #   box IterDomain: no box IterDomain, so implicit size 1
+
+        # Step 3: define tile
+        # We use dense tile here, so tile == box. Nothing to do here.
+
+        # Step 4: schedule the shared memory tensor
+        # By default, the allocation domain is the logical domain. The default
+        # value does not work for this case, because th tile will not be
+        # contiguous in shared memory.
+        # [I0, I1, I2]
+        smem_cache.split(2, 32)
+        smem_cache.split(1, 32)
+        # [I0, I1/32, 32, I2/32', 32']
+        smem_cache.split(3, 2)
+        smem_cache.split(1, 2)
+        # [I0, I1/32/2, 2, 32, I2/32'/2', 2', 32']
+        smem_cache.reorder({3: -2, 2: -4})
+        # [I0, I1/32/2, I2/32'/2', 2, 2', 32, 32']
+        smem_cache.set_allocation_domain(
+            smem_cache.get_loop_domain(), new_contiguity=True
+        )
+
+        # Step 5: schedule the consumer tensor
+        # Because we are not inlining anything in this example, we do not care
+        # about the order of IterDomains.
+        # [I0, I1/32, 32, I2/32', 32']
+        output.split(3, 2)
+        output.split(1, 2)
+        # [I0, I1/32/2, 2, 32, I2/32'/2', 2', 32']
+        output.axis(0).parallelize(ParallelType.grid_x)
+        output.axis(1).parallelize(ParallelType.grid_y)
+        output.axis(2).parallelize(ParallelType.block_x)
+        output.axis(3).parallelize(ParallelType.tma)
+        output.axis(4).parallelize(ParallelType.grid_z)
+        output.axis(6).parallelize(ParallelType.tma)
+        # [BIDx, BIDy, TIDx, Bulk, BIDz, Serial, Bulk]
+
+        # Schedule the gmem->smem part
+        smem_cache.merge(-2, -1)
+        smem_cache.axis(0).parallelize(ParallelType.grid_x)
+        smem_cache.axis(1).parallelize(ParallelType.grid_y)
+        smem_cache.axis(2).parallelize(ParallelType.grid_z)
+        smem_cache.axis(-1).parallelize(ParallelType.block_x)
+
+        if verbose_:
+            print(fd.fusion.print_math())
+            print(fd.fusion.print_kernel())
+            # TMA will be generated like:
+            # Note that the coordinate is in number of items, smem address is in
+            # bytes.Also note that coordinate is in column major, so inner dims
+            # goes first
+            #
+            # for (nvfuser_index_t i19 = 0; i19 < 2; ++i19) {
+            #   if (threadIdx.x < 2) {
+            #     Hopper::cpAsyncBulkTensorTileS2G(
+            #         coordinate =
+            #             {64 * blockIdx.z + 32 * i19,
+            #              64 * blockIdx.y + 32 * threadIdx.x,
+            #              blockIdx.x},
+            #         smem_addr = toSmem(T2) + 8192 * threadIdx.x + 4096 * i19);
+            #   }
+            # }
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(5, 3, 300, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0)

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -595,7 +595,6 @@ def test_tutorial_basic_tma_example1(nvfuser_direct_test):
     shared memory tensor and the fusion output.
     """
 
-    # TODO create CompileParams constructor
     # cache_after, cache_before
     # set_memory_type
 

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -922,3 +922,112 @@ def test_tutorial_basic_tma_example4(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0], compile_params=index32bit)
     outputs = ke.run([t0])
     assert outputs[0].equal(t0)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_basic_tma_example5(nvfuser_direct_test):
+    """
+    Example 5: Still the same copy kernel of 3D tensor, but this time, we
+     want to do tiling on the inner two dimensions. The first dimension is
+     treated as a "batch" dimension. We use CTA tile (64, 64), and TMA tile
+     (32, 32), so we need 4 TMA instructions to load the entire CTA tile.
+     We want to use two threads, and each thread issue two TMA instructions.
+    """
+
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1, -1], contiguity=[True, True, True])
+        output = fd.ops.set(input)
+        fd.add_output(output)
+
+        smem_cache = input.cache_after(LoadStoreOpType.tma)
+        smem_cache.set_memory_type(MemoryType.shared)
+
+        # For TMA load, both the shared memory layout and the loop nest and
+        # parallelization of TMA are specified by the consumer: smem_cache
+
+        # Step 1: define TMA domain
+        # For this case, we want to treat all three dimensions separately.
+        # TMA domain: [I0, I1, I2]
+        # Note that the TMA domain only exist in people's mind, there is no need to
+        # set anything here.
+
+        # Step 2: define box
+        smem_cache.split(2, 32)
+        smem_cache.split(1, 32)
+        # [I0, I1/32, 32, I2/32', 32']
+        # Box dimensions defined by partitioning: I1 and I2
+        #   partitioned IterDomain: I1, I2
+        #   coordinate IterDomain: I1/32, I2/32'
+        #   box IterDomain: 32, 32'
+        # Box dimension defined by compositing: I0
+        #   coordinate IterDomain: I0
+        #   box IterDomain: no box IterDomain, so implicit size 1
+
+        # Step 3: define tile
+        # We use dense tile here, so tile == box. Nothing to do here.
+
+        # Step 4: schedule the shared memory tensor
+        # By default, the allocation domain is the logical domain. The default
+        # value does not work for this case, because the tile will not be
+        # contiguous in shared memory.
+        # [I0, I1/32, 32, I2/32', 32']
+        smem_cache.split(3, 2)
+        smem_cache.split(1, 2)
+        # [I0, I1/32/2, 2, 32, I2/32'/2', 2', 32']
+        smem_cache.reorder({3: -2, 2: -4})
+        # [I0, I1/32/2, I2/32'/2', 2, 2', 32, 32']
+        smem_cache.set_allocation_domain(
+            smem_cache.get_loop_domain(), new_contiguity=True
+        )
+
+        # Step 5: schedule the consumer tensor
+        # [I0, I1/32/2, I2/32'/2', 2, 2', 32, 32']
+        smem_cache.axis(0).parallelize(ParallelType.grid_x)
+        smem_cache.axis(1).parallelize(ParallelType.grid_y)
+        smem_cache.axis(2).parallelize(ParallelType.grid_z)
+        smem_cache.axis(3).parallelize(ParallelType.block_x)
+        smem_cache.axis(5).parallelize(ParallelType.tma)
+        smem_cache.axis(6).parallelize(ParallelType.tma)
+        # [BIDx, BIDy, BIDz, TIDx, Serial, Bulk, Bulk]
+
+        # Schedule the smem->gmem part
+        output.split(2, 32)
+        output.split(1, 32)
+        output.split(3, 2)
+        output.split(1, 2)
+        output.reorder({3: -2, 2: -4})
+        output.axis(0).parallelize(ParallelType.grid_x)
+        output.axis(1).parallelize(ParallelType.grid_y)
+        output.axis(2).parallelize(ParallelType.grid_z)
+        output.merge(3, 4)
+        output.axis(3).parallelize(ParallelType.block_x)
+
+        if verbose_:
+            print(fd.fusion.print_math())
+            print(fd.fusion.print_kernel())
+            # TMA will be generated like:
+            # Note that the coordinate is in number of items, smem address is in
+            # bytes. Also note that coordinate is in column major, so inner dims
+            # goes first
+            #
+            # for (nvfuser_index_t i13 = 0; i13 < 2; ++i13) {
+            #   if (threadIdx.x < 2) {
+            #     Hopper::cpAsyncBulkTensorTileG2S(
+            #         coordinate =
+            #             {64 * blockIdx.z + 32 * i13,
+            #              64 * blockIdx.y + 32 * threadIdx.x,
+            #              blockIdx.x},
+            #         smem_addr = toSmem(T2) + 8192 * threadIdx.x + 4096 * i13);
+            #   }
+            # }
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(5, 3, 300, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0)


### PR DESCRIPTION
This PR migrates `Tutorial.BasicTMA` to python. It splits the six examples into separate tests for readability.

* Add constructor to `CompileParams`.
* Add docstrings to `CompileParams` and `LaunchParams`.
* Create `LoadStoreOpType`, `MemoryType`, and `CacheOp` Enums.
* Add `cache_after`, `cache_before`, `set_memory_type`, `reorder` to `TensorView`.