### PR TITLE
Remove duplicate parametrization

### DIFF
--- a/benchmarks/python/test_batchnorm_fwd.py
+++ b/benchmarks/python/test_batchnorm_fwd.py
@@ -10,7 +10,6 @@ from .core import DEFAULT_EXECUTORS
 
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("channels_last", [True, False])
 @pytest.mark.parametrize(
     "channels_last",
     [
@@ -42,7 +41,6 @@ def test_batchnorm_fwd_nvf_benchmark(
 @pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
 @pytest.mark.parametrize("size", generate_input_sizes(dims=4))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-@pytest.mark.parametrize("channels_last", [True, False])
 @pytest.mark.parametrize(
     "channels_last",
     [


### PR DESCRIPTION
Pytest throws an error for duplicate parameters. This has been causing the `batchnorm_fwd` benchmarking failures in CI.
