### PR TITLE
ScanOp supports bfloat16 and half inputs

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1747,7 +1747,23 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         ? grouped_id->extent()->evaluate().as<int64_t>()
         : 1;
 
-    template_args.arg(input->dtype()); // DataT
+    // Unlike ReductionOp, ScanOp supports bfloat16 and half. The
+    // nvFuser bfoat16 and half types do not support arithmetic
+    // operations, so they are cast to the corresponding CUDA native
+    // type.
+    const auto dtype = input->dtype();
+    std::string native_type_str;
+    if (dtype == PrimDataType::BFloat16) {
+      native_type_str = "__nv_bfloat16";
+    } else if (dtype == PrimDataType::Half) {
+      native_type_str = "__nv_half";
+    } else {
+      std::stringstream ss;
+      ss << dtype;
+      native_type_str = ss.str();
+    }
+    // template_args.arg(input->dtype()); // DataT
+    template_args.arg(native_type_str); // DataT
     template_args.arg(items_per_thread); // ITEMS_PER_THREAD
 
     // BlockDim type - using DefaultBlockDim pattern
@@ -1761,7 +1777,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // are not used here because out-of-bounds elements are initizlied
     // to the max or min value accordingly.
     func_args.arg("*(")
-        .append(output->dtype())
+        .append(native_type_str)
         .append("(*)[")
         .append(items_per_thread)
         .append("])")
@@ -1769,7 +1785,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
         .append(genInline(output))
         .append(")");
     func_args.arg("*(")
-        .append(input->dtype())
+        .append(native_type_str)
         .append("(*)[")
         .append(items_per_thread)
         .append("])")
@@ -1783,7 +1799,7 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
     // Fourth argument: binary operation lambda
     // This is slightly different from getReductionOp
     std::stringstream lambda;
-    lambda << "[](const " << input->dtype() << "& a, const " << input->dtype()
+    lambda << "[](const " << native_type_str << "& a, const " << native_type_str
            << "& b) "
            << "{ return "
            << genBinaryOp(scan->opType(), input->dtype(), "a", "b") << "; }";

--- a/csrc/ops/arith.cpp
+++ b/csrc/ops/arith.cpp
@@ -2592,6 +2592,9 @@ TensorView* scan(
     return set(in_tv);
   }
 
+  // Unlike ReducitonOp, low-precision input is not upcast to
+  // float. This seems inconsistent but aligns with the PyTorch eager
+  // implementation.
   DataType dtype = in_tv->dtype();
   auto new_dom = ops::newOutputDomain({in_tv});
   auto* td = IrBuilder::create<TensorDomain>(

--- a/csrc/ops/arith.h
+++ b/csrc/ops/arith.h
@@ -808,7 +808,11 @@ NVF_API TopKResult topk(
 //!   y[0] = x[0]
 //!   y[i] = y[i-1] + x[i] for 0 < i < n
 //!
-//! If the dimension being scanned is an expanded broadcast, we throw an error.
+//! If the dimension being scanned is an expanded broadcast, we throw
+//! an error.
+//!
+//! Note that unlike reductions, low precision inputs are not
+//! automtaically upcast to float, as that is the PyTorch convention.
 NVF_API TensorView* scan(
     TensorView* in_tv,
     int64_t dim,


### PR DESCRIPTION
In PyTorch, unlike reductions, scan does not automatically upcast to float for low-precision inputs. It seems inconsistent, but that is what it is. To follow the PyTorch convention, this PR adds support of bfloat16 and half inputs for `ScanOp`.
