### PR TITLE
[DRAFT] Have the pointwise scheduler process the Block Quantization Op.

### DIFF
--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1669,17 +1669,18 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
 
   void handle(const BlockQuantizationOp* bqop) final {
     // Get the vectorization size for items per thread
-    const auto input = bqop->in()->as<kir::TensorIndex>();
-    auto vectorized_input_to_reshape = input->view()->definition()->input(0);
-    int64_t vector_word_size = ir_utils::getVectorizeSize(
-        vectorized_input_to_reshape->as<TensorView>());
-    NVF_ERROR(
-        vector_word_size == 4,
-        "Vectorization size should be 4 for "
-        "BlockQuantizationOp: ",
-        bqop->toString());
+    // const auto input = bqop->in()->as<kir::TensorIndex>();
+    // auto vectorized_input_to_reshape = input->view()->definition()->input(0);
+    // int64_t vector_word_size = ir_utils::getVectorizeSize(
+    //     vectorized_input_to_reshape->as<TensorView>());
+    // NVF_ERROR(
+    //     vector_word_size == 4,
+    //     "Vectorization size should be 4 for "
+    //     "BlockQuantizationOp: ",
+    //     bqop->toString());
     ArgumentBuilder template_args;
-    template_args.arg(vector_word_size); // ITEMS_PER_THREAD
+    // template_args.arg(vector_word_size); // ITEMS_PER_THREAD
+    template_args.arg(4); // ITEMS_PER_THREAD
 
     // Function arguments
     ArgumentBuilder func_args;

--- a/csrc/codegen.cpp
+++ b/csrc/codegen.cpp
@@ -1668,19 +1668,17 @@ class CudaKernelGenerator : private kir::ConstIrVisitor {
   }
 
   void handle(const BlockQuantizationOp* bqop) final {
-    // Get the vectorization size for items per thread
-    // const auto input = bqop->in()->as<kir::TensorIndex>();
-    // auto vectorized_input_to_reshape = input->view()->definition()->input(0);
-    // int64_t vector_word_size = ir_utils::getVectorizeSize(
-    //     vectorized_input_to_reshape->as<TensorView>());
-    // NVF_ERROR(
-    //     vector_word_size == 4,
-    //     "Vectorization size should be 4 for "
-    //     "BlockQuantizationOp: ",
-    //     bqop->toString());
+    auto vectorized_input_to_reshape =
+        bqop->quantizedOutput()->as<kir::TensorIndex>()->view();
+    int64_t vector_word_size =
+        ir_utils::getVectorizeSize(vectorized_input_to_reshape);
+    NVF_ERROR(
+        vector_word_size == 4,
+        "Vectorization size should be 4 for "
+        "BlockQuantizationOp: ",
+        bqop->toString());
     ArgumentBuilder template_args;
-    // template_args.arg(vector_word_size); // ITEMS_PER_THREAD
-    template_args.arg(4); // ITEMS_PER_THREAD
+    template_args.arg(vector_word_size); // ITEMS_PER_THREAD
 
     // Function arguments
     ArgumentBuilder func_args;

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -1311,11 +1311,7 @@ void PointWiseScheduler::schedule(
       pparams != nullptr,
       "Incorrect parameters sent to PointWiseScheduler::schedule",
       params);
-  std::cout << "before pointwise sched" << std::endl;
-  fusion->print();
   schedulePointwise(fusion, pparams);
-  std::cout << "after sched" << std::endl;
-  fusion->print();
 }
 
 } // namespace nvfuser

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -1254,10 +1254,10 @@ void schedulePointwise(Fusion* fusion, const PointwiseParams* pparams) {
   }
 
   // Begin by inlining at the unswitch position for the entire DAG. The cached
-  // inputs, and outputs will keep this inline position, but other tensors
-  // will get a higher position in later inline propagation. We need this
-  // separate step because we were not using ParallelType::Unroll, so we have
-  // to do unrolling manually.
+  // inputs, and outputs will keep this inline position, but other tensors will
+  // get a higher position in later inline propagation. We need this separate
+  // step because we were not using ParallelType::Unroll, so we have to do
+  // unrolling manually.
   inlineAllAt(reference_tv, unswitch_pos, true);
 
   auto all_tvs = fusion->allTvs();

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -60,7 +60,6 @@ bool checkCanSchedule(Fusion* fusion, SchedulerType scheduler_type) {
           // TODO: remove this once we have a scheduler for it
           PreprocessGroupedMatmulInputSf,
           TopKOp,
-          BlockQuantizationOp,
           ScanOp>(fusion)) {
     scheduler_debug_utils::canScheduleRejectReason(
         scheduler_type, "Has unsupported ops");

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -1342,7 +1342,10 @@ std::vector<std::pair<TensorView*, TensorView*>> cacheAndForkOutputs(
     if (output->definition() == nullptr ||
         // the output of ScatterOp must on the global memory due to the random
         // or atomic access.
-        output->definition()->isA<ScatterOp>()) {
+        output->definition()->isA<ScatterOp>() ||
+        (output->definition()->isA<BlockQuantizationOp>() &&
+         output->definition()->as<BlockQuantizationOp>()->blockScales() ==
+             output)) {
       continue;
     }
     if (!output->uses().empty()) {

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -823,16 +823,15 @@ Val* ContiguousInnerDimensionsMapper::getContigMergeOfInnerSize(
         NVF_ERROR(
             expr->isA<Split>(),
             "alloc domain of block quantization should only have splits");
+        if (!expr->as<Split>()->outer()->isDeviceDim()) {
+          continue;
+        }
       } else {
         validateDeviceSplit(expr);
       }
       auto* split = expr->as<Split>();
       logical_id = split->in();
-      if (!is_block_scales_output ||
-          (is_block_scales_output && split->outer()->isDeviceDim())) {
-        num_devices =
-            SimplifyingIrBuilder::mulExpr(num_devices, split->factor());
-      }
+      num_devices = SimplifyingIrBuilder::mulExpr(num_devices, split->factor());
     }
 
     // Mapping order isn't correct, cannot expand vectorization dimension.

--- a/tests/cpp/test_low_precision_recipe.cpp
+++ b/tests/cpp/test_low_precision_recipe.cpp
@@ -495,13 +495,6 @@ TEST_F(BQTest, AutoScheduleBasicTest) {
 
   quantization_results.block_scales->setLoopDomain(temp_loop_domain);
 
-  // back to a 3D logical domain.
-  // quantization_results.block_scales->merge(0);
-  // quantization_results.block_scales->merge(0);
-  // quantization_results.block_scales->merge(1);
-
-  // fusion_new_op->print();
-
   FusionExecutorCache executor_cache(std::move(fusion_new_op));
   auto outputs_new_op = executor_cache.runFusionWithInputs(inputs);
 

--- a/tests/cpp/test_low_precision_recipe.cpp
+++ b/tests/cpp/test_low_precision_recipe.cpp
@@ -439,7 +439,7 @@ TEST_F(BQTest, ScheduleAsPointwise2D) {
   EXPECT_EQ(quantized_tensor_output.dim(), 3);
 }
 
-TEST_F(BQTest, AutoScheduleBasicTest) {
+TEST_F(BQTest, AutoScheduleSingleOpWithSwizzle) {
   const int m = 1024;
   const int n = 1024;
 
@@ -532,7 +532,7 @@ TEST_F(BQTest, AutoScheduleBasicTest) {
   }
 }
 
-TEST_F(BQTest, AutoSchedule) {
+TEST_F(BQTest, AutoScheduleMultipleOps) {
   const int m = 1024;
   const int n = 1024;
   const int k = 16;


### PR DESCRIPTION
The PR:

1. Modified the pointwise scheduler so that it can handle the `BlockQuantization` op.
2. Test this for a single block quantization op. This also tests the case where the output of the block quantization op can have a swizzled output domain.
3. Test the case where the fusion has multiple pointwise ops prior to the block quantization op. Please note for this test, I haven't compared the output of the fusion to the baseline where quantization is handled by the normalization scheduler.