### PR TITLE
Add support for automatic scheduler in direct bindings

### DIFF
--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -105,7 +105,7 @@ class KernelExecutor : public ExecutorAbstract {
       const KernelArgumentHolder& args = {},
       const LaunchParams& launch_constraints = LaunchParams(),
       CompileParams compile_params = CompileParams(),
-      SchedulerType sceduler_type = SchedulerType::None);
+      SchedulerType scheduler_type = SchedulerType::None);
 
   NVF_API KernelArgumentHolder
   run(KernelArgumentHolder args,

--- a/csrc/scheduler/heuristic.h
+++ b/csrc/scheduler/heuristic.h
@@ -21,7 +21,7 @@ class HeuristicDataCache;
 // Top-level class representing heuristic parameters. Most schedulers
 // have their own subclasses to have their specific parameters, except
 // for ExprEval schedulers.
-class HeuristicParams : public PolymorphicBase {
+class NVF_API HeuristicParams : public PolymorphicBase {
  public:
   std::string tag = "";
 

--- a/csrc/scheduler/registry.h
+++ b/csrc/scheduler/registry.h
@@ -96,7 +96,7 @@ namespace Schedule {
 
 //! External access for canSchedule utilities through SchedulerEntry
 //!  to avoid exposing a single function to the namespace
-bool canSchedule(
+NVF_API bool canSchedule(
     SchedulerType sh,
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,

--- a/csrc/scheduler/runtime_info.h
+++ b/csrc/scheduler/runtime_info.h
@@ -41,7 +41,7 @@ class SchedulerRuntimeInfo : public NonCopyable {
   //! The index type of forced_index_type is used if given, no matter
   //! how large the actual arguments and fusion tensors
   //! are. CORRECTNESS IS NOT GUARANTEED.
-  SchedulerRuntimeInfo(
+  NVF_API SchedulerRuntimeInfo(
       Fusion* complete_fusion,
       KernelArgumentHolder args,
       PrecomputedValues* precomputed_values = nullptr,

--- a/python/nvfuser_direct/__init__.py
+++ b/python/nvfuser_direct/__init__.py
@@ -322,7 +322,9 @@ class FusionDefinition:
             _disable_options=_disable_options,
         )
 
-    def manual_execute(self, inputs):
+    def manual_execute(
+        self, inputs, heuristic_params: Optional[HeuristicParams] = None
+    ):
         """
         Execute the fusion with the given inputs.
 
@@ -344,8 +346,21 @@ class FusionDefinition:
             self.ke = KernelExecutor()
 
         if not self.ke.is_compiled():
-            self.ke.compile(self.fusion, inputs)
+            if heuristic_params is not None:
+                self.ke.compile(
+                    self.fusion,
+                    inputs,
+                    heuristic_params.lparams,
+                    heuristic_params.cparams,
+                    heuristic_params.scheduler_type,
+                )
+            else:
+                self.ke.compile(self.fusion, inputs)
 
+        if heuristic_params is not None:
+            return self.ke.run(
+                inputs, heuristic_params.lparams, heuristic_params.cparams
+            )
         return self.ke.run(inputs)
 
     def last_repro_script(self) -> str:

--- a/python/python_direct/heuristic_params.cpp
+++ b/python/python_direct/heuristic_params.cpp
@@ -152,6 +152,39 @@ void bindHeuristicParams(py::module& nvfuser) {
       "include_paths", &CompileParams::include_paths, R"(
                 The additional include paths to use for the kernel.
               )");
+
+  py::class_<HeuristicParams> heuristic_parameters(
+      nvfuser, "HeuristicParams", py::module_local());
+  heuristic_parameters.def(
+      "__repr__", [](const HeuristicParams& self) { return self.toString(); });
+  heuristic_parameters.def("__eq__", &HeuristicParams::sameAs, R"(
+                Whether the heuristic parameters are the same.
+              )");
+  heuristic_parameters.def_readwrite("lparams", &HeuristicParams::lparams, R"(
+                The launch parameters for the kernel.
+              )");
+  heuristic_parameters.def_readwrite("cparams", &HeuristicParams::cparams, R"(
+                The compile parameters for the kernel.
+              )");
+  heuristic_parameters.def_readonly(
+      "scheduler_type", &HeuristicParams::scheduler_type, R"(
+                The type of scheduler that generated these parameters.
+              )");
+  heuristic_parameters.def("hash", &HeuristicParams::hash, R"(
+                The hash of the heuristic parameters.
+              )");
+
+  py::class_<PointwiseParams, HeuristicParams> pointwise(
+      nvfuser, "PointwiseParams", py::module_local());
+  pointwise.def(py::init());
+  pointwise.def(
+      "__repr__", [](const PointwiseParams& self) { return self.toString(); });
+
+  py::class_<ReductionParams, HeuristicParams> reduction(
+      nvfuser, "ReductionParams", py::module_local());
+  reduction.def(py::init());
+  reduction.def(
+      "__repr__", [](const ReductionParams& self) { return self.toString(); });
 }
 
 } // namespace nvfuser::python


### PR DESCRIPTION
* Define `HeuristicParams` struct
* Update `manual_execute` to take `launch_params`, `compile_params`, and `scheduler_type` from `HeuristicParams`
* Add `can_schedule`, `find_compatible_schedulers`, and `schedule` operations to `schedule` submodule.
* Create tests for pointwise, reduction, and inner persistent schedulers