### PR TITLE
Avoid measuring compile-time overhead for steady and dynamic host benchmarks

### DIFF
--- a/benchmarks/python/core.py
+++ b/benchmarks/python/core.py
@@ -299,8 +299,9 @@ def run_benchmark(
         # For dynamic host latency benchmarking, return a particular input shape, and reset FusionCache if all inputs have been executed.
         global counter
         counter += 1
-        # Execute fd with the first inputs to avoid measuring first time overhead.
-        fd.execute(inputs[0])
+        # The current input is counter % len(inputs). Execute fd with next input
+        # to avoid measuring first time overhead but avoid cache hit with current input.
+        fd.execute(inputs[(counter + 1) % len(inputs)])
         return [inputs[counter % len(inputs)]], {"fd": fd}
 
     # Create an instance of NVFBenchmark


### PR DESCRIPTION
Without using a cache system, the setup function must run once to compile `FusionExecutorCache` and avoid measuring first time overhead for `steady` and `dynamic` host benchmarks.

## test_adaptive_layernorm_fwd_benchmark

<details>

### Legacy:
```
-----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                     Max                    Mean                StdDev                  Median                 IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']           50.5910 (1.0)           63.9040 (1.0)           54.1116 (1.0)          4.9016 (1.0)           52.1910 (1.0)        2.9430 (1.0)           2;2  18,480.3258 (1.0)          10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']       1,581.6860 (31.26)      1,882.0040 (29.45)      1,642.6841 (30.36)       94.8949 (19.36)      1,604.1020 (30.74)     38.1760 (12.97)         1;2     608.7598 (0.03)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']     254,024.5160 (>1000.0)  258,626.3750 (>1000.0)  256,511.6368 (>1000.0)  1,213.9883 (247.67)   256,561.7485 (>1000.0)  931.7070 (316.58)        2;2       3.8985 (0.00)         10           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### With Fix:
```
----------------------------------------------------------------------------------------------------------------------- benchmark: 3 tests -----------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                             Min                     Max                    Mean                StdDev                  Median                 IQR            Outliers          OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']           50.5280 (1.0)           61.7280 (1.0)           52.6493 (1.0)          3.2446 (1.0)           51.7440 (1.0)        0.4170 (1.0)           1;3  18,993.6049 (1.0)          10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']       1,698.2980 (33.61)      2,985.7490 (48.37)      1,891.6154 (35.93)      414.9656 (127.89)     1,717.4975 (33.19)     23.2640 (55.79)         1;2     528.6487 (0.03)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']     257,325.4290 (>1000.0)  261,133.4470 (>1000.0)  259,223.4602 (>1000.0)  1,115.3542 (343.76)   259,453.8530 (>1000.0)  875.1960 (>1000.0)       3;3       3.8577 (0.00)         10           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

### Current ToT:
```
---------------------------------------------------------------------------------------------------------- benchmark: 3 tests ----------------------------------------------------------------------------------------------------------
Name (time in ms)                                                         Min                 Max                Mean             StdDev              Median               IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='dynamic']       1.7526 (1.0)      259.0739 (1.00)     232.4870 (1.0)      81.0748 (61.06)    258.0671 (1.00)     1.5578 (1.0)           1;1  4.3013 (1.0)          10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='compile']     254.4648 (145.20)   258.4844 (1.0)      256.8439 (1.10)      1.3277 (1.0)      256.8037 (1.0)      1.9529 (1.25)          3;0  3.8934 (0.91)         10           1
test_adaptive_layernorm_fwd_benchmark[host_bench_mode='steady']      256.9895 (146.64)   261.9270 (1.01)     258.4413 (1.11)      1.6553 (1.25)     257.7720 (1.00)     1.8639 (1.20)          2;1  3.8694 (0.90)         10           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

</details>

## test_many_segment_benchmark

<details> 

### Legacy:
```
------------------------------------------------------------------------------------------------------------------
Name (time in us)                                                   Min                     Max                    Mean                StdDev                  Median                   IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_many_segment_benchmark[host_bench_mode='steady']          375.8370 (1.0)          404.7980 (1.0)          390.3369 (1.0)         10.3778 (1.0)          388.1100 (1.0)         16.4150 (1.0)           5;0  2,561.8895 (1.0)          10           1
test_many_segment_benchmark[host_bench_mode='dynamic']       5,135.5190 (13.66)      5,567.8690 (13.75)      5,347.7904 (13.70)      166.0816 (16.00)      5,350.5265 (13.79)      298.4950 (18.18)         4;0    186.9931 (0.07)         10           1
test_many_segment_benchmark[host_bench_mode='compile']     387,057.3450 (>1000.0)  390,805.6420 (965.43)   388,637.6845 (995.65)   1,136.7208 (109.53)   388,615.8000 (>1000.0)  1,450.3590 (88.36)         3;0      2.5731 (0.00)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### With Fix:
```
-------------------------------------------------------------------------------
Name (time in us)                                                   Min                     Max                    Mean                StdDev                  Median                   IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_many_segment_benchmark[host_bench_mode='steady']          413.5990 (1.0)          451.0390 (1.0)          435.2208 (1.0)         11.2135 (1.0)          436.5260 (1.0)         15.1680 (1.0)           2;0  2,297.6843 (1.0)          10           1
test_many_segment_benchmark[host_bench_mode='dynamic']       5,456.6520 (13.19)      7,287.7810 (16.16)      5,877.1337 (13.50)      742.4765 (66.21)      5,531.2280 (12.67)      138.4960 (9.13)          2;2    170.1510 (0.07)         10           1
test_many_segment_benchmark[host_bench_mode='compile']     390,059.2480 (943.09)   397,860.2430 (882.10)   392,391.9849 (901.59)   2,172.3987 (193.73)   392,095.0000 (898.22)   1,903.5450 (125.50)        2;1      2.5485 (0.00)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Current ToT:
```
------------------------------------------------------------------------------------------------------
Name (time in ms)                                               Min                 Max                Mean              StdDev              Median                 IQR            Outliers     OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_many_segment_benchmark[host_bench_mode='dynamic']       5.5750 (1.0)      390.2831 (1.01)     273.7277 (1.0)      185.0062 (162.95)   387.6091 (1.00)     383.5338 (386.59)        3;0  3.6533 (1.0)          10           1
test_many_segment_benchmark[host_bench_mode='steady']      384.3614 (68.94)    388.1488 (1.0)      386.9628 (1.41)       1.1354 (1.0)      387.0855 (1.0)        0.9921 (1.0)           2;1  2.5842 (0.71)         10           1
test_many_segment_benchmark[host_bench_mode='compile']     385.9295 (69.22)    389.8209 (1.00)     387.7416 (1.42)       1.5655 (1.38)     387.9649 (1.00)       2.8585 (2.88)          5;0  2.5790 (0.71)         10           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

</details>