### PR TITLE
Prevent passing -DNVMMH_INCLUDE_DIR to cmake if env var missing

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -494,7 +494,6 @@ def cmake(config, relative_path):
         cmd_str.append("-G")
         cmd_str.append("Ninja")
     cmd_str.append(relative_path)
-    print(f'{cmd_str=}')
 
     print(f"Configuring CMake with {' '.join(cmd_str)}")
     subprocess.check_call(cmd_str)


### PR DESCRIPTION
Previously, if `NVFUSER_BUILD_NVMMH_INCLUDE_DIR` was unset, we would see this in the build output
```
  -- ******** Nvfuser configuration summary ********
  --   BUILD_CUTLASS: ENABLED
  --   UCC_FOUND: 1
  --   NVFUSER_STANDALONE_BUILD_WITH_UCC  : ON
  --   NVFUSER_BUILD_WITH_ASAN            : OFF
  --   NVFUSER_DISTRIBUTED                : ON
  --   NVFUSER_HOST_IR_JIT                : OFF
  --   NVFUSER_CPP_STANDARD               : 20
  --   NVMMH_INCLUDE_DIR                  : /opt/pytorch/nvfuser/python/None
  --     UCC_HOME: /opt/hpcx/ucc
  --     UCC_DIR : /opt/hpcx/ucc/lib/cmake/ucc
  --     UCX_HOME: /opt/hpcx/ucx
  --     UCX_DIR : /opt/hpcx/ucx/lib/cmake/ucx
  -- ******** End of Nvfuser configuration summary ********
```
That's because we were always passing `-DNVMMH_INCLUDE_DIR={config.nvmmh_include_dir}` regardless of whether the env var was found or not. This PR simply omits that argument when the env var is missing, so instead we see this:
```
  -- ******** Nvfuser configuration summary ********
  --   BUILD_CUTLASS: ENABLED
  --   UCC_FOUND: 1
  --     UCC_HOME: /opt/hpcx/ucc
  --     UCC_DIR : /opt/hpcx/ucc/lib/cmake/ucc
  --     UCX_HOME: /opt/hpcx/ucx
  --     UCX_DIR : /opt/hpcx/ucx/lib/cmake/ucx
  --   NVFUSER_STANDALONE_BUILD_WITH_UCC  : ON
  --   NVFUSER_BUILD_WITH_ASAN            : OFF
  --   NVFUSER_DISTRIBUTED                : ON
  --   NVFUSER_HOST_IR_JIT                : OFF
  --   NVFUSER_CPP_STANDARD               : 20
  --   NVMMH_INCLUDE_DIR                  : NVMMH_INCLUDE_DIR-NOTFOUND
  -- ******** End of Nvfuser configuration summary ********
```

Note that no functional change is expected unless for some odd reason there exists a `/opt/pytorch/nvfuser/python/None` directory, since we check whether the directory actually exists in order to enable the NVMMH build.