### PR TITLE
Refactor multidevice allocation utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,7 @@ list(APPEND NVFUSER_SRCS
   ${NVFUSER_SRCS_DIR}/kernel_ir_dispatch.cpp
   ${NVFUSER_SRCS_DIR}/logical_domain_map.cpp
   ${NVFUSER_SRCS_DIR}/mma_type.cpp
+  ${NVFUSER_SRCS_DIR}/multidevice/allocation_utils.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communication.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/communicator.cpp
   ${NVFUSER_SRCS_DIR}/multidevice/cuda_p2p.cpp

--- a/csrc/multidevice/allocation_utils.cpp
+++ b/csrc/multidevice/allocation_utils.cpp
@@ -1,0 +1,71 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#include <multidevice/allocation_utils.h>
+
+#include <algorithm>
+#include <optional>
+#include <ranges>
+#include <vector>
+
+#include <exceptions.h>
+#include <ir/interface_nodes.h>
+#include <ir/internal_nodes.h>
+#include <ir/utils.h>
+#include <multidevice/utils.h>
+
+namespace nvfuser {
+
+bool isTvContiguous(const TensorView* tv) {
+  // Reduction and broadcast axis do not have a contiguity value.
+  return std::all_of(
+      tv->getContiguity().begin(),
+      tv->getContiguity().end(),
+      [](std::optional<bool> c) { return c.value_or(true); });
+}
+
+IterDomain* projectShardedAllocationToLogical(
+    TensorView* tv,
+    IterDomain* allocation_id) {
+  if (allocation_id == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<Expr*> exprs = DependencyCheck::getAllExprsBetween(
+      {tv->getLogicalDomain().begin(), tv->getLogicalDomain().end()},
+      {allocation_id});
+
+  IterDomain* logical_id = allocation_id;
+  for (Expr* expr : exprs | std::views::reverse) {
+    NVF_ERROR(
+        isValidDeviceSplit(expr), "invalid device split: ", expr->toString());
+    logical_id = expr->as<Split>()->in();
+  }
+  return logical_id;
+}
+
+IterDomain* projectLogicalToShardedAllocation(
+    TensorView* tv,
+    IterDomain* logical_id) {
+  if (logical_id == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<Expr*> exprs = DependencyCheck::getAllExprsBetween(
+      {logical_id},
+      {tv->getMaybeAllocationDomain().begin(),
+       tv->getMaybeAllocationDomain().end()});
+  IterDomain* allocation_id = logical_id;
+  for (auto expr : exprs) {
+    NVF_ERROR(
+        isValidDeviceSplit(expr), "invalid device split: ", expr->toString());
+    allocation_id = expr->as<Split>()->inner();
+  }
+  return allocation_id;
+}
+
+} // namespace nvfuser

--- a/csrc/multidevice/allocation_utils.h
+++ b/csrc/multidevice/allocation_utils.h
@@ -1,0 +1,35 @@
+// clang-format off
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-present NVIDIA CORPORATION & AFFILIATES.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// clang-format on
+#pragma once
+
+namespace nvfuser {
+
+class IterDomain;
+class TensorView;
+
+// Return true if the TensorView is contiguous. This function is more
+// permissive than torch.Tensor.is_contiguous because it allows expanded
+// broadcasts.
+bool isTvContiguous(const TensorView* tv);
+
+// Find the producing logical id of the given allocation id traversing
+// through device splits. For unsharded allocation_id, logical_id is the same as
+// allocation_id.
+IterDomain* projectShardedAllocationToLogical(
+    TensorView* tv,
+    IterDomain* allocation_id);
+
+// Finds the allocated id corresponding to the given logical id
+// traversing through device splits. For e.g.: `i0` -> `DIDx(d), i0/d` will
+// return `i0/d`. For unsharded logical_id, allocation_id is the same as
+// logical_id.
+IterDomain* projectLogicalToShardedAllocation(
+    TensorView* tv,
+    IterDomain* logical_id);
+
+} // namespace nvfuser

--- a/csrc/multidevice/communication.cpp
+++ b/csrc/multidevice/communication.cpp
@@ -5,6 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <multidevice/communication.h>
+
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <c10/cuda/CUDAStream.h>
 #if defined(NVFUSER_DISTRIBUTED) && defined(USE_C10D_NCCL)
 #include <torch/csrc/distributed/c10d/ProcessGroupNCCL.hpp>
@@ -13,7 +22,7 @@
 #include <ir/cloner.h>
 #include <ir/iostream.h>
 #include <ir/printer.h>
-#include <multidevice/communication.h>
+#include <multidevice/allocation_utils.h>
 #include <multidevice/utils.h>
 #include <utils.h>
 

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -27,14 +27,6 @@
 
 namespace nvfuser {
 
-bool isTvContiguous(const TensorView* tv) {
-  // Reduction and broadcast axis do not have a contiguity value.
-  return std::all_of(
-      tv->getContiguity().begin(),
-      tv->getContiguity().end(),
-      [](std::optional<bool> c) { return c.value_or(true); });
-}
-
 bool isSharded(const TensorView* tv) {
   bool is_sharded = false;
   for (IterDomain* id : tv->getLoopDomain()) {
@@ -726,46 +718,6 @@ bool isValidDeviceSplit(Expr* expr) {
     return false;
   }
   return true;
-}
-
-IterDomain* projectShardedAllocationToLogical(
-    TensorView* tv,
-    IterDomain* allocation_id) {
-  if (allocation_id == nullptr) {
-    return nullptr;
-  }
-
-  std::vector<Expr*> exprs = DependencyCheck::getAllExprsBetween(
-      {tv->getLogicalDomain().begin(), tv->getLogicalDomain().end()},
-      {allocation_id});
-
-  IterDomain* logical_id = allocation_id;
-  for (Expr* expr : exprs | std::views::reverse) {
-    NVF_ERROR(
-        isValidDeviceSplit(expr), "invalid device split: ", expr->toString());
-    logical_id = expr->as<Split>()->in();
-  }
-  return logical_id;
-}
-
-IterDomain* projectLogicalToShardedAllocation(
-    TensorView* tv,
-    IterDomain* logical_id) {
-  if (logical_id == nullptr) {
-    return nullptr;
-  }
-
-  std::vector<Expr*> exprs = DependencyCheck::getAllExprsBetween(
-      {logical_id},
-      {tv->getMaybeAllocationDomain().begin(),
-       tv->getMaybeAllocationDomain().end()});
-  IterDomain* allocation_id = logical_id;
-  for (auto expr : exprs) {
-    NVF_ERROR(
-        isValidDeviceSplit(expr), "invalid device split: ", expr->toString());
-    allocation_id = expr->as<Split>()->inner();
-  }
-  return allocation_id;
 }
 
 } // namespace nvfuser

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -7,8 +7,6 @@
 // clang-format on
 #pragma once
 
-#include <c10/util/ArrayRef.h>
-
 #include <compute_at_map.h>
 #include <fusion.h>
 #include <ir/interface_nodes.h>
@@ -16,11 +14,6 @@
 #include <visibility.h>
 
 namespace nvfuser {
-
-// Return true if the TensorView is contiguous. This function is more
-// permissive than torch.Tensor.is_contiguous because it allows expanded
-// broadcasts.
-bool isTvContiguous(const TensorView* tv);
 
 // Returns whether a TensorView has a non-reduction axis parallelized Didx
 // Checks that the other non-reduction axis are not parallelized on Didx
@@ -115,20 +108,5 @@ std::unordered_map<int64_t, int64_t> reorderParallelizedToFront(TensorView*);
 // Validate the expression is a valid DID split: expr is an outer split with
 // device dim as the outer dimension.
 bool isValidDeviceSplit(Expr* expr);
-
-// Find the producing logical id of the given allocation id traversing
-// through device splits. For unsharded allocation_id, logical_id is the same as
-// allocation_id.
-IterDomain* projectShardedAllocationToLogical(
-    TensorView* tv,
-    IterDomain* allocation_id);
-
-// Finds the allocated id corresponding to the given logical id
-// traversing through device splits. For e.g.: `i0` -> `DIDx(d), i0/d` will
-// return `i0/d`. For unsharded logical_id, allocation_id is the same as
-// logical_id.
-IterDomain* projectLogicalToShardedAllocation(
-    TensorView* tv,
-    IterDomain* logical_id);
 
 } // namespace nvfuser

--- a/csrc/preseg_passes/finalize_multidevice_domains.cpp
+++ b/csrc/preseg_passes/finalize_multidevice_domains.cpp
@@ -13,6 +13,7 @@
 #include <ir/iostream.h>
 #include <ir/utils.h>
 #include <linked_hash_map.h>
+#include <multidevice/allocation_utils.h>
 #include <multidevice/utils.h>
 #include <scheduler/utils.h>
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -25,6 +25,7 @@
 #include <ir/interface_nodes.h>
 #include <ir/utils.h>
 #include <logical_domain_map.h>
+#include <multidevice/allocation_utils.h>
 #include <multidevice/utils.h>
 #include <ops/all_ops.h>
 #include <scheduler/mma_utils.h>


### PR DESCRIPTION
## Summary
- extract allocation helpers into dedicated multidevice/allocation_utils module
- register the new source in CMake and include the header where needed
- swap consumer code to use allocation_utils instead of utils for sharding helpers

## Testing
- not run (not requested)