### PR TITLE
Update benchmark_utils.py, pytorch_utils.py, and profile.cpp for benchmarking

### DIFF
--- a/python/nvfuser_direct/benchmark_utils.py
+++ b/python/nvfuser_direct/benchmark_utils.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-present NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from cupti import cupti
+import cxxfilt
+import pytest
+from ._C_DIRECT import get_fusion_profile
+
+
+# Base class for all timers used by pytest-benchmark.
+class Timer:
+    def __init__(self):
+        self.current_time = 0.0
+
+    def _increment_global_time(self, elapsed_time: float) -> None:
+        self.current_time += elapsed_time
+
+    def __call__(self):
+        raise NotImplementedError("Subclass must implement this method")
+
+    def cleanup(self):
+        pass
+
+
+def demangle_kernel_name(mangled_name):
+    try:
+        return cxxfilt.demangle(mangled_name)
+    except Exception:
+        return mangled_name  # Return original if demangling fails
+
+
+def cupti_call_safe(func, *args):
+    """Wrapper for CUPTI calls. Failing CUPTI calls will exit the program."""
+    try:
+        return func(*args)
+    except Exception as e:
+        print(f"CUPTI call {func.__name__} failed: {e}")
+        pytest.exit(1)
+
+
+class CuptiProfiler:
+    # List of activities to be recorded by CUPTI.
+    activity_kinds: list[cupti.ActivityKind] = [
+        cupti.ActivityKind.CONCURRENT_KERNEL,
+    ]
+
+    # Private class variable to store the subscriber handle.
+    __subscriber_handle = None
+
+    def _error_if_not_valid(self) -> None:
+        if not self.is_valid:
+            raise RuntimeError(
+                "CuptiProfiler is not valid. " "This instance has been torn down."
+            )
+
+    def _func_buffer_requested(self) -> tuple[int, int]:
+        # 8MB buffer size as recommended by CUPTI samples.
+        # max_num_records=0 indicates the buffer is filled with as many records as possible.
+        buffer_size = 8 * 1024 * 1024
+        max_num_records = 0
+        return buffer_size, max_num_records
+
+    def _func_buffer_completed(self, activities: list[cupti.ActivityAPI]) -> None:
+        for activity in activities:
+            # Activity.end and Activity.start are in nanoseconds.
+            duration = (activity.end - activity.start) / 1e9
+            self.profiler_output.append((demangle_kernel_name(activity.name), duration))
+
+    def __init__(self):
+        if CuptiProfiler.__subscriber_handle is not None:
+            raise RuntimeError(
+                "Only one instance of CuptiProfiler can be created. "
+                "CUPTI only supports one subscriber at a time."
+            )
+
+        self.profiler_output: list[tuple[str, float]] = []
+
+        # Subscribe to CUPTI and register activity callbacks.
+        CuptiProfiler.__subscriber_handle = cupti_call_safe(cupti.subscribe, None, None)
+        cupti_call_safe(
+            cupti.activity_register_callbacks,
+            self._func_buffer_requested,
+            self._func_buffer_completed,
+        )
+        self.is_valid = True
+
+    def start(self) -> None:
+        self._error_if_not_valid()
+        cupti_call_safe(cupti.activity_flush_all, 1)
+        self.profiler_output = []
+        for activity_kind in CuptiProfiler.activity_kinds:
+            cupti_call_safe(cupti.activity_enable, activity_kind)
+
+    def stop(self) -> list[tuple[str, float]]:
+        self._error_if_not_valid()
+        for activity_kind in CuptiProfiler.activity_kinds:
+            cupti_call_safe(cupti.activity_disable, activity_kind)
+        cupti_call_safe(cupti.activity_flush_all, 0)
+        return self.profiler_output
+
+    def teardown_cupti(self) -> None:
+        self._error_if_not_valid()
+        if CuptiProfiler.__subscriber_handle is None:
+            return
+        cupti_call_safe(cupti.unsubscribe, CuptiProfiler.__subscriber_handle)
+        cupti_call_safe(cupti.finalize)
+        CuptiProfiler.__subscriber_handle = None
+        # Invalidate the profiler so it cannot be used again.
+        self.is_valid = False
+
+
+class CuptiTimer(Timer):
+    def __init__(self):
+        super().__init__()
+        self.cupti_profiler = CuptiProfiler()
+        self.is_running = False
+
+    def __call__(self):
+        torch.cuda.synchronize()
+
+        if not self.is_running:
+            self.cupti_profiler.start()
+            self.is_running = True
+            return self.current_time
+
+        profiler_output = self.cupti_profiler.stop()
+        self.is_running = False
+
+        # Check if any activities were recorded
+        if len(profiler_output) == 0:
+            self.cleanup()
+            raise RuntimeError("No activities were recorded.")
+
+        self._increment_global_time(sum(duration for _, duration in profiler_output))
+        return self.current_time
+
+    def cleanup(self):
+        self.is_running = False
+        self.cupti_profiler.teardown_cupti()
+
+
+class FusionProfileTimer(Timer):
+    def __init__(self):
+        super().__init__()
+        self.fd = None
+        # Specifies if the timer in host measurement is called at the start/finish of execution.
+        # Timings are measured at the end of execution.
+        self.execution_start = True
+
+    def set_fd(self, fd):
+        self.fd = fd
+
+    def __call__(self):
+        if not self.execution_start:
+            profile = get_fusion_profile()
+            elapsed_host_time = profile.host_time_ms / 1e3
+            self._increment_global_time(elapsed_host_time)
+        self.execution_start = not self.execution_start
+        return self.current_time

--- a/python/nvfuser_direct/pytorch_utils.py
+++ b/python/nvfuser_direct/pytorch_utils.py
@@ -5,7 +5,8 @@ import torch
 
 from ._C_DIRECT import DataType
 
-from typing import Type, Union
+import ctypes
+from typing import Type, Union, Tuple
 import functools
 
 NumberTypeType = Union[Type[bool], Type[int], Type[float], Type[complex]]
@@ -75,3 +76,114 @@ def retry_on_oom_or_skip_test(func):
         return output
 
     return retried_func
+
+
+def get_device_properties() -> Tuple[int, float]:
+    """
+    Computes device properties using ctypes and cuda.
+    Note: Consider using CUDA-Python when CUDA support >= 12.0.
+    """
+    libnames = ("libcuda.so", "libcuda.dylib", "nvcuda.dll", "cuda.dll")
+    for libname in libnames:
+        try:
+            cuda = ctypes.CDLL(libname)
+        except OSError:
+            continue
+        else:
+            break
+    else:
+        raise OSError("could not load any of: " + " ".join(libnames))
+
+    # Device attribute enums (taken from cuda.h)
+    # https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1ge12b8a782bebe21b1ac0091bf9f4e2a3
+
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1
+    CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8
+    CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12
+    CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13
+    CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36
+    CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37
+    CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38
+    CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39
+
+    device_properties = {}
+    device = torch.cuda.current_device()
+    cuda_properties = torch.cuda.get_device_properties(device)
+
+    device_properties["gpu_name"] = cuda_properties.name
+    device_properties["gpu_compute_capability_major"] = cuda_properties.major
+    device_properties["gpu_compute_capability_minor"] = cuda_properties.minor
+    device_properties["gpu_gmem_bytes"] = cuda_properties.total_memory
+    device_properties["gpu_sm_count"] = cuda_properties.multi_processor_count
+
+    max_threads_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_max_threads_per_block"] = max_threads_per_block.value
+
+    smem_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(smem_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_smem_bytes_per_block"] = smem_per_block.value
+
+    max_reg_per_block = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_reg_per_block),
+        CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
+        device,
+    )
+    device_properties["gpu_regs_per_block"] = max_reg_per_block.value
+
+    max_clock_khz = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_clock_khz),
+        CU_DEVICE_ATTRIBUTE_CLOCK_RATE,
+        device,
+    )
+    device_properties["gpu_clock_rate_khz"] = max_clock_khz.value
+
+    l2_cache_size = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(l2_cache_size), CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, device
+    )
+    device_properties["gpu_l2_bytes"] = l2_cache_size.value
+
+    memory_clock_rate = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_clock_rate), CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, device
+    )
+    device_properties["gpu_mem_clock_khz"] = memory_clock_rate.value
+
+    memory_bus_width = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(memory_bus_width),
+        CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
+        device,
+    )
+    device_properties["gpu_mem_bus_width"] = memory_bus_width.value
+
+    max_threads_per_sm = ctypes.c_int()
+    cuda.cuDeviceGetAttribute(
+        ctypes.byref(max_threads_per_sm),
+        CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR,
+        device,
+    )
+    device_properties["gpu_max_threads_per_sm"] = max_threads_per_sm.value
+
+    # Compute peak bandwidth in GBps
+    peak_bandwidth = (2 * memory_bus_width.value * memory_clock_rate.value) / (1e6 * 8)
+    device_properties["gpu_peak_bandwidth_gbps"] = peak_bandwidth
+
+    return device_properties
+
+
+DEVICE_PROPERTIES = None
+if torch.cuda.is_available():
+    # Loading libraries will raise errors on non-CUDA machines.
+    DEVICE_PROPERTIES = get_device_properties()

--- a/python/python_direct/profile.cpp
+++ b/python/python_direct/profile.cpp
@@ -168,6 +168,19 @@ Returns the kernel profiles of the fusion profile.
 )");
 }
 
+const FusionProfile& get_fusion_profile() {
+  const FusionProfile& profile = FusionProfiler::profile();
+  NVF_ERROR(
+      profile.fusion_id != -1,
+      "Something went wrong with Fusion Profiling as an illegal fusion_id "
+      "was returned!")
+  NVF_ERROR(
+      profile.segments > 0,
+      "Something went wrong with Fusion Profiling as no kernel segments were "
+      "profiled!")
+  return profile;
+}
+
 class PythonProfiler {
  public:
   PythonProfiler(bool auto_scheduled = false)
@@ -190,23 +203,6 @@ class PythonProfiler {
     }
     ProfilerOptionsGuard::getCurOptions().unset(ProfilerOption::Enable);
     DisableOptionsGuard::getCurOptions().unset(DisableOption::ParallelCompile);
-  }
-
-  void reset() {
-    FusionProfiler::reset();
-  }
-
-  const FusionProfile& get_fusion_profile() {
-    const FusionProfile& profile = FusionProfiler::profile();
-    NVF_ERROR(
-        profile.fusion_id != -1,
-        "Something went wrong with Fusion Profiling as an illegal fusion_id "
-        "was returned!")
-    NVF_ERROR(
-        profile.segments > 0,
-        "Something went wrong with Fusion Profiling as no kernel segments were "
-        "profiled!")
-    return profile;
   }
 
  private:
@@ -235,12 +231,9 @@ auto_scheduled : bool, optional
           py::object exc_type,
           py::object exc_value,
           py::object traceback) { self.stop(); });
-  profiler.def("reset", &PythonProfiler::reset, R"(
-Resets the fusion profile, so FusionProfiler can be used again.
-)");
   profiler.def_property_readonly(
       "profile",
-      &PythonProfiler::get_fusion_profile,
+      [&](PythonProfiler& self) { return get_fusion_profile(); },
       py::return_value_policy::reference,
       R"(
 Returns the FusionProfile for the profiled fusion.
@@ -248,6 +241,20 @@ Returns the FusionProfile for the profiled fusion.
 Returns:
     FusionProfile
 )");
+  nvfuser.def(
+      "get_fusion_profile",
+      &get_fusion_profile,
+      py::return_value_policy::reference,
+      R"(
+Returns the FusionProfile for the profiled fusion.
+
+Returns:
+    FusionProfile
+)");
+  nvfuser.def(
+      "reset_profiler",
+      &FusionProfiler::reset,
+      R"(Resets FusionProfiler so it can be used again.)");
 }
 
 } // namespace


### PR DESCRIPTION
Add utilities so `nvfuser_direct` works for python benchmarks.
Changed profiling API so `FusionProfile` is accessible outside of `PythonProfiler` context manager.

PR Stack:
- #5395 **<<< This PR.**
- #5224