### PR TITLE
Migrate `Tutorial.TMABankConflictFreeTranspose` to direct bindings

### DIFF
--- a/csrc/scheduler/utils.h
+++ b/csrc/scheduler/utils.h
@@ -557,7 +557,7 @@ void transformPropagateToAllFrom(TensorView* from_tv, int64_t pos);
 //!
 //! There are currently three modes of propagation: forward, backward and
 //! both-way, see comment on the interface functions for details.
-struct BoundedDirectionalTransformPropagator {
+struct NVF_API BoundedDirectionalTransformPropagator {
   //! Custom option container for configuring
   //!  the transform propagation actions.
   //! All option values default to false unless

--- a/python/python_direct/ir.cpp
+++ b/python/python_direct/ir.cpp
@@ -405,6 +405,29 @@ TensorView
     A TensorView with the reordered axes in its loop domain.
 )")
       .def(
+          "swizzle",
+          [](TensorView* self, int64_t x, int64_t y) {
+            return self->swizzle(SwizzleType::XOR, x, y);
+          },
+          py::return_value_policy::reference,
+          py::arg("x"),
+          py::arg("y"),
+          R"(
+Swizzle the axes of this tensor.
+
+Parameters
+----------
+x : int
+    The x axis to swizzle.
+y : int
+    The y axis to swizzle.
+
+Returns
+-------
+TensorView
+    A TensorView with the swizzled axes in its loop domain.
+)")
+      .def(
           "rfactor",
           static_cast<TensorView* (TensorView::*)(const std::vector<int64_t>&)>(
               &TensorView::rFactor),

--- a/python/python_direct/schedule.cpp
+++ b/python/python_direct/schedule.cpp
@@ -16,6 +16,43 @@ namespace {
 
 void bindTensorviewScheduleOps(py::module_& schedule) {
   schedule.def(
+      "bounded_transform_backward",
+      [](TensorView* from,
+         int64_t pos,
+         std::vector<TensorView*> to,
+         bool propagate_parallel_type) {
+        using TransformPropagator =
+            scheduler_utils::BoundedDirectionalTransformPropagator;
+        TransformPropagator::Options options;
+        if (propagate_parallel_type) {
+          options.propagateParallelType();
+        }
+        TransformPropagator::backward(from, pos, to, options);
+      },
+      R"(
+      Propagate scheduler transformations from a reference TensorView to other TensorViews.
+
+      Parameters
+      ----------
+      from : TensorView
+          The reference TensorView whose transformations will be propagated.
+      pos : int
+          The position up to which dimensions should be selected. -1 means all dimensions.
+      to : List[TensorView]
+          List of TensorViews to propagate transformations to.
+      propagate_parallel_type : bool
+          Whether to propagate parallel type.
+
+      Returns
+      -------
+      None
+      )",
+      py::arg("from"),
+      py::arg("pos"),
+      py::arg("to"),
+      py::arg("propagate_parallel_type") = false);
+
+  schedule.def(
       "transform_like",
       [](TensorView* reference_tv,
          const std::vector<TensorView*>& selected_tensors) {

--- a/tests/python/direct/test_tutorial.py
+++ b/tests/python/direct/test_tutorial.py
@@ -1330,3 +1330,107 @@ def test_tutorial_pointwise_broadcast_tma(nvfuser_direct_test):
     ke.compile(fd.fusion, [t0, t1], compile_params=index32bit)
     outputs = ke.run([t0, t1])
     assert outputs[0].equal(t2)
+
+
+@pytest.mark.skipif(
+    is_pre_hopper(), reason="Only supported on Hopper and newer devices."
+)
+def test_tutorial_tma_bank_conflict_free_transpose(nvfuser_direct_test):
+    with FusionDefinition() as fd:
+        input = fd.define_tensor(shape=[-1, -1], contiguity=[True, True])
+        output = fd.ops.permute(input, [1, 0])
+        fd.add_output(output)
+
+        # Change the fusion to input->smem->register->smem->output where the
+        # smem->register part does the transpose
+        input_smem_cache = input.cache_after(LoadStoreOpType.tma)
+        input_smem_cache.set_memory_type(MemoryType.shared)
+
+        output_smem_cache = output.cache_before(LoadStoreOpType.tma)
+        output_smem_cache.set_memory_type(MemoryType.shared)
+
+        output_reg_cache = output_smem_cache.cache_before()
+
+        # Create 32x32 tile. Each CTA has one tile, and the entire tile will be
+        # loaded to shared memory by TMA, and stored back to global memory by TMA.
+
+        # [I1, I0]
+        output.split(1, 32)
+        output.split(0, 32)
+        # [I1, 32', I0, 32]
+        output.reorder({0: 1, 1: 2, 2: 0})
+        output.merge(0, 1)
+        # [I0/32 * I1/32', 32', 32]
+        output.axis(0).parallelize(ParallelType.grid_x)
+        # [BIDx, 32', 32]
+
+        fd.sched.bounded_transform_backward(
+            output, -1, [input], propagate_parallel_type=True
+        )
+
+        # For fusion output, we just use TMA to store the entire tile back to global
+        # memory. There is no need to further schedule the output tensor.
+        output.axis(1).parallelize(ParallelType.tma)
+        output.axis(2).parallelize(ParallelType.tma)
+        # [BIDx, Bulk, Bulk]
+
+        # output_smem_cache and output_reg_cache are scheduled in the same way.
+        # We use each warp to load one column of input_smem_cache. We vectorize
+        # the load to 16 bytes, and use 8 warps to load all these 8 columns. Then,
+        # when we write to output_smem_cache, we unroll the write. Each warp writes
+        # one row in output_smem_cache in each iteration, so there is no bank
+        # conflict.
+
+        # [BIDx, 32', 32]
+        output_smem_cache.set_allocation_domain(
+            output_smem_cache.get_loop_domain(), new_contiguity=True
+        )
+        output_smem_cache.split(1, 4)
+        # [BIDx, 8', 4', 32]
+
+        fd.sched.bounded_transform_backward(output_smem_cache, -1, [input])
+
+        output_smem_cache.merge(1, 3)
+        # [BIDx, 256, 4']
+        output_smem_cache.axis(1).parallelize(ParallelType.block_x)
+
+        fd.sched.bounded_transform_backward(
+            output_smem_cache, -1, [input_smem_cache], propagate_parallel_type=True
+        )
+
+        output_smem_cache.axis(2).parallelize(ParallelType.unroll)
+        output_reg_cache.axis(2).parallelize(ParallelType.vectorize)
+        output_reg_cache.set_allocation_domain(
+            output_reg_cache.get_loop_domain(), new_contiguity=True
+        )
+
+        # Schedule the memory format for 128 byte swizzle
+        # [BIDx, 8', 4', 32]
+        input_smem_cache.reorder({3: 1, 1: 2, 2: 3})
+        # [BIDx, 32, 8', 4']
+        input_smem_cache.split(1, 8)
+        # [BIDx, 4, 8, 8', 4']
+        input_smem_cache.swizzle(2, 3)
+        # [BIDx, 4, 8, 8', 4']
+        input_smem_cache.set_allocation_domain(
+            input_smem_cache.get_loop_domain(), new_contiguity=True
+        )
+
+        input_smem_cache.axis(1).parallelize(ParallelType.tma)
+        input_smem_cache.axis(2).parallelize(ParallelType.tma)
+        input_smem_cache.axis(3).parallelize(ParallelType.tma)
+        input_smem_cache.axis(4).parallelize(ParallelType.tma)
+        # [BIDx, Bulk, Bulk, Bulk, Bulk]
+
+        if verbose_:
+            print(fd.fusion.print_math())
+            print(fd.fusion.print_kernel())
+
+    index32bit = CompileParams(
+        index_type=DataType.Int32, maxrregcount=255, enable_magic_zero=False
+    )
+    t0 = torch.randn(10000, 10000, dtype=torch.float, device="cuda:0")
+    ke = KernelExecutor()
+    ke.compile(fd.fusion, [t0], compile_params=index32bit)
+    outputs = ke.run([t0])
+    assert outputs[0].equal(t0.t())


### PR DESCRIPTION
* Add `swizzle` to `TensorView`; Always use `SwizzleType::XOR`
* Create `bounded_transform_backward` for `BoundedDirectionalTransformPropagator::backward`

### Generated CUDA Kernel

<details>

```cuda
__global__ void CUDAGeneratedKernel(Tensor<float, 2, 2> T0, const __grid_constant__ TensorMap var0, const __grid_constant__ TensorMap var1, Tensor<float, 2, 2> T1) {
  alignas(16) extern __shared__ char array[];
  const unsigned smem_offset = 0;
  const TensorMap* ptr2;
  ptr2 = &var0;
  nvfuser_index_t i3;
  i3 = ceilDiv(T0.logical_size[1LL], 32LL);
  nvfuser_index_t i4;
  i4 = 32LL * (((nvfuser_index_t)blockIdx.x) / i3);
  int i5;
  i5 = __to_int32(i4);
  nvfuser_index_t i6;
  i6 = 32LL * (((nvfuser_index_t)blockIdx.x) % i3);
  int i7;
  i7 = __to_int32(i6);
  Array<int, 2, 1> a8;
  a8 = Array<int, 2, 1>{i7, i5};
  nvfuser_index_t i9;
  i9 = ((nvfuser_index_t)threadIdx.x) % 32LL;
  nvfuser_index_t i10;
  i10 = ((nvfuser_index_t)threadIdx.x) / 32LL;
  nvfuser_index_t i11;
  i11 = (128LL * i10) + i9;
  bool b12;
  b12 = ((nvfuser_index_t)threadIdx.x) < 32ULL;
  bool b13;
  b13 = (((3LL + (4LL * i10)) + i6) < T0.logical_size[1LL]) && ((i9 + i4) < T0.logical_size[0LL]);
  float* T2 = reinterpret_cast<float*>(array + smem_offset + 4096LL);
  float* T3 = reinterpret_cast<float*>(array + smem_offset + 0LL);
  uint64_t* T5 = reinterpret_cast<uint64_t*>(array + smem_offset + 8192LL);
  mbarrier::init(toSmem(T5), 1U);
  __syncthreads();
  if ((Hopper::electSync(4294967295U) && b12)) {
    uint64_t i14;
    i14 = mbarrier::arriveExpectTX(toSmem(T5), 4096U);
    Hopper::cpAsyncBulkTensorTileG2S((Hopper::CpAsyncBulkTensorTileG2SIndex<2>{ ptr2, a8, toSmem(T5) }), toSmem(T2));
    mbarrier::wait(toSmem(T5), i14);
  }
  __syncthreads();
  mbarrier::inval(toSmem(T5));
  Array<float, 4LL, 4> T4;
  loadGeneric<float, 4>( &T4[0LL],  &T2[((32LL * i9) + (4LL * ((i9 % 8LL) ^ i10)))]);
  #pragma unroll
  for(nvfuser_index_t i15 = 0LL; i15 < 4LL; ++i15) {
    T3[(i11 + (32LL * i15))] = 0LL;
  }
  if (b13) {
    #pragma unroll
    for(nvfuser_index_t i15 = 0LL; i15 < 4LL; ++i15) {
      T3[(i11 + (32LL * i15))]
         = T4[i15];
    }
  } else {
    #pragma unroll
    for(nvfuser_index_t i15 = 0LL; i15 < 4LL; ++i15) {
      if (b13) {
        T3[(i11 + (32LL * i15))]
           = T4[i15];
      }
    }
  }
  __syncthreads();
  fenceAsyncProxy();
  if (b12) {
    Hopper::cpAsyncBulkTensorTileS2G((Hopper::CpAsyncBulkTensorTileS2GIndex<2>{ (&var1), (Array<int, 2, 1>{i5, i7}) }), toSmem(T3));
  }
  cpAsyncBulkCommitGroup();
  cpAsyncBulkWaitGroup<0LL>();
}
```

</details>

PR stack
* #5247
* #5248
* #5249 **<< This PR**