### PR TITLE
Validate offsets only in debug mode

### DIFF
--- a/cutlass/group_mm.cu
+++ b/cutlass/group_mm.cu
@@ -427,7 +427,7 @@ void validateInputsGroupMm(
       c10::cuda::CaptureStatus::None) {
     const int64_t m = a.size(0);
     const int64_t g = expert_offsets.size(0);
-    // This validation requires an expensive synchronization and therfore is
+    // This validation requires an expensive synchronization and therefore is
     // only enabled in debug mode. See #5470.
     at::Tensor expert_offsets_cpu = expert_offsets.cpu();
     int64_t prev_offset = 0;


### PR DESCRIPTION
This turns out to be expensive because
`thunder/benchmarks/benchmark_inference.py`'s decoding time is CPU bound.

```
me @ gb200-nvl4-ts2-105 : dev | /opt/pytorch/nvfuser
$ python thunder/benchmarks/benchmark_inference.py --input-length 4096 --output-length 2 --mode thunder --enable-nv-linear
```

|  | prefill (ms) | decode (ms) |
|--|--------------|-------------|
| before this PR | 20.97 | 12.57 |
| [batch copy](https://github.com/NVIDIA/Fuser/pull/5470/commits/3795deb7cb1db2db92155b3f2db70acc3dca235c) | 16.02 | 7.48 |
| after this PR | 15.64 | 7.09 |

Making the memcpy (triggered by `item`) batched saves most of the time, but I still prefer removing offset validation entirely for SOL. 