### PR TITLE
Fix minor bug in printed repros when definition fails

### DIFF
--- a/python/nvfuser/__init__.py
+++ b/python/nvfuser/__init__.py
@@ -512,6 +512,11 @@ class FusionDefinition(_C._FusionDefinition):
         msg = "# CUDA devices:\n"
         for i in range(torch.cuda.device_count()):
             msg += f"#  {i}: {torch.cuda.get_device_name(i)}\n"
+        fusion_func_name = (
+            "nvfuser_incomplete_fusion"
+            if self.id() is None
+            else f"nvfuser_fusion_id{self.id()}"
+        )
         msg += (
             f"# torch version: {torch.__version__}\n"
             f"# cuda version: {torch.version.cuda}\n"
@@ -520,7 +525,7 @@ class FusionDefinition(_C._FusionDefinition):
             "from nvfuser import FusionDefinition, DataType\n"
             f"{self}"
             "with FusionDefinition() as fd:\n"
-            f"    nvfuser_fusion_id{self.id()}(fd)\n"
+            f"    {fusion_func_name}(fd)\n"
         )
         if inputs is not None:
             msg += "\ninputs = [\n"


### PR DESCRIPTION
See #5244 where we hit a definition failure. In this case we print the repro correctly but the FusionDefinition has no id yet, so we should invoke the function `nvfuser_incomplete_fusion` instead of `f"nvfuser_fusion_id{self.id()}"` which prints as
`nvfuser_fusion_idNone` in these cases.