### PR TITLE
Revert "Disable UCC tests for CUDA 13 (#4680)"

### DIFF
--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -411,7 +411,7 @@ TEST_P(CommunicationTest, ReduceScatter) {
 INSTANTIATE_TEST_SUITE_P(
     ,
     CommunicationTest,
-    testing::Values(CommunicatorBackend::kNccl),
+    testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
     testing::PrintToStringParamName());
 
 using P2PCommunicationTest = MultiDeviceTest;

--- a/tests/cpp/test_multidevice_communicator.cpp
+++ b/tests/cpp/test_multidevice_communicator.cpp
@@ -98,7 +98,7 @@ TEST_P(CommunicatorTest, DISABLED_Barrier) {
 INSTANTIATE_TEST_SUITE_P(
     ,
     CommunicatorTest,
-    testing::Values(CommunicatorBackend::kNccl),
+    testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
     testing::PrintToStringParamName());
 
 } // namespace nvfuser

--- a/tests/cpp/test_multidevice_lower_communication.cpp
+++ b/tests/cpp/test_multidevice_lower_communication.cpp
@@ -758,7 +758,7 @@ INSTANTIATE_TEST_SUITE_P(
     ,
     LowerCollectiveTest,
     ::testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         testing::Bool()),
     ([](const testing::TestParamInfo<std::tuple<CommunicatorBackend, bool>>&
             info) -> std::string {

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -326,7 +326,8 @@ TEST_P(PipelineTestTwoStages, Communication) {
 }
 
 namespace {
-auto all_backends = testing::Values(CommunicatorBackend::kNccl);
+auto all_backends =
+    testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc);
 
 DeviceMesh mesh_null;
 DeviceMesh mesh0({0});
@@ -344,7 +345,7 @@ INSTANTIATE_TEST_SUITE_P(
     Gather,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_meshes,
         all_meshes,
         testing::Values(true),
@@ -357,7 +358,7 @@ INSTANTIATE_TEST_SUITE_P(
     Scatter,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         testing::Values(mesh0, mesh1),
         testing::Values(mesh2, mesh4, mesh5),
         testing::Values(false),
@@ -370,7 +371,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_meshes,
         all_meshes,
         testing::Values(false),
@@ -397,7 +398,7 @@ INSTANTIATE_TEST_SUITE_P(
     Bcast_sharded_same_mesh,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         testing::Values(mesh0, mesh1),
         testing::Values(mesh_null), // the same mesh is used for all tensors
         testing::Values(true),
@@ -410,7 +411,7 @@ INSTANTIATE_TEST_SUITE_P(
     Reduce,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_nontrivial_meshes,
         all_meshes,
         testing::Values(true),
@@ -423,7 +424,7 @@ INSTANTIATE_TEST_SUITE_P(
     ReduceScatter,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_nontrivial_meshes,
         testing::Values(mesh_null), // the same mesh is used for all tensors
         testing::Values(true),
@@ -438,7 +439,7 @@ INSTANTIATE_TEST_SUITE_P(
     DISABLED_FusionExecutorCache_Reduce,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_nontrivial_meshes,
         all_meshes,
         testing::Values(true),
@@ -451,7 +452,7 @@ INSTANTIATE_TEST_SUITE_P(
     DISABLED_FusionExecutorCache_ReduceScatter,
     PipelineTestTwoStages,
     testing::Combine(
-        testing::Values(CommunicatorBackend::kNccl),
+        testing::Values(CommunicatorBackend::kNccl, CommunicatorBackend::kUcc),
         all_nontrivial_meshes,
         testing::Values(mesh_null), // the same mesh is used for all tensors
         testing::Values(true),

--- a/tests/python/multidevice/test_overlap.py
+++ b/tests/python/multidevice/test_overlap.py
@@ -11,7 +11,9 @@ from nvfuser_direct import DataType, FusionDefinition, CommunicatorBackend, Tens
 
 
 @pytest.mark.mpi
-@pytest.mark.parametrize("backend_type", [CommunicatorBackend.nccl])
+@pytest.mark.parametrize(
+    "backend_type", [CommunicatorBackend.nccl, CommunicatorBackend.ucc]
+)
 @pytest.mark.parametrize("s", [1, 8])
 def test_overlap_allgather_matmul_stream_outermost(
     multidevice_direct_test, benchmark, backend_type, s


### PR DESCRIPTION
This reverts commit 949e50b33529895cf10d94187a3e7a6752d3d529 and reenables UCC.

Those tests pass when I run them on DGX 8*H100 on pjnl:latest container.

If CI is green, let's reenable them !