### PR TITLE
add quack to pybm

### DIFF
--- a/benchmarks/python/conftest.py
+++ b/benchmarks/python/conftest.py
@@ -42,7 +42,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Benchmarks flashinfer mode.",
     )
-
+    parser.addoption(
+        "--benchmark-quack",
+        action="store_true",
+        help="Benchmarks quack mode.",
+    )
     # pytest-benchmark does not have CLI options to set rounds/warmup_rounds for benchmark.pedantic.
     # The following two options are used to overwrite the default values through CLI.
     parser.addoption(
@@ -155,6 +159,7 @@ def pytest_collection_modifyitems(session, config, items):
         "thunder",
         "thunder-torchcompile",
         "flashinfer",
+        "quack",
     ]
 
     def get_test_executor(item) -> str | None:

--- a/benchmarks/python/cross_entropy_loss.py
+++ b/benchmarks/python/cross_entropy_loss.py
@@ -162,6 +162,20 @@ cross_entropy_loss_setup = {
 
 
 class SyntheticMiniModel:
+    # Vocab sizes from popular models
+    sizes_from_models = [
+        49152,  # Starcoder
+        129280,  # DeepSeek-R1
+        128256,  # Llama3
+        202048,  # Llama4
+        256000,  # Gemma2
+        131072,  # Mistral
+        152064,  # Qwen2
+        32064,  # Phi3.5
+        100352,  # Phi4
+        50264,  # GPT-2
+    ]
+
     @staticmethod
     def mini_model(logits, labels):
         labels = torch.nn.functional.pad(labels, (0, 1))
@@ -196,22 +210,11 @@ class SyntheticMiniModel:
 
     @staticmethod
     def generate_vocab_sizes():
-        sizes_from_models = [
-            49152,  # Starcoder
-            129280,  # DeepSeek-R1
-            128256,  # Llama3
-            202048,  # Llama4
-            256000,  # Gemma2
-            131072,  # Mistral
-            152064,  # Qwen2
-            32064,  # Phi3.5
-            100352,  # Phi4
-            50264,  # GPT-2
-        ]
-
         powers_of_2 = [2**i * 1024 for i in range(4, 9)]
 
-        combined_set = sorted(set(sizes_from_models) | set(powers_of_2))
+        combined_set = sorted(
+            set(SyntheticMiniModel.sizes_from_models) | set(powers_of_2)
+        )
 
         # for each vocab size in the set we increment in steps 64 in +/- 5 directions
         # which gives the total number of vocab sizes to benchmark

--- a/benchmarks/python/torch_ops.py
+++ b/benchmarks/python/torch_ops.py
@@ -115,3 +115,9 @@ def scatter_reduce(inputs: list):
     out = out.reshape(*topk_weight.shape, -1)  # [seq, top_k, hidden]
     out = out * topk_weight.unsqueeze(-1)  # [seq, top_k, hidden]
     return out.sum(dim=1)  # [seq, hidden]
+
+
+# simply cross entropy to benchmark quack cross entropy
+def cross_entropy(inputs: list):
+    logits, labels = inputs
+    return F.cross_entropy(logits, labels, reduction="none")


### PR DESCRIPTION
This PR only added cross entropy fwd, it benchmarks `F.cross_entropy(logits, labels, reduction="none")` same as [quack](https://github.com/Dao-AILab/quack/blob/7dcb92ecd541d64e36cd5689cc700bf4a4c10652/benchmarks/benchmark_cross_entropy.py#L37).