### PR TITLE
Always use the IdModel indexing when ScatterOp is detected

### DIFF
--- a/csrc/device_lower/lower2device.cpp
+++ b/csrc/device_lower/lower2device.cpp
@@ -311,7 +311,7 @@ IdModelOptions getIdModelOptions(Fusion* fusion) {
     } else if (expr->isA<MmaOp>()) {
       options.setBuildTensorIndexer(true);
       continue;
-    } else if (expr->isOneOf<SliceOp, PadOp>()) {
+    } else if (expr->isOneOf<ScatterOp, SliceOp, PadOp>()) {
       options.setProducerIndex(true);
       options.setConsumerIndex(true);
       options.setInlinePredicate(true);


### PR DESCRIPTION
Scatter indexing, which is currently only done when scheduled with the greedy scheduler, relies on `TensorIndexer`, so it needs to be always enabled whenever a fusion has scatter.