### PR TITLE
Fix ShareIpcMemHandles test

### DIFF
--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -432,6 +432,10 @@ TEST_F(MultiDeviceTest, ShareIpcMemHandles) {
         << "Rank " << my_rank << " failed at repetition " << repetition
         << " with recv tensor " << recv_tensor << " and ref_recv_tensor "
         << ref_recv_tensor;
+    // Prevent recv_peer from writing the next iteration's data before
+    // we finish verifying this iteration's data
+    torch::cuda::synchronize();
+    communicator_->barrier();
   }
 }
 


### PR DESCRIPTION
Fixes failure with some ranks running ahead of others:

```
[ RUN      ] MultiDeviceTest.ShareIpcMemHandles
/opt/Fuser/tests/cpp/test_multidevice_host_ir.cpp:431: Failure
Value of: at::allclose(recv_tensor, ref_recv_tensor)
  Actual: false
Expected: true
Rank 3 failed at repetition 4 with recv tensor  260
 261
 262
 263
[ CUDAIntType{4} ] and ref_recv_tensor  250
 251
 252
 253
[ CUDAIntType{4} ]

To reproduce: NVFUSER_TEST_RANDOM_SEED=1760733540 NVFUSER_TEST_ATEN_RANDOM_SEED=0 test_nvfuser --gtest_filter='MultiDeviceTest.ShareIpcMemHandles'
[       OK ] MultiDeviceTest.ShareIpcMemHandles (9763 ms)
[----------] 1 test from MultiDeviceTest (9763 ms total)

[  FAILED  ] MultiDeviceTest.ShareIpcMemHandles (9699 ms)
```

The tens place in the recvbuf is the iteration number. In the example, 260 was reported while 250 was expected. The issue is while rank i is checking the recvbuf, rank i+1 can overwrite it in his next iteration. This PR adds a synchronization to stop that.