### PR TITLE
WAR fix of a bug in compute map based loop ID retrieval

### DIFF
--- a/tests/python/direct/test_repro.py
+++ b/tests/python/direct/test_repro.py
@@ -4451,3 +4451,52 @@ def test_domain_map_hang(nvfuser_direct_test):
         ),
     ]
     fd.validate(inputs)
+
+
+def test_ca_map_concrete_loop_id(nvfuser_direct_test):
+    def nvfuser_fusion_id10(fd: FusionDefinition) -> None:
+        T0 = fd.define_tensor(
+            shape=[16, 1, 1],
+            contiguity=[True, None, None],
+            dtype=DataType.Float,
+            is_cpu=False,
+        )
+        T1 = fd.define_tensor(
+            shape=[1, 1, 1024],
+            contiguity=[None, None, True],
+            dtype=DataType.Float,
+            is_cpu=False,
+        )
+        T2 = fd.ops.sub(T0, T0)
+        T3 = fd.ops.exp(T2)
+        T4 = fd.ops.reciprocal(T3)
+        T5 = fd.ops.mul(T3, T4)
+        T6 = fd.ops.broadcast(T5, is_broadcast_dim=[False, False, True, False])
+        S7 = fd.ops.size(T5, dim=1)
+        S8 = fd.define_scalar(16, dtype=DataType.Int)
+        S9 = fd.define_scalar(64, dtype=DataType.Int)
+        V10 = fd.define_vector([S7, S7, S8, S9], dtype=DataType.Int)
+        T11 = fd.ops.reshape(T1, new_shape=V10)
+        T12 = fd.ops.permute(T11, dims=[0, 2, 1, 3])
+        T13 = fd.ops.squeeze(T12, dims=[0], squeeze_expanded=True)
+        T14 = fd.ops.permute(T13, dims=[0, 2, 1])
+        T15 = fd.ops.broadcast(T14, is_broadcast_dim=[False, True, False, False])
+        T16 = fd.ops.mul(T6, T15)
+        T17 = fd.ops.squeeze(T16, dims=[3], squeeze_expanded=True)
+        T18 = fd.ops.broadcast(T17, is_broadcast_dim=[True, False, False, False])
+        T19 = fd.ops.permute(T18, dims=[0, 2, 1, 3])
+        S20 = fd.define_scalar(1024, dtype=DataType.Int)
+        V21 = fd.define_vector([S7, S7, S20], dtype=DataType.Int)
+        T22 = fd.ops.reshape(T19, new_shape=V21)
+        fd.add_output(T5)
+        fd.add_output(T13, stride_order=[1, 2, 0])
+        fd.add_output(T22)
+
+    with FusionDefinition() as fd:
+        nvfuser_fusion_id10(fd)
+
+    inputs = [
+        torch.testing.make_tensor((16, 1, 1), dtype=torch.float32, device="cuda:0"),
+        torch.testing.make_tensor((1, 1, 1024), dtype=torch.float32, device="cuda:0"),
+    ]
+    fd.validate(inputs)


### PR DESCRIPTION
# WAR fix of a bug in compute map based loop ID retrieval

## Problem
See issue-https://github.com/NVIDIA/Fuser/issues/5326
The NVFuser kernel generator was creating loops with incorrect extents, causing index computation failures:
```
INTERNAL ASSERT FAILED at index_compute.cpp:1987
Couldn't find allocation mapping for T18_l_float[iblockIdx.x137{8}, ...]
```

The root cause: `FOR blockIdx.x in iblockIdx.x202{1}:` was generated when it should have been `FOR blockIdx.x in iblockIdx.x202{8}:`

## Root Cause

In `getConcreteLoopID()`, when using the ComputeAtMap path:
- Multiple `IterDomain`s with different extents (1 and 8) are mapped into the same LOOP group
- `ComputeAtMap::computeConcreteId()` picks a representative based on graph topology

## The WAR Fix
**The IdModel path correctly generates loop IDs**, while the ComputeAtMap path is scheduled for deprecation. A temporary WAR fix is introduced here to unblock execution.

### What was changed:

Added extent validation logic in the CA map path (non-IdModel):
1. **Broadcast Promotion**: Prefer non-broadcast IDs over broadcast/size-1 IDs
2. **Maximum Extent**: Choose the ID with the largest extent in the group
3. **Extent Validation**: Actively check for extent compatibility

