### PR TITLE
Pass EVT arguments by configurable names

### DIFF
--- a/csrc/cutlass/evt.h
+++ b/csrc/cutlass/evt.h
@@ -41,8 +41,9 @@ class EVTModel {
   struct Node {
     const std::string name;
     std::vector<Node*> inputs;
-    // If an argument is required, provide it here
-    Val* argument = nullptr;
+    // Arguments are an ordered set of key-value pairs corresponding to the
+    // struct field and the value we will assign at runtime
+    std::vector<std::pair<std::string, std::string>> arguments;
   };
 
   Node* makeNode(const std::string& name) {

--- a/csrc/cutlass/gemm.h
+++ b/csrc/cutlass/gemm.h
@@ -12,6 +12,7 @@
 namespace nvfuser {
 
 class Fusion;
+class Val;
 
 class CutlassParams;
 class ScaledMmaOp;
@@ -19,6 +20,12 @@ class ScaledMmaOp;
 namespace cutlass_codegen {
 
 ScaledMmaOp* findScaledMmaOp(Fusion* fusion);
+
+//! Simply finds the position of a Val in fusion->inputs().
+int64_t fusionInputPosition(Fusion* fusion, Val* v);
+
+//! Simply finds the position of a Val in fusion->outputs().
+int64_t fusionOutputPosition(Fusion* fusion, Val* v);
 
 std::string generateNvfp4ScaledMmKernel(
     Fusion* fusion,


### PR DESCRIPTION
Previously, we supported a single `TensorView*` argument for each EVT node. Instead, this PR changes to allow an argument list, provided as a simple list of key-value string pairs. This provides more flexibility which is needed to support EVT nodes that require multiple parameters.

This is needed for #5441 and #5440