### PR TITLE
Move unshard helpers into pipeline test

### DIFF
--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -723,21 +723,6 @@ int64_t requestedNumberOfDevices(Fusion* fusion) {
   return max_index + 1;
 }
 
-void unshard(TensorView* tv) {
-  for (IterDomain* id : tv->getLoopDomain()) {
-    if (id->isDeviceDim()) {
-      id->parallelize(ParallelType::Serial);
-    }
-  }
-  tv->setDeviceMesh(DeviceMesh());
-}
-
-void unshard(Fusion* fusion) {
-  for (auto tv : fusion->allTvs()) {
-    unshard(tv);
-  }
-}
-
 namespace {
 int64_t rankOfParallelType(ParallelType parallel_type) {
   // Currently, when reorderParallelizedToFront is called, the loop domain is

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -94,10 +94,6 @@ void shardBetween(
 // device meshes in the Fusion
 int64_t requestedNumberOfDevices(Fusion*);
 
-// remove the multi-device scheduling annotations
-void unshard(Fusion*);
-void unshard(TensorView*);
-
 // Returns the index of the sharded logical axis that produces the allocation
 // IterDomain sharded on `parallel_type`. If `tv` isn't sharded on the parallel
 // type, returns -1.

--- a/tests/cpp/test_multidevice_pipeline.cpp
+++ b/tests/cpp/test_multidevice_pipeline.cpp
@@ -42,6 +42,25 @@
 
 namespace nvfuser {
 
+namespace {
+
+void unshard(TensorView* tv) {
+  for (IterDomain* id : tv->getLoopDomain()) {
+    if (id->isDeviceDim()) {
+      id->parallelize(ParallelType::Serial);
+    }
+  }
+  tv->setDeviceMesh(DeviceMesh());
+}
+
+void unshard(Fusion* fusion) {
+  for (auto tv : fusion->allTvs()) {
+    unshard(tv);
+  }
+}
+
+} // namespace
+
 class PipelineTest : public MultiDeviceTest {
  protected:
   PipelineTest();


### PR DESCRIPTION
## Summary
- move unshard declarations out of shared multidevice utils header
- keep helpers private to pipeline test where they are used

## Testing
- _bn