### PR TITLE
Skip failing `rope_bwd` benchmarks

### DIFF
--- a/benchmarks/python/test_rope.py
+++ b/benchmarks/python/test_rope.py
@@ -79,6 +79,14 @@ def test_rope_bwd_benchmark(
         kwargs["nv_enable_matmul"] = True
     elif executor == "torchcompile":
         clear_dynamo_cache()
+    elif executor == "thunder-torchcompile" and variation in [
+        "llama_2_7b_hf",
+        "llama_3_8B",
+    ]:
+        # See https://github.com/Lightning-AI/lightning-thunder/issues/2297
+        pytest.skip(
+            "torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors"
+        )
 
     model, gen_inputs, grad, iobytes = rope_setup[variation](seq_length)
     fwd_inputs = gen_inputs()


### PR DESCRIPTION
`llama_2_7b_hf` and `llama_3_8B` networks fail with `thunder-torchcompile` executor. The error is related to torch compile so skipping the benchmark.

Error:
```
E RuntimeError: Exception when running unary_bwd_torch: Dynamo failed to run FX node with fake tensors: call_function <built-in method cat of type object at 0xfffff57cb7c8>(*((FakeTensor(..., device='cuda:0', size=(2, 8, 4, 24576, 128),
E  dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(2, 8, 1, 24576, 128),
E dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(2, 32, 24576, 128))), 2), **{}): got RuntimeError('Number of dimensions of tensors must match.  Expected 5-D tensors, but got 4-D for tensor number 2 in the list')
E           
E  from user code:
E  File "thunder.to_be_compiled_125", line 103, in to_be_compiled
E t132 = torch.cat((t129, t128, t77), 2)  # t132: "cuda:0 bf16[2, 8, 6, 24576, 128]"
E           
E Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```