### PR TITLE
Improve host ForLoop construction and inline printing

### DIFF
--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -568,19 +568,23 @@ NVFUSER_DEFINE_CLONE_AND_CREATE(ForLoop)
 std::string ForLoop::toString(int indent_size) const {
   std::stringstream ss;
   indent(ss, indent_size) << "FOR " << index()->toString() << " from "
-                          << start()->toString() << " to " << stop()->toString()
-                          << ":\n"
+                          << start()->toInlineString() << " to "
+                          << stop()->toInlineString() << ":" << std::endl
                           << body().toString(indent_size + 1);
   return ss.str();
 }
 
 std::string ForLoop::toInlineString(int indent_size) const {
-  NVF_CHECK(false, "Cannot be printed inline");
+  std::stringstream ss;
+  indent(ss, indent_size) << "FOR " << index()->toInlineString() << " from "
+                          << start()->toInlineString() << " to "
+                          << stop()->toInlineString();
+  return ss.str();
 }
 
-/*static*/ ForLoop* ForLoop::createFromIterDomain(
-    Val* index,
-    IterDomain* iter_domain) {
+/*static*/ ForLoop* ForLoop::createFromIterDomain(IterDomain* iter_domain) {
+  FusionGuard fg(iter_domain->fusion());
+  auto* index = IrBuilder::create<Val>(DataType::Index);
   return IrBuilder::create<ForLoop>(
       index, iter_domain->start(), iter_domain->stop());
 }

--- a/csrc/host_ir/host_ir.h
+++ b/csrc/host_ir/host_ir.h
@@ -65,20 +65,18 @@ class HostUnit : public Expr {
   std::unique_ptr<Fusion> fusion_;
 };
 
-/*
-  PostOnStream represents the host instruction of executing a HostUnit. Its I/O
-  represents in the host program the concrete I/O that will be bound at runtime
-  to the Fusion's I/O for compilation and execution. At runtime, PostOnStream
-  will compile and launch the kernel lowered from the HostUnit's embedded
-  Fusion.
-
-  Note: later PostOnStream will take a "Stream" argument
-
-  Note: later PostOnStream will also be able to launch network Communications
-
-  Note: later compilation and kernel launch will be separated and represented by
-  distinct Host IRs
-*/
+// PostOnStream represents the host instruction of executing a HostUnit. Its I/O
+// represents in the host program the concrete I/O that will be bound at runtime
+// to the Fusion's I/O for compilation and execution. At runtime, PostOnStream
+// will compile and launch the kernel lowered from the HostUnit's embedded
+// Fusion.
+//
+// Note: later PostOnStream will take a "Stream" argument
+//
+// Note: later PostOnStream will also be able to launch network Communications
+//
+// Note: later compilation and kernel launch will be separated and represented
+// by distinct Host IRs
 class PostOnStream : public Expr {
  public:
   using Expr::Expr;
@@ -498,7 +496,7 @@ class ForLoop : public Expr {
 
   NVFUSER_DECLARE_CLONE_AND_CREATE
 
-  static ForLoop* createFromIterDomain(Val* index, IterDomain* iter_domain);
+  static ForLoop* createFromIterDomain(IterDomain* iter_domain);
 
   std::string toString(int indent_size = 0) const override;
   std::string toInlineString(int indent_size = 0) const override;


### PR DESCRIPTION
## Summary
- allow printing ForLoop ranges inline and provide a inline-only string helper
- collapse ForLoop::createFromIterDomain into a self-contained helper that creates the index inside a FusionGuard
- update lowering to use the loop's index when sharding tensors by stream

## Testing
- Not run (not requested)
