### PR TITLE
Fix GroupedMmaOp so it's capturable

### DIFF
--- a/csrc/ir/nodes.cpp
+++ b/csrc/ir/nodes.cpp
@@ -5819,7 +5819,7 @@ std::vector<PolymorphicValue> GroupedMmaOp::evaluate(
           at::stack({group_sizes, c_strides, ab_strides}, /*dim=*/-1)
               .to(at::kInt);
       offsets = at::cat(
-          {at::tensor({0}, at::dtype(at::kInt).device(offsets.device())),
+          {at::zeros({1}, at::dtype(at::kInt).device(offsets.device())),
            offsets.slice(0, 0, -1)});
       return cutlass_kernels::grouped_mm(
           mat1, mat2, ab_strides, c_strides, problem_sizes, offsets);

--- a/cutlass/group_mm.cu
+++ b/cutlass/group_mm.cu
@@ -5,23 +5,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <cutlass_utils.h>
-#include <nvf_cutlass.h>
+#include <cassert>
 
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAGraphsUtils.cuh>
+
 #include <cutlass/arch/arch.h>
-#include <torch/torch.h>
-
-#include <cassert>
-
-#include "cutlass/epilogue/collective/collective_builder.hpp"
-#include "cutlass/gemm/collective/collective_builder.hpp"
-#include "cutlass/gemm/device/gemm_universal_adapter.h"
-#include "cutlass/gemm/group_array_problem_shape.hpp"
-
+#include <cutlass/epilogue/collective/collective_builder.hpp>
+#include <cutlass/gemm/collective/collective_builder.hpp>
+#include <cutlass/gemm/device/gemm_universal_adapter.h>
+#include <cutlass/gemm/group_array_problem_shape.hpp>
+#include <cutlass_utils.h>
 #include <exceptions.h>
+#include <nvf_cutlass.h>
 
 namespace nvfuser::cutlass_kernels {
 
@@ -128,29 +126,24 @@ __global__ void get_group_gemm_starts(
 //   K: Common K dimension across all groups
 //   stream: CUDA stream for kernel execution
 void run_get_group_gemm_starts(
-    const torch::Tensor& a_starts,
-    const torch::Tensor& b_starts,
-    const torch::Tensor& out_starts,
-    const torch::Tensor& a_tensors,
-    const torch::Tensor& b_tensors,
-    const torch::Tensor& out_tensors,
-    const torch::Tensor& expert_offsets,
-    const torch::Tensor& problem_sizes,
+    const at::Tensor& a_starts,
+    const at::Tensor& b_starts,
+    const at::Tensor& out_starts,
+    const at::Tensor& a_tensors,
+    const at::Tensor& b_tensors,
+    const at::Tensor& out_tensors,
+    const at::Tensor& expert_offsets,
+    const at::Tensor& problem_sizes,
     int M,
     int N,
     int K,
     cudaStream_t stream) {
   int num_experts = (int)expert_offsets.size(0);
 
-  NVF_CHECK(
-      out_tensors.size(1) == N,
-      "Output tensor shape doesn't match expected shape");
-  NVF_CHECK(
-      K == b_tensors.size(2),
-      "b_tensors(dim = 2) and a_tensors(dim = 1) trailing"
-      " dimension must match");
+  NVF_CHECK_EQ(out_tensors.size(1), N);
+  NVF_CHECK_EQ(K, b_tensors.size(2));
 
-  if (out_tensors.dtype() == torch::kBFloat16) {
+  if (out_tensors.dtype() == at::kBFloat16) {
     get_group_gemm_starts<cutlass::bfloat16_t, cutlass::bfloat16_t>
         <<<1, num_experts, 0, stream>>>(
             static_cast<cutlass::bfloat16_t**>(a_starts.data_ptr()),
@@ -163,7 +156,7 @@ void run_get_group_gemm_starts(
             static_cast<int32_t*>(problem_sizes.data_ptr()),
             K,
             N);
-  } else if (out_tensors.dtype() == torch::kFloat16) {
+  } else if (out_tensors.dtype() == at::kHalf) {
     get_group_gemm_starts<cutlass::half_t, cutlass::half_t>
         <<<1, num_experts, 0, stream>>>(
             static_cast<cutlass::half_t**>(a_starts.data_ptr()),
@@ -197,13 +190,13 @@ void run_get_group_gemm_starts(
 //   stream: CUDA stream for kernel execution
 template <typename DType>
 void run_group_mm(
-    torch::Tensor& output,
-    const torch::Tensor& a,
-    const torch::Tensor& b,
-    const torch::Tensor& ab_strides,
-    const torch::Tensor& c_strides,
-    const torch::Tensor& problem_sizes,
-    const torch::Tensor& expert_offsets,
+    at::Tensor& output,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& ab_strides,
+    const at::Tensor& c_strides,
+    const at::Tensor& problem_sizes,
+    const at::Tensor& expert_offsets,
     int M,
     int N,
     int K,
@@ -291,11 +284,10 @@ void run_group_mm(
 
   // Create cutlass arguments
   int num_experts = static_cast<int>(expert_offsets.size(0));
-  auto options_int =
-      torch::TensorOptions().dtype(torch::kInt64).device(a.device());
-  torch::Tensor a_ptrs = torch::empty(num_experts, options_int);
-  torch::Tensor b_ptrs = torch::empty(num_experts, options_int);
-  torch::Tensor out_ptrs = torch::empty(num_experts, options_int);
+  auto options_int = at::TensorOptions().dtype(at::kLong).device(a.device());
+  at::Tensor a_ptrs = at::empty(num_experts, options_int);
+  at::Tensor b_ptrs = at::empty(num_experts, options_int);
+  at::Tensor out_ptrs = at::empty(num_experts, options_int);
   run_get_group_gemm_starts(
       a_ptrs,
       b_ptrs,
@@ -360,8 +352,8 @@ void run_group_mm(
 
   size_t workspace_size = Gemm::get_workspace_size(args);
   auto const workspace_options =
-      torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
-  auto workspace = torch::empty(workspace_size, workspace_options);
+      at::TensorOptions().dtype(at::kByte).device(a.device());
+  auto workspace = at::empty(workspace_size, workspace_options);
 
   auto can_implement_status = gemm_op.can_implement(args);
   NVF_CHECK(
@@ -384,13 +376,13 @@ void run_group_mm(
 // Returns: Never returns (throws exception)
 template <typename DType>
 void run_group_mm(
-    torch::Tensor& output,
-    const torch::Tensor& a,
-    const torch::Tensor& b,
-    const torch::Tensor& ab_strides,
-    const torch::Tensor& c_strides,
-    const torch::Tensor& problem_sizes,
-    const torch::Tensor& expert_offsets,
+    at::Tensor& output,
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& ab_strides,
+    const at::Tensor& c_strides,
+    const at::Tensor& problem_sizes,
+    const at::Tensor& expert_offsets,
     int M,
     int N,
     int K,
@@ -414,12 +406,12 @@ void run_group_mm(
 //
 // Throws: NVF_CHECK exceptions for any validation failures
 void validateInputsGroupMm(
-    const torch::Tensor& a,
-    const torch::Tensor& b,
-    const torch::Tensor& ab_strides,
-    const torch::Tensor& c_strides,
-    const torch::Tensor& problem_sizes,
-    const torch::Tensor& expert_offsets) {
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& ab_strides,
+    const at::Tensor& c_strides,
+    const at::Tensor& problem_sizes,
+    const at::Tensor& expert_offsets) {
   // Check data types
   NVF_CHECK(
       a.scalar_type() == at::ScalarType::BFloat16 ||
@@ -430,14 +422,16 @@ void validateInputsGroupMm(
           b.scalar_type() == at::ScalarType::Half,
       "Expected BFloat16 or Half for Operand B.")
 
-  const int64_t m = a.sizes()[0];
-  const int64_t g = expert_offsets.sizes()[0];
-  int64_t prev_offset = 0;
-  for (int64_t i = 0; i < g; ++i) {
-    int64_t expert_offset = expert_offsets[i].item<int64_t>();
-    NVF_CHECK_LE(expert_offset, m);
-    NVF_CHECK_LE(prev_offset, expert_offset);
-    prev_offset = expert_offset;
+  if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) {
+    const int64_t m = a.size(0);
+    const int64_t g = expert_offsets.size(0);
+    int64_t prev_offset = 0;
+    for (int64_t i = 0; i < g; ++i) {
+      const auto expert_offset = expert_offsets[i].item<int64_t>();
+      NVF_CHECK_LE(expert_offset, m);
+      NVF_CHECK_LE(prev_offset, expert_offset);
+      prev_offset = expert_offset;
+    }
   }
 
   NVF_CHECK_EQ(ab_strides.dtype(), at::kLong);
@@ -452,15 +446,10 @@ void validateInputsGroupMm(
   NVF_CHECK(b.is_contiguous(), "Expected contiguous tensor for Operand B.")
 
   // Check shapes
-  NVF_CHECK(problem_sizes.dim() == 2, "problem_sizes must be  a 2D tensor");
-  NVF_CHECK(
-      problem_sizes.size(1) == 3,
-      "problem_sizes must have the shape (num_experts, 3)");
-  NVF_CHECK(
-      problem_sizes.size(0) == expert_offsets.size(0),
-      "Number of experts in problem_sizes must match expert_offsets");
-  NVF_CHECK(
-      problem_sizes.dtype() == torch::kInt32, "problem_sizes must be int32.");
+  NVF_CHECK_EQ(problem_sizes.dim(), 2);
+  NVF_CHECK_EQ(problem_sizes.size(1), 3);
+  NVF_CHECK_EQ(problem_sizes.size(0), expert_offsets.size(0));
+  NVF_CHECK_EQ(problem_sizes.dtype(), at::kInt);
 }
 
 } // namespace
@@ -482,18 +471,18 @@ void validateInputsGroupMm(
 //
 // Returns: Grouped matrix C = A @ B for all groups in the specified
 // output dtype
-torch::Tensor grouped_mm(
-    const torch::Tensor& a,
-    const torch::Tensor& b,
-    const torch::Tensor& ab_strides,
-    const torch::Tensor& c_strides,
-    const torch::Tensor& problem_sizes,
-    const torch::Tensor& expert_offsets) {
+at::Tensor grouped_mm(
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& ab_strides,
+    const at::Tensor& c_strides,
+    const at::Tensor& problem_sizes,
+    const at::Tensor& expert_offsets) {
   // Calculate output shape and allocate output tensor
   auto options = at::TensorOptions()
                      .dtype(a.scalar_type())
                      .device(at::kCUDA, a.get_device());
-  torch::Tensor output = at::empty({a.size(0), b.size(1)}, options);
+  at::Tensor output = at::empty({a.size(0), b.size(1)}, options);
 
   validateInputsGroupMm(
       a, b, ab_strides, c_strides, problem_sizes, expert_offsets);


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/Fuser/issues/5434

Also remove including torch.h so the file is faster to compile

cc @kshitij12345 

Without CUDA graph:
```
me @ gb200-nvl4-ts2-65 : dev | /opt/pytorch/lightning-thunder (wjy/capture*)
$ python thunder/benchmarks/benchmark_inference.py --input-length 4096 --output-length 2 --mode thunder --enable-nv-linear
  Prefill Time: 21.07 ms
  Decode Time: 12.74 ms
```

With CUDA graph:
```
$ python thunder/benchmarks/benchmark_inference.py --input-length 4096 --output-length 2 --mode thunder --enable-nv-linear --enable-thunder-cudagraph
  Prefill Time: 16.05 ms
  Decode Time: 5.47 ms
```