### PR TITLE
import pytest to fix CI

### DIFF
--- a/tests/python/opinfo/opinfo_utils.py
+++ b/tests/python/opinfo/opinfo_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Owner(s): ["module: nvfuser"]
 
+import pytest
 import torch
 from torch.testing import make_tensor
 from enum import Enum, auto


### PR DESCRIPTION
When JAX is unavailable, the script needs to import `pytest`

Run `pytest tests/python/opinfo/ -k logical_right_shift` with today container.

```python
    @wraps(fn)
    def _fn(*args, **kwargs):
        if not JAX_AVAILABLE:
>           pytest.xfail("Requires JAX")
            ^^^^^^
E           NameError: name 'pytest' is not defined
```