### PR TITLE
Update Cutlass grouped gemm alignments constraints.

### DIFF
--- a/cutlass/group_mm.cu
+++ b/cutlass/group_mm.cu
@@ -218,10 +218,14 @@ void run_group_mm(
   using LayoutD = LayoutC;
 
   // Alignment constraints
-  static constexpr int AlignmentA = 128 / cutlass::sizeof_bits<ElementA>::value;
-  static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementB>::value;
-  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
-  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int kAlignmentA =
+      128 / cutlass::sizeof_bits<ElementA>::value;
+  static constexpr int kAlignmentB =
+      128 / cutlass::sizeof_bits<ElementB>::value;
+  static constexpr int kAlignmentC =
+      128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int kAlignmentD =
+      128 / cutlass::sizeof_bits<ElementD>::value;
 
   // Architecture definitions
   using ArchTag = cutlass::arch::Sm100;
@@ -247,10 +251,10 @@ void run_group_mm(
           ElementAccumulator,
           ElementC,
           LayoutC*,
-          AlignmentC,
+          kAlignmentC,
           ElementD,
           LayoutC*,
-          AlignmentD,
+          kAlignmentD,
           typename SingleSmKernelTraits::EpilogueSchedule>::CollectiveOp;
 
   using CollectiveMainloop =
@@ -259,10 +263,10 @@ void run_group_mm(
           MainloopOperatorClass,
           ElementA,
           LayoutA*,
-          AlignmentA,
+          kAlignmentA,
           ElementB,
           LayoutB*,
-          AlignmentB,
+          kAlignmentB,
           ElementAccumulator,
           MmaTileShape,
           ClusterShape,
@@ -456,29 +460,29 @@ void validateInputsGroupMm(
   NVF_CHECK_EQ(b.dim(), 3, "Expected Operand B to be a 3D tensor.");
 
   // Alignment constraints
-  static constexpr int Alignment =
+  static constexpr int kAlignment =
       128 / cutlass::sizeof_bits<cutlass::bfloat16_t>::value;
   NVF_CHECK_EQ(
-      a.size(-1) % Alignment,
+      a.size(-1) % kAlignment,
       0,
       "The inner dimension ",
       a.size(-1),
       " of Operand A is not a multiple of ",
-      Alignment)
+      kAlignment)
   NVF_CHECK_EQ(
-      b.size(-1) % Alignment,
+      b.size(-1) % kAlignment,
       0,
       "The inner dimension ",
       b.size(-1),
       " of Operand B is not a multiple of ",
-      Alignment)
+      kAlignment)
   NVF_CHECK_EQ(
-      b.size(-2) % Alignment,
+      b.size(-2) % kAlignment,
       0,
       "The inner dimension ",
       b.size(-2),
       " of the output tensor is not a multiple of ",
-      Alignment)
+      kAlignment)
 
   // Check shapes
   NVF_CHECK_EQ(problem_sizes.dim(), 2);

--- a/cutlass/nvf_cutlass.cpp
+++ b/cutlass/nvf_cutlass.cpp
@@ -67,11 +67,21 @@ std::tuple<int64_t, int64_t, int64_t> validateInputsNvfp4ScaledMm(
       "Expected FP32 for alpha scalar.")
 
   // Check alignment requirements
-  constexpr int64_t alignment = 32;
+  constexpr int64_t kAlignment = 32;
   NVF_CHECK_EQ(
-      k % alignment, 0, "The K dimension", k, "is not divisible by ", alignment)
+      k % kAlignment,
+      0,
+      "The K dimension",
+      k,
+      "is not divisible by ",
+      kAlignment)
   NVF_CHECK_EQ(
-      n % alignment, 0, "The N dimension", n, "is not divisible by ", alignment)
+      n % kAlignment,
+      0,
+      "The N dimension",
+      n,
+      "is not divisible by ",
+      kAlignment)
 
   // Calculate rounded dimensions for scale matrix validation
   int64_t rounded_m = roundUp(m, 128);

--- a/cutlass/nvfp4_scaled_group_mm.cu
+++ b/cutlass/nvfp4_scaled_group_mm.cu
@@ -337,10 +337,12 @@ void run_nvfp4_scaled_group_mm(
   using LayoutD = LayoutC;
 
   // Alignment constraints
-  static constexpr int AlignmentA = 32;
-  static constexpr int AlignmentB = 32;
-  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
-  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int kAlignmentA = 32;
+  static constexpr int kAlignmentB = 32;
+  static constexpr int kAlignmentC =
+      128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int kAlignmentD =
+      128 / cutlass::sizeof_bits<ElementD>::value;
 
   // Architecture definitions
   using ArchTag = cutlass::arch::Sm100;
@@ -365,10 +367,10 @@ void run_nvfp4_scaled_group_mm(
           ElementAccumulator,
           ElementC,
           LayoutC*,
-          AlignmentC,
+          kAlignmentC,
           ElementD,
           LayoutC*,
-          AlignmentD,
+          kAlignmentD,
           cutlass::epilogue::PtrArrayTmaWarpSpecialized1Sm>::CollectiveOp;
 
   using CollectiveMainloop =
@@ -377,10 +379,10 @@ void run_nvfp4_scaled_group_mm(
           MainloopOperatorClass,
           ElementA,
           LayoutA*,
-          AlignmentA,
+          kAlignmentA,
           ElementB,
           LayoutB*,
-          AlignmentB,
+          kAlignmentB,
           ElementAccumulator,
           MmaTileShape,
           ClusterShape,
@@ -636,30 +638,30 @@ void validateInputsNvfp4ScaledGroupMm(
   NVF_CHECK_EQ(b.dim(), 3, "Expected Operand B to be a 3D tensor.");
 
   // Alignment constraints
-  static constexpr int OperandAlignment = 32;
+  static constexpr int kOperandAlignment = 32;
   NVF_CHECK_EQ(
-      a.size(-1) % OperandAlignment,
+      a.size(-1) % kOperandAlignment,
       0,
       "The inner dimension ",
       a.size(-1),
       " of Operand A is not a multiple of ",
-      OperandAlignment)
+      kOperandAlignment)
   NVF_CHECK_EQ(
-      b.size(-1) % OperandAlignment,
+      b.size(-1) % kOperandAlignment,
       0,
       "The inner dimension ",
       b.size(-1),
       " of Operand B is not a multiple of ",
-      OperandAlignment)
-  static constexpr int OutputAlignment =
+      kOperandAlignment)
+  static constexpr int kOutputAlignment =
       128 / cutlass::sizeof_bits<cutlass::bfloat16_t>::value;
   NVF_CHECK_EQ(
-      b.size(-2) % OutputAlignment,
+      b.size(-2) % kOutputAlignment,
       0,
       "The inner dimension ",
       b.size(-2),
       " of the output tensor is not a multiple of ",
-      OutputAlignment)
+      kOutputAlignment)
 
 #ifndef NDEBUG
   if (c10::cuda::currentStreamCaptureStatusMayInitCtx() ==

--- a/cutlass/nvfp4_scaled_mm.cu
+++ b/cutlass/nvfp4_scaled_mm.cu
@@ -56,20 +56,22 @@ struct Fp4GemmSm100 {
   // A matrix configuration
   using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
   using LayoutATag = cutlass::layout::RowMajor;
-  static constexpr int AlignmentA = 32;
+  static constexpr int kAlignmentA = 32;
 
   // B matrix configuration
   using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
   using LayoutBTag = cutlass::layout::ColumnMajor;
-  static constexpr int AlignmentB = 32;
+  static constexpr int kAlignmentB = 32;
 
   // C/D matrix configuration
   using ElementD = T;
   using ElementC = T;
   using LayoutCTag = cutlass::layout::RowMajor;
   using LayoutDTag = cutlass::layout::RowMajor;
-  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
-  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int kAlignmentD =
+      128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int kAlignmentC =
+      128 / cutlass::sizeof_bits<ElementC>::value;
   // Kernel functional config
   using ElementAccumulator = float;
   using ArchTag = cutlass::arch::Sm100;
@@ -91,10 +93,10 @@ struct Fp4GemmSm100 {
           ElementAccumulator,
           ElementC,
           LayoutCTag,
-          AlignmentC,
+          kAlignmentC,
           ElementD,
           LayoutDTag,
-          AlignmentD,
+          kAlignmentD,
           cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
 
   using CollectiveMainloop =
@@ -103,10 +105,10 @@ struct Fp4GemmSm100 {
           OperatorClass,
           ElementA,
           LayoutATag,
-          AlignmentA,
+          kAlignmentA,
           ElementB,
           LayoutBTag,
-          AlignmentB,
+          kAlignmentB,
           ElementAccumulator,
           MmaTileShape,
           ClusterShape,

--- a/cutlass/nvfp4_scaled_mm_blockscale.cu
+++ b/cutlass/nvfp4_scaled_mm_blockscale.cu
@@ -49,12 +49,12 @@ struct Fp4GemmSm100 {
   // A matrix configuration
   using ElementA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
   using LayoutATag = cutlass::layout::RowMajor;
-  static constexpr int AlignmentA = 32;
+  static constexpr int kAlignmentA = 32;
 
   // B matrix configuration
   using ElementB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
   using LayoutBTag = cutlass::layout::ColumnMajor;
-  static constexpr int AlignmentB = 32;
+  static constexpr int kAlignmentB = 32;
 
   // C/D matrix configuration
   using ElementD = cutlass::float_e2m1_t;
@@ -64,8 +64,10 @@ struct Fp4GemmSm100 {
   using LayoutDTag = cutlass::layout::RowMajor;
   using LayoutSFDTag = LayoutDTag;
 
-  static constexpr int AlignmentD = 128 / cutlass::sizeof_bits<ElementD>::value;
-  static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<ElementC>::value;
+  static constexpr int kAlignmentD =
+      128 / cutlass::sizeof_bits<ElementD>::value;
+  static constexpr int kAlignmentC =
+      128 / cutlass::sizeof_bits<ElementC>::value;
 
   // Kernel functional config
   using ElementAccumulator = float;
@@ -101,10 +103,10 @@ struct Fp4GemmSm100 {
           ElementAccumulator,
           ElementC,
           LayoutCTag,
-          AlignmentC,
+          kAlignmentC,
           ElementD,
           LayoutDTag,
-          AlignmentD,
+          kAlignmentD,
           cutlass::epilogue::collective::EpilogueScheduleAuto,
           FusionOperation>::CollectiveOp;
 
@@ -114,10 +116,10 @@ struct Fp4GemmSm100 {
           OperatorClass,
           ElementA,
           LayoutATag,
-          AlignmentA,
+          kAlignmentA,
           ElementB,
           LayoutBTag,
-          AlignmentB,
+          kAlignmentB,
           ElementAccumulator,
           MmaTileShape,
           ClusterShape,


### PR DESCRIPTION
This PR adds alignment constraints to `validateInputsGroupMm` and `validateInputsNvfp4ScaledGroupMm` respectively.

For `bf16` and `fp16`, the alignment constraint is `128 / sizeof(bf16) == 64`. For `nvfp4`, the alignment constraint is `32`. The K and N dimensions must be a multiple of this alignment.

In nvfp4 grouped gemm, the expert offsets constraint is only active when built in Debug mode.