### PR TITLE
[HostIR] Print index definitions in `HostIrContainer::print`

### DIFF
--- a/csrc/ir/printer.cpp
+++ b/csrc/ir/printer.cpp
@@ -86,16 +86,18 @@ void IrPrinter::handle(const hir::HostIrContainer* host_ir_container) {
   os() << "} // %HostIrContainer\n\n";
 
   // Print the definitions of the indices that are used in the host_ir_container
-  os() << "Index definitions:\n";
-  indent_size_++;
-  for (auto val : host_ir_container->vals()) {
-    if (val->isScalar() && val->definition() != nullptr &&
-        val->dtype() == DataType::Index) {
-      os() << val->definition()->toString(indent_size_);
+  if (hasDebugDumpArgument(DebugDumpOption::HostIr, "indices")) {
+    os() << "Index definitions:\n";
+    indent_size_++;
+    for (Val* val : host_ir_container->vals()) {
+      if (val->isScalar() && val->definition() != nullptr &&
+          val->dtype() == DataType::Index) {
+        os() << val->definition()->toString(indent_size_);
+      }
     }
+    indent_size_--;
+    os() << "\n";
   }
-  indent_size_--;
-  os() << "\n";
 }
 
 void IrTransformPrinter::handle(const Fusion* f) {

--- a/csrc/ir/printer.cpp
+++ b/csrc/ir/printer.cpp
@@ -84,6 +84,18 @@ void IrPrinter::handle(const hir::HostIrContainer* host_ir_container) {
     os() << host_unit->toString(indent_size_);
   }
   os() << "} // %HostIrContainer\n\n";
+
+  // Print the definitions of the indices that are used in the host_ir_container
+  os() << "Index definitions:\n";
+  indent_size_++;
+  for (auto val : host_ir_container->vals()) {
+    if (val->isScalar() && val->definition() != nullptr &&
+        val->dtype() == DataType::Index) {
+      os() << val->definition()->toString(indent_size_);
+    }
+  }
+  indent_size_--;
+  os() << "\n";
 }
 
 void IrTransformPrinter::handle(const Fusion* f) {


### PR DESCRIPTION
Improve printing of HostIrContainer by printing the index computations which are not explicitly part of the `topLevelExprs`.
Example from https://github.com/NVIDIA/Fuser/pull/5259

```
%HostIrContainer { (T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), T1_g___bfloat[iS3{1024}, iS4{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), T2_g___bfloat[iS5{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})) -> (T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})) :
  T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}) = ALLOCATE(buffer=T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), mem_type=global, size=1048576, zero_init=false, resets_to_zero=false)
  T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}) = ALLOCATE(buffer=T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), mem_type=global, size=1048576, zero_init=false, resets_to_zero=false)
  GetCurrentStream into Stream 0
  FOR streamIdx in istreamIdx10{8}:
    SetCurrentStream to Stream ( streamIdx % numberOfStreams )
    Synchronize Stream 0
  FOR streamIdx in istreamIdx10{8}:
    SetCurrentStream to Stream ( streamIdx % numberOfStreams )
    T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = HirAliasSelect( T4_g___bfloat[istreamIdx10{8}, iS11{128}, iS12{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = istreamIdx10{8}, index = i84 )
    IF Manual ( ( ( 8 + ( rank - streamIdx ) ) % 8 ) == rank ):
      T5_l___bfloat[iS13{128}, iS14{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
         = HirAliasSelect( T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = ideviceIdx.x0{8}, index = 0 )
      T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
         = Set( T5_l___bfloat[iS13{128}, iS14{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), cache_op=Streaming )
    ELSE:
      ShareMemHandles(P2PCommunication 37 (type=recv, buffer=T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=i84, backend=CUDA), P2PCommunication 38 (type=send, buffer=T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=i90, backend=CUDA),
      P2PCommunication 38 (type=send, buffer=T0_g___bfloat[ideviceIdx.x0{8}, iS1{128}, iS2{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=i90, backend=CUDA)
      P2PCommunication 37 (type=recv, buffer=T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), peer=i84, backend=CUDA)
      Wait Communication 38
      Wait Communication 37
    T7_l___bfloat[iS17{128}, iS18{1024}, rS19{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = HirAliasSelect( T3_g___bfloat[istreamIdx6{8}, iS7{128}, iS8{1024}, rS9{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}), axis = istreamIdx6{8}, index = i84 )
    T7_l___bfloat[iS17{128}, iS18{1024}, rS19{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})
       = linear(T6_l___bfloat[iS15{128}, iS16{1024}] (DeviceMesh{0 1 2 3 4 5 6 7}),
                T1_g___bfloat[iS3{1024}, iS4{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})      ,
          T2_g___bfloat[iS5{1024}] (DeviceMesh{0 1 2 3 4 5 6 7})      )
    SetCurrentStream to Stream 0
    Synchronize Stream ( streamIdx % numberOfStreams )
} // %HostIrContainer

Index definitions:
  i111 = streamIdx % numberOfStreams;
  i90 = i88 % 8;
  i32 = i30 * 1024;
  i30 = 8 * 128;
  i86 = rank - streamIdx;
  i82 = rank + streamIdx;
  i74 = 8 * 128;
  i76 = i74 * 1024;
  i84 = i82 % 8;
  i88 = 8 + i86;

```