### PR TITLE
Ensure the M dimension is larger than the expert offsets

### DIFF
--- a/cutlass/group_mm.cu
+++ b/cutlass/group_mm.cu
@@ -436,7 +436,7 @@ void validateInputsGroupMm(
   for (int64_t i = 0; i < g; ++i) {
     int64_t expert_offset = expert_offsets[i].item<int64_t>();
     NVF_CHECK(
-        m > expert_offset,
+        expert_offset <= m,
         "The expert offset ",
         i,
         " is ",

--- a/cutlass/nvfp4_scaled_group_mm.cu
+++ b/cutlass/nvfp4_scaled_group_mm.cu
@@ -637,7 +637,7 @@ void validateInputsNvfp4ScaledGroupMm(
   for (int64_t i = 0; i < g; ++i) {
     int64_t expert_offset = expert_offsets[i].item<int64_t>();
     NVF_CHECK(
-        m > expert_offset,
+        expert_offset <= m,
         "The expert offset ",
         i,
         " is ",

--- a/tests/python/direct/test_cutlass_gemm.py
+++ b/tests/python/direct/test_cutlass_gemm.py
@@ -16,7 +16,7 @@ from nvfuser_direct import nvf_cutlass
 @pytest.mark.skipif(
     not microarchitecture_is_pre(12), reason="Does not support blackwell compute 12.0."
 )
-@pytest.mark.parametrize("config", [[1024, 128, 256], [268, 128, 256]])
+@pytest.mark.parametrize("config", [[1024, 128, 256], [267, 128, 256]])
 @pytest.mark.parametrize("tokens_per_expert_neg_one", [[115, 144, 8], [5, 7, 9]])
 @pytest.mark.parametrize("tensor_dtype", [torch.bfloat16, torch.float16])
 def test_grouped_mm(


### PR DESCRIPTION
Fix #5347 by guaranteeing that the m dimension is larger than the expert offsets. Previously, in the failing case, it was `32` which is less than the `115` tokens per expert.

Command
`pip install pytest-repeat`
`pytest tests/python/direct/test_cutlass_gemm.py -vsk 'grouped' --count=1000 -x`