### PR TITLE
Jj/fixing grouped mm test quantization

### DIFF
--- a/tests/python/direct/test_narrow_precision.py
+++ b/tests/python/direct/test_narrow_precision.py
@@ -134,7 +134,9 @@ def test_cutlass_nvfp4_grouped_mm(
 
     mat1_ref = torch.testing.make_tensor((m, k), dtype=torch.float32, device="cuda:0")
     # format is g, n, k instead of g, k, n
-    mat2_ref = torch.testing.make_tensor((g, n, k), dtype=torch.float32, device="cuda:0")
+    mat2_ref = torch.testing.make_tensor(
+        (g, n, k), dtype=torch.float32, device="cuda:0"
+    )
 
     offsets = torch.empty((g,), dtype=torch.int32, device="cuda:0")
     blockscale_offsets = torch.empty((g,), dtype=torch.int32, device="cuda:0")
@@ -267,5 +269,5 @@ def test_cutlass_nvfp4_grouped_mm(
             )
             * mat2_gs[i]
         )
-        
+
     assert torch.allclose(o_decomposed_ref, o[0], atol=1e-2, rtol=1e-2)

--- a/tests/python/direct/test_narrow_precision.py
+++ b/tests/python/direct/test_narrow_precision.py
@@ -245,7 +245,6 @@ def test_cutlass_nvfp4_grouped_mm(
     o, _ = nvfuser_direct_test.exec_nvfuser(nvfuser_fusion_id0, inputs)
 
     o_decomposed_ref = torch.empty(m, n, dtype=torch.bfloat16, device="cuda:0")
-    o_ref = torch.empty(m, n, dtype=torch.bfloat16, device="cuda:0")
     for i in range(g):
         l = offsets[i]
         l_sf = blockscale_offsets[i]
@@ -268,6 +267,5 @@ def test_cutlass_nvfp4_grouped_mm(
             )
             * mat2_gs[i]
         )
-        o_ref[l:r] = mat1_ref[l:r] @ mat2_ref[i].tranpose(-1, -2)
         
     assert torch.allclose(o_decomposed_ref, o[0], atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
global scaling factor was missing the reciprocal. So the nvfp4 math was wrong inside grouped gemm.

Because reference implementation used the same factor, the issue didn't get caught earlier.