### PR TITLE
Add __device__ so dumped source code can be compiled with nvcc

### DIFF
--- a/runtime/array.cu
+++ b/runtime/array.cu
@@ -25,7 +25,7 @@ struct alignas(sizeof(scalar_t) * align_size) Array {
     return array[i];
   }
 
-  Array& operator=(const Array& a) {
+  __device__ Array& operator=(const Array& a) {
 #pragma unroll
     for (int i = 0; i < size; ++i) {
       array[i] = a[i];
@@ -51,7 +51,7 @@ struct alignas(align_size / 2) Array<__e2m1, size, align_size> {
     return array[i / 2];
   }
 
-  Array& operator=(const Array& a) {
+  __device__ Array& operator=(const Array& a) {
 #pragma unroll
     for (int i = 0; i < size / 2; ++i) {
       array[i] = a.array[i];

--- a/runtime/bf16_support.cu
+++ b/runtime/bf16_support.cu
@@ -16,19 +16,19 @@ __device__ __inline__ __bfloat __float2bfloat(const float);
 struct __align__(2) __bfloat {
   __bfloat() = default;
 
-  __bfloat(const __bfloat& other) {
+  __device__ __bfloat(const __bfloat& other) {
     __x = other.__x;
   }
 
-  __bfloat(const __bfloat&& other) {
+  __device__ __bfloat(const __bfloat&& other) {
     __x = other.__x;
   }
 
-  __bfloat(const volatile __bfloat& other) {
+  __device__ __bfloat(const volatile __bfloat& other) {
     __x = other.__x;
   }
 
-  __bfloat(const volatile __bfloat&& other) {
+  __device__ __bfloat(const volatile __bfloat&& other) {
     __x = other.__x;
   }
 

--- a/runtime/fp16_support.cu
+++ b/runtime/fp16_support.cu
@@ -16,19 +16,19 @@ __device__ __inline__ __half __float2half(const float);
 struct __align__(2) __half {
   __half() = default;
 
-  __half(const __half& other) {
+  __device__ __half(const __half& other) {
     __x = other.__x;
   }
 
-  __half(const __half&& other) {
+  __device__ __half(const __half&& other) {
     __x = other.__x;
   }
 
-  __half(const volatile __half& other) {
+  __device__ __half(const volatile __half& other) {
     __x = other.__x;
   }
 
-  __half(const volatile __half&& other) {
+  __device__ __half(const volatile __half&& other) {
     __x = other.__x;
   }
 


### PR DESCRIPTION
This PR add `__device__` to some functions so the cuda file dumped via `cuda_to_file` can be compiled with `nvcc`.