### PR TITLE
perf optimization for rmsnorm add

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -37,6 +37,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Benchmarks torch.compile mode.",
     )
+    parser.addoption(
+        "--benchmark-flashinfer",
+        action="store_true",
+        help="Benchmarks flashinfer mode.",
+    )
 
     # pytest-benchmark does not have CLI options to set rounds/warmup_rounds for benchmark.pedantic.
     # The following two options are used to overwrite the default values through CLI.
@@ -144,7 +149,13 @@ def pytest_collection_modifyitems(session, config, items):
 
     from nvfuser.pytorch_utils import retry_on_oom_or_skip_test
 
-    executors = ["eager", "torchcompile", "thunder", "thunder-torchcompile"]
+    executors = [
+        "eager",
+        "torchcompile",
+        "thunder",
+        "thunder-torchcompile",
+        "flashinfer",
+    ]
 
     def get_test_executor(item) -> str | None:
         if hasattr(item, "callspec") and "executor" in item.callspec.params:

--- a/benchmarks/python/test_rmsnorm_add_fwd.py
+++ b/benchmarks/python/test_rmsnorm_add_fwd.py
@@ -4,12 +4,52 @@
 import pytest
 from .core import run_benchmark, clear_dynamo_cache, with_executor, DEFAULT_EXECUTORS
 import torch
-from .global_params import generate_input_sizes, FLOAT_DTYPES
+from .global_params import FLOAT_DTYPES, BENCHMARK_CONFIG
 from .torch_ops import rmsnorm_add
+from flashinfer import fused_add_rmsnorm
+import itertools
+from random import sample
+from typing import List, Tuple
+
+
+def generate_input_sizes_rmsnorm_add(dims: int = 2) -> List[Tuple]:
+    """
+    Local version of generate_input_sizes specifically for rmsnorm_add_fwd tests.
+    Uses batch sizes [1, 2, 4, 8, 16, 32, ..., 16384] (powers of 2).
+    Uses hidden sizes [256, 512, 768, 1024, ..., 16384] (step size 256).
+    """
+    inputs = []
+
+    if dims == 2:
+        input_ranges = []
+
+        step_size = 256
+        # Use powers of 2 from 1 to 16384 for batch sizes
+        batch_range = [2**i for i in range(0, 15)]  # [1, 2, 4, 8, 16, 32, ..., 16384]
+
+        # Hidden range is always [256, 512, 768, 1024, ..., 16384]
+        hidden_range = list(range(step_size, 16384 + 1, step_size))
+
+        # Use the same hidden range for all batch sizes since it's already capped at 16384
+        input_ranges.append((batch_range, hidden_range))
+
+        for batch_range_subset, hidden_range_subset in input_ranges:
+            inputs.extend(
+                list(itertools.product(batch_range_subset, hidden_range_subset))
+            )
+    else:
+        raise NotImplementedError(
+            f"Generating input sizes of dimension {dims} is not implemented for rmsnorm_add"
+        )
+
+    if BENCHMARK_CONFIG["num_inputs"] is not None:
+        inputs = sample(inputs, BENCHMARK_CONFIG["num_inputs"])
+
+    return inputs
 
 
 @pytest.mark.parametrize("executor", DEFAULT_EXECUTORS)
-@pytest.mark.parametrize("size", generate_input_sizes(dims=2))
+@pytest.mark.parametrize("size", generate_input_sizes_rmsnorm_add(dims=2))
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 @pytest.mark.inner_persistent
 def test_rmsnorm_add_fwd_baseline_benchmark(
@@ -25,6 +65,38 @@ def test_rmsnorm_add_fwd_baseline_benchmark(
     residual = torch.randn(size, device="cuda", dtype=dtype, requires_grad=False)
 
     benchmark_fn = with_executor(executor, rmsnorm_add)
+    run_benchmark(
+        benchmark,
+        benchmark_fn,
+        [inputs, weights, residual],
+    )
+
+
+# flash infer does inplace update of inputs and residual tensors
+# needs to explicitly return the updated tensors to correctly compute IO bytes
+# https://github.com/flashinfer-ai/flashinfer/blob/ba2b4aa636c4ecf99981794767ffbf89267720cd/flashinfer/norm.py#L106
+def flashinfer_rmsnorm_add_wrapper(inputs_list):
+    inputs, weights, residual = inputs_list
+    fused_add_rmsnorm(inputs, residual, weights)
+    return inputs, residual
+
+
+# requires flashinfer to be installed
+# `pip install flashinfer-python` works in pjnl container
+@pytest.mark.parametrize("executor", ["flashinfer"])
+@pytest.mark.parametrize("size", generate_input_sizes_rmsnorm_add(dims=2))
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.inner_persistent
+def test_rmsnorm_add_fwd_flashinfer_benchmark(
+    benchmark,
+    size: tuple,
+    dtype: torch.dtype,
+    executor: str,
+):
+    inputs = torch.randn(size, device="cuda", dtype=dtype, requires_grad=False)
+    weights = torch.randn(size[1], device="cuda", dtype=dtype, requires_grad=False)
+    residual = torch.randn(size, device="cuda", dtype=dtype, requires_grad=False)
+    benchmark_fn = flashinfer_rmsnorm_add_wrapper
     run_benchmark(
         benchmark,
         benchmark_fn,

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -395,7 +395,10 @@ void innerPersistentHeuristic2D(
       properties.inner_most_dimension_numel / properties.vectorize_factor;
 
   // try to use at least 4 warps per block
-  const int64_t min_threads_per_block = 4l * threads_per_warp;
+  bool can_use_all_sms =
+      properties.total_iteration_numel >= device_multiprocessor_count;
+  const int64_t min_threads_per_block =
+      can_use_all_sms ? 4l * threads_per_warp : max_threads_in_block;
 
   // set the min persistent buffer size to avoid requesting
   // a block size larger than device limit

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -518,11 +518,14 @@ void innerPersistentHeuristic2D(
     }
   }
 
+  rparams->static_bdimx = true;
+
   rparams->lparams = LaunchParams(
       gdimx,
       LaunchParams::UNINITIALIZED_VAL,
       LaunchParams::UNINITIALIZED_VAL,
-      LaunchParams::UNINITIALIZED_VAL,
+      rparams->static_bdimx ? best_heuristic.bdimx
+                            : LaunchParams::UNINITIALIZED_VAL,
       best_heuristic.bdimy,
       LaunchParams::UNINITIALIZED_VAL);
 }

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -197,9 +197,15 @@ TensorView* scheduleReductionTV(
     if (rparams->cross_grid_inner_reduction) {
       outer_parallel(outer_i++, rparams->grid_dim_inner_reduction);
     }
-
-    reduction_tv->split(
-        outer_i++, rparams->batches_per_block_inner_reduction, false);
+    if (rparams->static_bdimx) {
+      inner_parallel_static(
+          inner_reduce_axis,
+          rparams->block_dim_inner_reduction,
+          rparams->lparams.bdimx());
+    } else {
+      reduction_tv->split(
+          outer_i++, rparams->batches_per_block_inner_reduction, false);
+    }
 
     outer_unswitch(outer_i++);
 
@@ -210,13 +216,14 @@ TensorView* scheduleReductionTV(
 
     if (rparams->combined_inner_outer && !rparams->multiple_reds_per_blk) {
       reduction_tv->axis(outer_i)->parallelize(ParallelType::TIDz);
-    } else {
+    } else if (!rparams->static_bdimx) {
       reduction_tv->axis(outer_i)->parallelize(
           rparams->block_dim_inner_reduction);
+      if (rparams->pad_inner_reduction_to_warp) {
+        reduction_tv->axis(outer_i)->padToMultipleOfWarp();
+      }
     }
-    if (rparams->pad_inner_reduction_to_warp) {
-      reduction_tv->axis(outer_i)->padToMultipleOfWarp();
-    }
+
   } else {
     // Non-persistent format:
     // [Grid Split, Remainder, unswitch, unroll, thread dim, vectorize]


### PR DESCRIPTION
1. Add flashinfer in benchmarks.

2. Two optimizations for inner persistent scheduler:
(1) Given a LLM model, the hidden dimension is fixed, we can use static shape in that dimension. Change bdimx to static.
(2) For input with small batch size, not all SMs are used, pick a large bdimx to allow more warps.
After these two optimizations, the performance of nvFuser is better than flashinfer.
<img width="1187" height="529" alt="image" src="https://github.com/user-attachments/assets/281139af-8ecf-4973-9ed1-fdf36b9f5af7" />

raw data: https://docs.google.com/spreadsheets/d/1JMea0s_Z2mYDgbdNSI7-pS4MtdUBrIONl5EqiezFrDo/edit?usp=sharing