### PR TITLE
Fix bug in EVT Sm90Compute type arguments

### DIFF
--- a/csrc/cutlass/evt.cpp
+++ b/csrc/cutlass/evt.cpp
@@ -177,9 +177,10 @@ class EVTConverter : OptInDispatch {
     EVTModel::Node* func_node =
         model_.makeNode("cutlass::epilogue::fusion::Sm90Compute");
     func_node->inputs.push_back(model_.makeNode("cutlass::" + op_name));
-    // TODO: infer type of inputs from dtypes
-    func_node->inputs.push_back(model_.makeNode(dtypeToCutlass(in_type)));
     func_node->inputs.push_back(model_.makeNode(dtypeToCutlass(out_type)));
+    // Compute type determines what precision the operation will take place in.
+    // The op is computed as (out_type)(op((compute_type)x, (compute_type)y))
+    func_node->inputs.push_back(model_.makeNode(dtypeToCutlass(in_type)));
     // rounding mode
     // https://github.com/NVIDIA/cutlass/blob/2b8dff1f90605452c378c02298dd0cacaf65753c/include/cutlass/numeric_conversion.h#L56
     func_node->inputs.push_back(
@@ -219,10 +220,11 @@ class EVTConverter : OptInDispatch {
         model_.makeNode("cutlass::epilogue::fusion::Sm90Compute");
     func_node->inputs.push_back(model_.makeNode("cutlass::" + op_name));
     func_node->inputs.push_back(
-        model_.makeNode(dtypeToCutlass(uop->in()->dtype())));
-    // This is the "compute" type of the op
-    func_node->inputs.push_back(
         model_.makeNode(dtypeToCutlass(uop->out()->dtype())));
+    // Compute type determines what precision the operation will take place in.
+    // The op is computed as (out_type)(op((compute_type)x))
+    func_node->inputs.push_back(
+        model_.makeNode(dtypeToCutlass(uop->in()->dtype())));
     // rounding mode
     // https://github.com/NVIDIA/cutlass/blob/2b8dff1f90605452c378c02298dd0cacaf65753c/include/cutlass/numeric_conversion.h#L56
     func_node->inputs.push_back(
@@ -249,7 +251,7 @@ class EVTConverter : OptInDispatch {
         makeBinaryOpNode(
             bop->getBinaryOpType(),
             /*in_type=*/bop->lhs()->dtype(),
-            /*out_type=*/bop->lhs()->dtype(),
+            /*out_type=*/bop->out()->dtype(),
             getNodeFor(bop->lhs()),
             getNodeFor(bop->rhs())));
   }


### PR DESCRIPTION
I had the type arguments swapped in Sm90Compute. This did not affect the ReLU test but it started affecting the one without an epilogue because that now also gets translated to EVT instead of using the default epilogue.

This fixes the compile error in CI.