### PR TITLE
Reorder all parallelized IterDomains to front

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -708,20 +708,21 @@ void unshard(Fusion* fusion) {
   }
 }
 
-std::unordered_map<int64_t, int64_t> reorderDIDToFront(TensorView* tv) {
+std::unordered_map<int64_t, int64_t> reorderParallelizedToFront(
+    TensorView* tv) {
   // old position to new position
-  std::unordered_map<int64_t, int64_t> order_map;
+  std::unordered_map<int64_t, int64_t> order;
   int64_t current_pos = 0;
 
-  for (auto pos : arange(tv->nDims())) {
-    if (tv->axis(pos)->isDeviceDim()) {
-      order_map[pos] = current_pos;
+  for (const auto pos : arange(tv->nDims())) {
+    if (tv->axis(pos)->isParallelized()) {
+      order[pos] = current_pos;
       current_pos++;
     }
   }
 
-  tv->reorder(order_map);
-  return order_map;
+  tv->reorder(order);
+  return order;
 }
 
 std::unordered_set<TensorView*> getTvsWithDifferentSharding(

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -124,7 +124,7 @@ NVF_API at::Tensor shardTensor(
 
 // Reorders a TensorView so that the DID parallelized axis are in front.
 // Returns a map of the old index to the new index.
-std::unordered_map<int64_t, int64_t> reorderDIDToFront(TensorView*);
+std::unordered_map<int64_t, int64_t> reorderParallelizedToFront(TensorView*);
 
 // Given a TensorView and the shape of a sharded tensor of which certain
 // dimensions are partially allocated, returns the global shape that'll be used

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -122,7 +122,10 @@ NVF_API at::Tensor shardTensor(
     const DeviceMesh& mesh,
     DeviceIdxType device_id);
 
-// Reorders a TensorView so that the DID parallelized axis are in front.
+// Reorders a TensorView's loop domain so that parallelized IterDomains are in
+// front, making the order most convenient for (inter-GPU and intra-GPU)
+// schedulers.
+//
 // Returns a map of the old index to the new index.
 std::unordered_map<int64_t, int64_t> reorderParallelizedToFront(TensorView*);
 

--- a/csrc/preseg_passes/finalize_multidevice_domains.cpp
+++ b/csrc/preseg_passes/finalize_multidevice_domains.cpp
@@ -113,7 +113,7 @@ void setLoopAndAllocationDomain(TensorView* tv, bool is_resharding) {
   }
 
   // Most schedulers require DIDx to be at the front of the loop domain.
-  auto old2new = reorderDIDToFront(tv);
+  auto old2new = reorderParallelizedToFront(tv);
   auto new2old = ir_utils::normalizeOld2New(old2new, tv->nDims());
   std::vector<std::optional<bool>> reordered_contiguity;
   std::transform(

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -880,7 +880,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams* pparams) {
     reference_tv->reorder(
         scheduler_utils::domainReorderAsLogicalMap(reference_tv));
     // Reorder so that DeviceDims are in front
-    reorderDIDToFront(reference_tv);
+    reorderParallelizedToFront(reference_tv);
 
     // Break point is relative to logical domain, find the loop domain ID's in
     // the left/right side, we really need the values in domain, but easiest way
@@ -966,7 +966,7 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams* pparams) {
     if (!reorder_map.empty()) {
       reference_tv->reorder(reorder_map);
     }
-    reorderDIDToFront(reference_tv);
+    reorderParallelizedToFront(reference_tv);
 
     // Merge right side of break point
     for (int64_t i = reference_tv->nDims(); i > device_aware_break_point; i--) {

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -691,7 +691,7 @@ TEST_F(MultiDeviceTest, ViewWithMerge) {
       UnorderedElementsAre(HeuristicIs(SchedulerType::PointWise)));
 }
 
-TEST_F(MultiDeviceTest, ReorderDIDToFront) {
+TEST_F(MultiDeviceTest, ReorderParallelizedToFront) {
   auto fusion = std::make_unique<Fusion>();
   FusionGuard fg(fusion.get());
 
@@ -708,7 +708,7 @@ TEST_F(MultiDeviceTest, ReorderDIDToFront) {
     tv->setDeviceMesh(mesh);
     tv->outer_split(-1, d);
     tv->axis(-2)->parallelize(ParallelType::DIDx);
-    reorderDIDToFront(tv);
+    reorderParallelizedToFront(tv);
     NVF_CHECK(tv->axis(0)->isDeviceDim());
   }
 
@@ -1132,7 +1132,7 @@ TEST_F(MultiDeviceTest, AllocationPermutationOfLoop) {
     tv->axis(1)->parallelize(ParallelType::DIDx);
     // DIDx is outermost in loop but not in allocation domain
     tv->setAllocationDomain(tv->getLoopDomain(), true);
-    reorderDIDToFront(tv);
+    reorderParallelizedToFront(tv);
   }
 
   // Disable the pass to verify we can run a fusion where allocation domain


### PR DESCRIPTION
This PR changed reorderDIDToFront to reorder all parallelized dimensions to front. This is less controversial than I expected because currently we only call reorderDIDToFront before intra-GPU scheduling kicks in. 

Needed by #5229