### PR TITLE
Revert "Remove unnecessary barrier in share mem handle cuda ipc"

### DIFF
--- a/csrc/multidevice/ipc_handle.cpp
+++ b/csrc/multidevice/ipc_handle.cpp
@@ -143,9 +143,6 @@ void IpcHandleCache::exchangeHandles(
     insert(communication, std::move(ipc_handles));
   }
 
-  if (non_cached_communications.empty()) {
-    return;
-  }
   // a barrier is needed here to ensure all ranks have received the
   // memhandles and the keys are deleted from the store before the next call to
   // exchangeHandles, otherwise there is a correctness issue


### PR DESCRIPTION
Reverts NVIDIA/Fuser#5260

`RingAllgatherOverlapTest.RingAllgatherBasedPipeliningHostIRImplementationCudaIpc` failed for this PR.