### PR TITLE
Rename MultiDeviceTest tensor options member

### DIFF
--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -38,7 +38,7 @@ MultiDeviceTest::MultiDeviceTest() {
   c10d::setDebugLevelFromEnvironment();
 
   communicator_ = &Communicator::getInstance();
-  tensor_options =
+  tensor_options_ =
       at::TensorOptions().dtype(at::kFloat).device(communicator_->device());
   debug_print = getNvFuserEnv("MULTIDEVICE_DEBUG_PRINT") != nullptr;
   disable_skip = getNvFuserEnv("MULTIDEVICE_DISABLE_SKIP") != nullptr;

--- a/tests/cpp/multidevice.h
+++ b/tests/cpp/multidevice.h
@@ -46,7 +46,7 @@ class MultiDeviceTest : public NVFuserTest {
       const std::vector<double>& atols);
 
   Communicator* communicator_;
-  c10::TensorOptions tensor_options;
+  c10::TensorOptions tensor_options_;
   bool debug_print;
   bool disable_skip;
 };

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -77,12 +77,12 @@ TEST_P(CommunicationTest, Gather) {
   auto* communication = IrBuilder::create<Communication>(
       CommunicationType::Gather, out, in, all_ranks_, kRoot);
 
-  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
+  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options_);
   at::Tensor output_tensor =
-      at::empty({communicator_->size(), kTensorSize}, tensor_options);
+      at::empty({communicator_->size(), kTensorSize}, tensor_options_);
   for (auto repetition : arange(kNumRepetitions)) {
     input_tensor.copy_(
-        at::arange(kTensorSize, tensor_options).unsqueeze(0) +
+        at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
         (communicator_->deviceId() + 1) * repetition);
     auto work = postSingleCommunication(
         communication,
@@ -93,8 +93,8 @@ TEST_P(CommunicationTest, Gather) {
     work->wait();
 
     if (communicator_->deviceId() == kRoot) {
-      at::Tensor ref = at::arange(kTensorSize, tensor_options).unsqueeze(0) +
-          at::arange(1, communicator_->size() + 1, tensor_options)
+      at::Tensor ref = at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
+          at::arange(1, communicator_->size() + 1, tensor_options_)
                   .unsqueeze(1) *
               repetition;
       validate(output_tensor, ref);
@@ -111,12 +111,12 @@ TEST_P(CommunicationTest, Allgather) {
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::Allgather, out, in, all_ranks_);
 
-  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
+  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options_);
   at::Tensor output_tensor =
-      at::empty({communicator_->size(), kTensorSize}, tensor_options);
+      at::empty({communicator_->size(), kTensorSize}, tensor_options_);
   for (auto repetition : arange(kNumRepetitions)) {
     input_tensor.copy_(
-        at::arange(kTensorSize, tensor_options).unsqueeze(0) +
+        at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
         (communicator_->deviceId() + 1) * repetition);
 
     auto work = postSingleCommunication(
@@ -127,8 +127,8 @@ TEST_P(CommunicationTest, Allgather) {
         output_tensor);
     work->wait();
 
-    at::Tensor ref = at::arange(kTensorSize, tensor_options).unsqueeze(0) +
-        at::arange(1, communicator_->size() + 1, tensor_options).unsqueeze(1) *
+    at::Tensor ref = at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
+        at::arange(1, communicator_->size() + 1, tensor_options_).unsqueeze(1) *
             repetition;
     validate(output_tensor, ref);
   }
@@ -146,15 +146,15 @@ TEST_P(CommunicationTest, Scatter) {
   at::Tensor input_tensor;
   if (communicator_->deviceId() == kRoot) {
     input_tensor =
-        at::empty({communicator_->size(), kTensorSize}, tensor_options);
+        at::empty({communicator_->size(), kTensorSize}, tensor_options_);
   }
-  at::Tensor output_tensor = at::empty({1, kTensorSize}, tensor_options);
+  at::Tensor output_tensor = at::empty({1, kTensorSize}, tensor_options_);
 
   for (auto repetition : arange(kNumRepetitions)) {
     if (communicator_->deviceId() == kRoot) {
       input_tensor.copy_(
-          at::arange(kTensorSize, tensor_options).unsqueeze(0) +
-          at::arange(1, communicator_->size() + 1, tensor_options)
+          at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
+          at::arange(1, communicator_->size() + 1, tensor_options_)
                   .unsqueeze(1) *
               repetition);
     }
@@ -167,7 +167,7 @@ TEST_P(CommunicationTest, Scatter) {
         output_tensor);
     work->wait();
 
-    auto ref = at::arange(kTensorSize, tensor_options).unsqueeze(0) +
+    auto ref = at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
         (communicator_->deviceId() + 1) * repetition;
     validate(output_tensor, ref);
   }
@@ -184,12 +184,12 @@ TEST_P(CommunicationTest, Broadcast) {
 
   at::Tensor input_tensor;
   if (communicator_->deviceId() == kRoot) {
-    input_tensor = at::empty({kTensorSize}, tensor_options);
+    input_tensor = at::empty({kTensorSize}, tensor_options_);
   }
-  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options);
+  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options_);
   for (auto repetition : arange(kNumRepetitions)) {
     if (communicator_->deviceId() == kRoot) {
-      input_tensor.copy_(at::arange(kTensorSize, tensor_options) + repetition);
+      input_tensor.copy_(at::arange(kTensorSize, tensor_options_) + repetition);
     }
 
     auto work = postSingleCommunication(
@@ -202,7 +202,7 @@ TEST_P(CommunicationTest, Broadcast) {
       work->wait();
     }
 
-    auto ref = at::arange(kTensorSize, tensor_options) + repetition;
+    auto ref = at::arange(kTensorSize, tensor_options_) + repetition;
     validate(output_tensor, ref);
   }
 }
@@ -235,17 +235,17 @@ TEST_P(CommunicationTest, SendRecv) {
   at::Tensor input_tensor;
   at::Tensor output_tensor;
   if (rank == sender) {
-    input_tensor = at::empty({kTensorSize}, tensor_options);
+    input_tensor = at::empty({kTensorSize}, tensor_options_);
   } else {
     NVF_ERROR(rank == receiver);
-    output_tensor = at::empty({kTensorSize}, tensor_options);
+    output_tensor = at::empty({kTensorSize}, tensor_options_);
   }
 
   c10d::Backend* backend =
       communicator_->getBackendForTeam(communication->team(), GetParam());
   for (auto repetition : arange(kNumRepetitions)) {
     if (rank == sender) {
-      input_tensor.copy_(at::arange(kTensorSize, tensor_options) + repetition);
+      input_tensor.copy_(at::arange(kTensorSize, tensor_options_) + repetition);
     }
 
     auto work = postSingleCommunication(
@@ -253,7 +253,7 @@ TEST_P(CommunicationTest, SendRecv) {
     work->wait();
 
     if (rank == receiver) {
-      auto ref = at::arange(kTensorSize, tensor_options) + repetition;
+      auto ref = at::arange(kTensorSize, tensor_options_) + repetition;
       validate(output_tensor, ref);
     }
   }
@@ -274,13 +274,13 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::SendRecv, out, in, Team({sender}), sender);
 
-  at::Tensor input_tensor = at::empty({kTensorSize}, tensor_options);
+  at::Tensor input_tensor = at::empty({kTensorSize}, tensor_options_);
   at::Tensor output_tensor = at::empty_like(input_tensor);
 
   c10d::Backend* backend =
       communicator_->getBackendForTeam(communication->team(), GetParam());
   for (auto repetition : arange(kNumRepetitions)) {
-    input_tensor.copy_(at::arange(kTensorSize, tensor_options) + repetition);
+    input_tensor.copy_(at::arange(kTensorSize, tensor_options_) + repetition);
 
     postSingleCommunication(
         communication,
@@ -289,7 +289,7 @@ TEST_P(CommunicationTest, SendRecvToSelf) {
         input_tensor,
         output_tensor);
 
-    auto ref = at::arange(kTensorSize, tensor_options) + repetition;
+    auto ref = at::arange(kTensorSize, tensor_options_) + repetition;
     validate(output_tensor, ref);
   }
 }
@@ -303,12 +303,12 @@ TEST_P(CommunicationTest, Reduce) {
   auto communication = IrBuilder::create<Communication>(
       CommunicationType::Reduce, out, in, all_ranks_, kRoot, kReductionOp);
 
-  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
-  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options);
+  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options_);
+  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options_);
 
   for (auto repetition : arange(kNumRepetitions)) {
     input_tensor.copy_(
-        at::arange(kTensorSize, tensor_options).unsqueeze(0) +
+        at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
         (communicator_->deviceId() + 1) * repetition);
 
     auto work = postSingleCommunication(
@@ -321,7 +321,7 @@ TEST_P(CommunicationTest, Reduce) {
 
     if (communicator_->deviceId() == kRoot) {
       const int s = communicator_->size();
-      auto ref = at::arange(kTensorSize, tensor_options) * s +
+      auto ref = at::arange(kTensorSize, tensor_options_) * s +
           s * (s + 1) / 2 * repetition;
       validate(output_tensor, ref);
     }
@@ -342,11 +342,11 @@ TEST_P(CommunicationTest, Allreduce) {
       /*root=*/-1,
       kReductionOp);
 
-  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options);
-  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options);
+  at::Tensor input_tensor = at::empty({1, kTensorSize}, tensor_options_);
+  at::Tensor output_tensor = at::empty({kTensorSize}, tensor_options_);
   for (auto repetition : arange(kNumRepetitions)) {
     input_tensor.copy_(
-        at::arange(kTensorSize, tensor_options).unsqueeze(0) +
+        at::arange(kTensorSize, tensor_options_).unsqueeze(0) +
         (communicator_->deviceId() + 1) * repetition);
 
     auto work = postSingleCommunication(
@@ -358,7 +358,7 @@ TEST_P(CommunicationTest, Allreduce) {
     work->wait();
 
     const int s = communicator_->size();
-    auto ref = at::arange(kTensorSize, tensor_options) * s +
+    auto ref = at::arange(kTensorSize, tensor_options_) * s +
         s * (s + 1) / 2 * repetition;
     validate(output_tensor, ref);
   }
@@ -381,10 +381,10 @@ TEST_P(CommunicationTest, ReduceScatter) {
   const int num_devices = communicator_->size();
   const int device_id = communicator_->deviceId();
   at::Tensor unsharded_input_tensor =
-      at::empty({num_devices, num_devices, kTensorSize}, tensor_options);
+      at::empty({num_devices, num_devices, kTensorSize}, tensor_options_);
   at::Tensor input_tensor =
       unsharded_input_tensor.slice(0, device_id, device_id + 1);
-  at::Tensor output_tensor = at::empty({1, kTensorSize}, tensor_options);
+  at::Tensor output_tensor = at::empty({1, kTensorSize}, tensor_options_);
 
   for (auto repetition : arange(kNumRepetitions)) {
     std::ignore = repetition;
@@ -392,7 +392,7 @@ TEST_P(CommunicationTest, ReduceScatter) {
     // Create a tensor with integer values to avoid rounding error so we can
     // validate using `equal` for more confidence.
     unsharded_input_tensor.copy_(at::randint(
-        2, {num_devices, num_devices, kTensorSize}, tensor_options));
+        2, {num_devices, num_devices, kTensorSize}, tensor_options_));
 
     auto work = postSingleCommunication(
         communication,
@@ -464,20 +464,20 @@ TEST_F(P2PCommunicationTest, CudaComm) {
 
   hir::HostIrEvaluator executor(std::move(container), communicator_);
 
-  at::Tensor send_tensor = at::empty({kTensorSize}, tensor_options);
-  at::Tensor recv_tensor = at::empty({kTensorSize}, tensor_options);
+  at::Tensor send_tensor = at::empty({kTensorSize}, tensor_options_);
+  at::Tensor recv_tensor = at::empty({kTensorSize}, tensor_options_);
 
   std::unordered_map<Val*, PolymorphicValue> inputs = {
       {send_tv, send_tensor}, {recv_tv, recv_tensor}};
 
   for (auto repetition : c10::irange(kNumRepetitions)) {
     send_tensor.copy_(
-        at::arange(kTensorSize, tensor_options) + repetition * 10 +
+        at::arange(kTensorSize, tensor_options_) + repetition * 10 +
         100 * my_rank);
 
     executor.runWithInput(inputs);
 
-    auto ref = at::arange(kTensorSize, tensor_options) + repetition * 10 +
+    auto ref = at::arange(kTensorSize, tensor_options_) + repetition * 10 +
         100 * recv_peer;
     EXPECT_TRUE(at::allclose(recv_tensor, ref))
         << "Rank " << my_rank << " failed at repetition " << repetition

--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -73,7 +73,7 @@ TEST_P(LowerGatherTest, ) {
 
   const auto device_id = communicator_->deviceId();
   at::Tensor unsharded_tensor =
-      at::randn({in_mesh.size(), kTensorSize}, tensor_options);
+      at::randn({in_mesh.size(), kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -145,7 +145,7 @@ TEST_P(LowerScatterTest, ) {
 
   const auto device_id = communicator_->deviceId();
   at::Tensor unsharded_tensor =
-      at::randn({out_mesh.size(), kTensorSize}, tensor_options);
+      at::randn({out_mesh.size(), kTensorSize}, tensor_options_);
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor out_tensor =
@@ -197,7 +197,7 @@ TEST_P(LowerSendRecvTest, ) {
 
   const auto device_id = communicator_->deviceId();
   at::Tensor unsharded_tensor =
-      at::randn({in_mesh.size(), kTensorSize}, tensor_options);
+      at::randn({in_mesh.size(), kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -258,7 +258,7 @@ TEST_P(LowerCollectiveTest, Allgather) {
   in->axis(0)->parallelize(ParallelType::DIDx);
 
   at::Tensor unsharded_tensor =
-      at::randn({num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -318,7 +318,7 @@ TEST_P(LowerCollectiveTest, Broadcast) {
   out->setDeviceMesh(mesh);
 
   at::Tensor unsharded_tensor =
-      at::randn({num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, kTensorSize}, tensor_options_);
   const auto device_id = communicator_->deviceId();
   at::Tensor in_tensor = unsharded_tensor.slice(0, device_id, device_id + 1);
 
@@ -351,7 +351,7 @@ TEST_P(LowerCollectiveTest, Reduce) {
   in->axis(0)->parallelize(ParallelType::DIDx);
 
   at::Tensor unsharded_in_tensor =
-      at::randn({num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, kTensorSize}, tensor_options_);
   const auto device_id = communicator_->deviceId();
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
@@ -382,7 +382,7 @@ TEST_P(LowerCollectiveTest, Allreduce) {
   in->axis(0)->parallelize(ParallelType::DIDx);
 
   at::Tensor unsharded_in_tensor =
-      at::randn({num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -411,7 +411,7 @@ TEST_P(LowerCollectiveTest, Allreduce_Concrete) {
   in->axis(0)->parallelize(ParallelType::DIDx);
 
   at::Tensor unsharded_in_tensor =
-      at::randn({num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -448,7 +448,7 @@ TEST_P(LowerCollectiveTest, ReduceScatter) {
   out->axis(0)->parallelize(ParallelType::DIDx);
   out->setAllocationDomain(out->getLoopDomain(), true);
 
-  at::Tensor unsharded_in_tensor = at::randn({d * 2, d * 3}, tensor_options);
+  at::Tensor unsharded_in_tensor = at::randn({d * 2, d * 3}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -499,7 +499,7 @@ TEST_P(LowerCollectiveTest, ReduceScatter_LogicalSplit) {
   out->axis(1)->parallelize(ParallelType::DIDx);
 
   at::Tensor unsharded_in_tensor =
-      at::randn({num_devices, num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, num_devices, kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -533,7 +533,7 @@ TEST_P(LowerCollectiveTest, ReduceScatter_Allgather) {
   fusion->addOutput(out);
 
   at::Tensor unsharded_in_tensor =
-      at::randn({num_devices, num_devices, kTensorSize}, tensor_options);
+      at::randn({num_devices, num_devices, kTensorSize}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -573,7 +573,7 @@ TEST_P(LowerCollectiveTest, ReduceScatterNoncontig) {
   fusion->addOutput(tv1);
 
   at::Tensor unsharded_in_tensor =
-      at::randint(2, {5, d * 3, d * 7}, tensor_options);
+      at::randint(2, {5, d * 3, d * 7}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, 1, mesh);
 
   at::Tensor expected_output =
@@ -612,7 +612,7 @@ TEST_P(LowerCollectiveTest, AllreduceNoncontig) {
   fusion->addInput(tv0);
   fusion->addOutput(tv1);
 
-  at::Tensor unsharded_in_tensor = at::randn({5, d * 3}, tensor_options);
+  at::Tensor unsharded_in_tensor = at::randn({5, d * 3}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, 1, mesh);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -653,7 +653,7 @@ TEST_P(LowerCollectiveTest, Allgather_CompliantAllocation) {
   fusion->addInput(tv0);
   fusion->addOutput(tv1);
 
-  at::Tensor unsharded_in_tensor = at::randn({d * 3, 5}, tensor_options);
+  at::Tensor unsharded_in_tensor = at::randn({d * 3, 5}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, 0, mesh).t();
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -695,7 +695,7 @@ TEST_P(LowerCollectiveTest, Allgather_NonCompliantAllocation) {
   fusion->addInput(tv0);
   fusion->addOutput(tv1);
 
-  at::Tensor unsharded_in_tensor = at::randn({5, d * 3}, tensor_options);
+  at::Tensor unsharded_in_tensor = at::randn({5, d * 3}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, 1, mesh);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -735,7 +735,7 @@ TEST_P(LowerCollectiveTest, Allgather_NoncontiguousOutput) {
   in->outer_split(1, d);
   in->axis(1)->parallelize(ParallelType::DIDx);
 
-  at::Tensor unsharded_in_tensor = at::randn({2, d * 3}, tensor_options);
+  at::Tensor unsharded_in_tensor = at::randn({2, d * 3}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, 1, mesh);
 
   FusionExecutorCache executor_cache(std::move(fusion));

--- a/tests/cpp/test_multidevice_matmul.cpp
+++ b/tests/cpp/test_multidevice_matmul.cpp
@@ -378,8 +378,8 @@ TEST_F(DistributedMatmulTest, PresegPreservesSharding) {
     tv->axis(0)->parallelize(ParallelType::DIDx);
   }
 
-  auto x_tensor = at::randn({12, 48}, tensor_options);
-  auto w_tensor = at::randn({mesh.size(), 36, 48}, tensor_options);
+  auto x_tensor = at::randn({12, 48}, tensor_options_);
+  auto w_tensor = at::randn({mesh.size(), 36, 48}, tensor_options_);
   auto sharded_w_tensor = shardTensor(w_tensor, w);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -420,9 +420,10 @@ TEST_F(DistributedMatmulTest, AnnotateWeightOnly) {
   // y is expected to have shape [2, D*5] and to be also column-wise sharded.
   constexpr int64_t kLowerBound = 0;
   constexpr int64_t kUpperBound = 10;
-  auto x_tensor = at::randint(kLowerBound, kUpperBound, {2, 3}, tensor_options);
+  auto x_tensor =
+      at::randint(kLowerBound, kUpperBound, {2, 3}, tensor_options_);
   auto w_tensor = at::randint(
-      kLowerBound, kUpperBound, {mesh.size(), 3, 5}, tensor_options);
+      kLowerBound, kUpperBound, {mesh.size(), 3, 5}, tensor_options_);
   auto sharded_w_tensor = shardTensor(w_tensor, w);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -483,8 +484,8 @@ TEST_F(DistributedMatmulTest, RowParallelLinear) {
   constexpr int64_t b = 1;
   for (int64_t s : {4, 8, 16}) {
     // Use randint instead of randn to avoid floating point accumulation errors.
-    auto x_tensor = at::randint(/*high=*/5, {b, s, e}, tensor_options);
-    auto w_tensor = at::randint(/*high=*/5, {e, e}, tensor_options);
+    auto x_tensor = at::randint(/*high=*/5, {b, s, e}, tensor_options_);
+    auto w_tensor = at::randint(/*high=*/5, {e, e}, tensor_options_);
     auto sharded_x = shardTensor(x_tensor, x);
     auto sharded_w = shardTensor(w_tensor, w);
 

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -236,8 +236,8 @@ TEST_F(PipelineTest, Pipeline) {
   // Note: each process is binded to a different GPU
   // Note: the concrete values are only used at the relevant ranks
   unsharded_args = {
-      at::randn(input_shape1, tensor_options),
-      at::randn(input_shape2, tensor_options)};
+      at::randn(input_shape1, tensor_options_),
+      at::randn(input_shape2, tensor_options_)};
 
   SKIP_IF_NOT_ENOUGH_DEVICES(fusion);
   executeAndValidate();
@@ -314,7 +314,7 @@ TEST_P(PipelineTestTwoStages, Communication) {
     tv3->axis(sharded_dim)->parallelize(ParallelType::DIDx);
   }
 
-  unsharded_args = {at::randn(unsharded_input_sizes, tensor_options)};
+  unsharded_args = {at::randn(unsharded_input_sizes, tensor_options_)};
 
   if (use_fusion_executor_cache) {
     host_ir_executor_params.use_fusion_executor_cache = true;

--- a/tests/cpp/test_multidevice_sharding.cpp
+++ b/tests/cpp/test_multidevice_sharding.cpp
@@ -62,7 +62,7 @@ TEST_P(MultiDeviceReductionTest, UnshardedInput_ShardedOutput) {
     tv->setDeviceMesh(mesh);
   }
 
-  auto x0 = at::randn(input_shape, tensor_options);
+  auto x0 = at::randn(input_shape, tensor_options_);
   auto x1 = shardTensor(x0, tv1);
   auto x2 = x1 + x1;
   auto x3 = shardTensor(at::sum(x0 + x0, {sharded_input_dim}), tv3);
@@ -100,7 +100,7 @@ TEST_P(MultiDeviceReductionTest, ShardedInput_ReplicatedOutput) {
     tv->setDeviceMesh(mesh);
   }
 
-  auto x1 = at::randn(unsharded_input_shape, tensor_options);
+  auto x1 = at::randn(unsharded_input_shape, tensor_options_);
   KernelArgumentHolder args = {shardTensor(x1, tv0)};
   auto x2 = x1 * 2;
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -135,7 +135,7 @@ TEST_F(MultiDeviceTest, Reduction) {
   in->setDeviceMesh(mesh);
   in->axis(0)->parallelize(ParallelType::DIDx);
 
-  auto unsharded_in_tensor = at::randn({mesh.size(), 4}, tensor_options);
+  auto unsharded_in_tensor = at::randn({mesh.size(), 4}, tensor_options_);
   auto in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -204,7 +204,7 @@ TEST_F(MultiDeviceTest, BackpropMeshes) {
   x->setDeviceMesh(mesh);
   x->axis(0)->parallelize(ParallelType::DIDx);
 
-  at::Tensor unsharded_x_tensor = at::randn({num_devices, 4}, tensor_options);
+  at::Tensor unsharded_x_tensor = at::randn({num_devices, 4}, tensor_options_);
   at::Tensor x_tensor = shardTensor(unsharded_x_tensor, x);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -240,7 +240,7 @@ TEST_F(MultiDeviceTest, DivideBySum) {
   const int64_t b = 2;
   const int64_t h = d * 3;
   const int64_t s = 5;
-  at::Tensor unsharded_x_tensor = at::randint(5, {b, h, s, s}, tensor_options);
+  at::Tensor unsharded_x_tensor = at::randint(5, {b, h, s, s}, tensor_options_);
   at::Tensor x_tensor = shardTensor(unsharded_x_tensor, x);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -317,7 +317,7 @@ TEST_F(MultiDeviceTest, Issue2758) {
   fusion->addOutput(out);
 
   at::Tensor unsharded_in_tensor =
-      at::zeros({num_devices, num_devices, 4}, tensor_options);
+      at::zeros({num_devices, num_devices, 4}, tensor_options_);
   at::Tensor in_tensor = shardTensor(unsharded_in_tensor, in);
 
   FusionExecutorCache executor_cache(std::move(fusion));
@@ -356,7 +356,7 @@ TEST_F(MultiDeviceTest, Transpose) {
   fusion->addOutput(out);
 
   // Sizes need to be large enough to trigger the transpose scheduler.
-  at::Tensor in_tensor = at::randn({1024, 1024}, tensor_options);
+  at::Tensor in_tensor = at::randn({1024, 1024}, tensor_options_);
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs({in_tensor})[0].as<at::Tensor>();
@@ -393,7 +393,7 @@ TEST_F(MultiDeviceTest, LoopSplit) {
     tv->axis(0)->parallelize(ParallelType::DIDx);
   }
 
-  at::Tensor in_tensor = at::randn({3}, tensor_options);
+  at::Tensor in_tensor = at::randn({3}, tensor_options_);
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs({in_tensor})[0].as<at::Tensor>();
@@ -432,7 +432,7 @@ TEST_F(MultiDeviceTest, LoopSplitWithReorder) {
   out->axis(1)->parallelize(ParallelType::DIDx);
   out->setAllocationDomain(out->getLoopDomain(), true);
 
-  at::Tensor in_tensor = at::randn({3, 2}, tensor_options).t();
+  at::Tensor in_tensor = at::randn({3, 2}, tensor_options_).t();
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs({in_tensor})[0].as<at::Tensor>();
@@ -516,7 +516,7 @@ TEST_P(MultiDeviceBroadcastTest, Expanded) {
 
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor in_tensor =
-      at::randn({8}, tensor_options)
+      at::randn({8}, tensor_options_)
           .as_strided(
               {parallelizes_broadcast ? 3 : num_devices * 3, 8}, {0, 1});
   at::Tensor out_tensor =
@@ -601,8 +601,8 @@ TEST_F(MultiDeviceTest, BiasAddRelu) {
   }
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor in_tensor = at::randn({b, s, h / d}, tensor_options);
-  at::Tensor bias_tensor = at::randn({h / d}, tensor_options);
+  at::Tensor in_tensor = at::randn({b, s, h / d}, tensor_options_);
+  at::Tensor bias_tensor = at::randn({h / d}, tensor_options_);
   KernelArgumentHolder args = {in_tensor, bias_tensor};
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs(args)[0].as<at::Tensor>();
@@ -633,7 +633,7 @@ TEST_F(MultiDeviceTest, ViewWithSplit) {
   out->setAllocationDomain(out->getLoopDomain(), true);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor in_tensor = at::randn({2, 15}, tensor_options);
+  at::Tensor in_tensor = at::randn({2, 15}, tensor_options_);
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs({in_tensor})[0].as<at::Tensor>();
   testValidate(
@@ -674,7 +674,7 @@ TEST_F(MultiDeviceTest, ViewWithMerge) {
   out->setAllocationDomain(out->getLoopDomain(), true);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor in_tensor = at::randn({2, 3, 5}, tensor_options);
+  at::Tensor in_tensor = at::randn({2, 3, 5}, tensor_options_);
   at::Tensor out_tensor =
       executor_cache.runFusionWithInputs({in_tensor})[0].as<at::Tensor>();
   testValidate(
@@ -733,7 +733,7 @@ TEST_P(InsertReshardingTest, Execute) {
     tv3->axis(1)->parallelize(ParallelType::DIDx);
   }
 
-  at::Tensor t0 = at::randint(3, {2, mesh.size(), 5}, tensor_options);
+  at::Tensor t0 = at::randint(3, {2, mesh.size(), 5}, tensor_options_);
   at::Tensor t1 = t0 * t0;
   at::Tensor t2 = t0 + t1;
   at::Tensor t5 = t2 * t2.sum({1}, /*keepdim=*/true);
@@ -809,7 +809,7 @@ TEST_F(MultiDeviceTest, TransformPropagatorSplitReshape) {
   tv1->setAllocationDomain(tv1->getLoopDomain(), true);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp = at::randn({b, s, d * h * e}, tensor_options);
+  at::Tensor inp = at::randn({b, s, d * h * e}, tensor_options_);
   at::Tensor sharded_inp = shardTensor(inp, tv0);
 
   at::Tensor nvf_out =
@@ -848,7 +848,7 @@ TEST_F(MultiDeviceTest, LoopShardedSplitReshapeIds) {
   tv1->axis(-3)->parallelize(ParallelType::DIDx);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp = at::randn({b, s, d * h * e}, tensor_options);
+  at::Tensor inp = at::randn({b, s, d * h * e}, tensor_options_);
   at::Tensor sharded_inp = shardTensor(inp, -1, mesh);
 
   at::Tensor nvf_out =
@@ -885,7 +885,7 @@ TEST_F(MultiDeviceTest, LoopShardedMergeReshapeIds) {
   tv1->axis(-2)->parallelize(ParallelType::DIDx);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp = at::randn({b, s, d * h, e}, tensor_options);
+  at::Tensor inp = at::randn({b, s, d * h, e}, tensor_options_);
   at::Tensor sharded_inp = shardTensor(inp, -2, mesh);
   at::Tensor nvf_out =
       executor_cache.runFusionWithInputs({sharded_inp})[0].as<at::Tensor>();
@@ -915,7 +915,7 @@ TEST_F(MultiDeviceTest, MultipleTransformReshape) {
   tv0->split(0, d, /*inner_split=*/false);
   tv0->axis(0)->parallelize(ParallelType::DIDx);
 
-  at::Tensor inp = at::randn({d * b, s, h * e}, tensor_options);
+  at::Tensor inp = at::randn({d * b, s, h * e}, tensor_options_);
   at::Tensor sharded_inp = shardTensor(inp, 0, mesh);
   FusionExecutorCache executor_cache(std::move(fusion));
   at::Tensor nvf_out =
@@ -942,7 +942,7 @@ TEST_F(MultiDeviceTest, AliasingRetainsSharding) {
   tv0->axis(0)->parallelize(ParallelType::DIDx);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor t0 = at::randn({3 * d}, tensor_options);
+  at::Tensor t0 = at::randn({3 * d}, tensor_options_);
   at::Tensor sharded_t0 = shardTensor(t0, 0, mesh);
   at::Tensor nvf_out =
       executor_cache.runFusionWithInputs({sharded_t0})[0].as<at::Tensor>();
@@ -981,9 +981,11 @@ TEST_F(MultiDeviceTest, DecomposeRowParallelLinearWithBias) {
   tv2->setDeviceMesh(mesh);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp = at::ones({b, s, d * e}, tensor_options.dtype(at::kBFloat16));
-  at::Tensor weight = at::ones({e, d * e}, tensor_options.dtype(at::kBFloat16));
-  at::Tensor bias = at::ones({e}, tensor_options.dtype(at::kBFloat16));
+  at::Tensor inp =
+      at::ones({b, s, d * e}, tensor_options_.dtype(at::kBFloat16));
+  at::Tensor weight =
+      at::ones({e, d * e}, tensor_options_.dtype(at::kBFloat16));
+  at::Tensor bias = at::ones({e}, tensor_options_.dtype(at::kBFloat16));
   at::Tensor sharded_inp = shardTensor(inp, -1, mesh);
   at::Tensor sharded_weight = shardTensor(weight, -1, mesh);
   at::Tensor nvf_out =
@@ -1027,9 +1029,9 @@ TEST_F(MultiDeviceTest, OuterReductionShardedInnerDimension) {
 
   fusion->addOutput(tv7);
   std::vector<at::Tensor> inputs = {
-      at::randn({b, s, h, e / h}, tensor_options.dtype(at::kBFloat16)),
-      at::randn({b, s, h, e / h}, tensor_options.dtype(at::kBFloat16)),
-      at::randn({b, s, h, e / h}, tensor_options.dtype(at::kBFloat16))};
+      at::randn({b, s, h, e / h}, tensor_options_.dtype(at::kBFloat16)),
+      at::randn({b, s, h, e / h}, tensor_options_.dtype(at::kBFloat16)),
+      at::randn({b, s, h, e / h}, tensor_options_.dtype(at::kBFloat16))};
 
   std::vector<at::Tensor> sharded_inputs = {
       shardTensor(inputs[0], 2, mesh),
@@ -1108,7 +1110,7 @@ TEST_F(MultiDeviceTest, AllocationPermutationOfLoop) {
       optimization_guard(false);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp = at::randn({5, 3 * d}, tensor_options);
+  at::Tensor inp = at::randn({5, 3 * d}, tensor_options_);
   at::Tensor sharded_inp = shardTensor(inp, -1, mesh);
   at::Tensor nvf_out =
       executor_cache.runFusionWithInputs({sharded_inp})[0].as<at::Tensor>();

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -1024,15 +1024,15 @@ TEST_P(DistributedTransformerTest, LoopSplitMLP) {
   w1->axis(1)->parallelize(ParallelType::DIDx);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp_tensor = at::randn({B, S, E}, tensor_options.dtype(at_dtype));
+  at::Tensor inp_tensor = at::randn({B, S, E}, tensor_options_.dtype(at_dtype));
   at::Tensor w0_tensor =
-      at::randn({4 * E, E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({4 * E, E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor b0_tensor =
-      at::randn({4 * E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({4 * E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor w1_tensor =
-      at::randn({E, 4 * E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({E, 4 * E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor b1_tensor =
-      at::randn({E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({E}, tensor_options_.dtype(at_dtype)) * kParamScale;
 
   at::Tensor w0_sharded = shardTensor(w0_tensor, 0, mesh);
   at::Tensor b0_sharded = shardTensor(b0_tensor, 0, mesh);
@@ -1118,18 +1118,18 @@ TEST_P(DistributedTransformerTest, LoopSplitMHAFwd) {
   mha_w1->axis(1)->parallelize(ParallelType::DIDx);
 
   FusionExecutorCache executor_cache(std::move(fusion));
-  at::Tensor inp_tensor = at::randn({B, S, E}, tensor_options.dtype(at_dtype));
+  at::Tensor inp_tensor = at::randn({B, S, E}, tensor_options_.dtype(at_dtype));
   at::Tensor mha_w0_tensor =
-      at::randn({3 * E, E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({3 * E, E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor sharded_mha_w0 = shardTensor(mha_w0_tensor, 0, mesh);
   at::Tensor mha_b0_tensor =
-      at::randn({3 * E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({3 * E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor sharded_mha_b0 = shardTensor(mha_b0_tensor, 0, mesh);
   at::Tensor mha_w1_tensor =
-      at::randn({E, E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({E, E}, tensor_options_.dtype(at_dtype)) * kParamScale;
   at::Tensor sharded_mha_w1 = shardTensor(mha_w1_tensor, 1, mesh);
   at::Tensor mha_b1_tensor =
-      at::randn({E}, tensor_options.dtype(at_dtype)) * kParamScale;
+      at::randn({E}, tensor_options_.dtype(at_dtype)) * kParamScale;
 
   KernelArgumentHolder args = {
       inp_tensor,


### PR DESCRIPTION
## Summary
- rename MultiDeviceTest::tensor_options to tensor_options_ for consistent private member naming

## Testing
- _bn && mpirun -np 2 bin/test_multidevice
