### PR TITLE
Require explicit domain selection for sharding helpers

### DIFF
--- a/csrc/host_ir/host_ir.cpp
+++ b/csrc/host_ir/host_ir.cpp
@@ -464,14 +464,16 @@ TensorView* shardByStream(TensorView* in, Val* stream_index) {
   auto* out = ops::newValLike(in, *in->getDataType())->as<TensorView>();
 
   NVF_ERROR(
-      getShardedIterDomain(in, ParallelType::Stream) == nullptr,
+      getShardedIterDomain(in, ParallelType::Stream, DomainType::kAllocation) ==
+          nullptr,
       "Input allocation shouldn't be sharded on stream: ",
       in);
   TransformReplay::selfReplay(in->domain(), out->domain());
 
   shardAllocationAsLoop(out, {ParallelType::Stream});
   NVF_ERROR(
-      getShardedIterDomain(out, ParallelType::Stream) != nullptr,
+      getShardedIterDomain(
+          out, ParallelType::Stream, DomainType::kAllocation) != nullptr,
       "Output allocation should be sharded on stream after "
       "shardAllocationAsLoop: ",
       out);

--- a/csrc/multidevice/execution_utils.cpp
+++ b/csrc/multidevice/execution_utils.cpp
@@ -53,7 +53,11 @@ std::vector<int64_t> unshardedSizes(
     c10::IntArrayRef sizes) {
   std::vector<int64_t> unsharded_sizes = sizes.vec();
   for (ParallelType parallel_type : deviceAndStreamParallelTypes()) {
-    IterDomain* sharded_id = getShardedIterDomain(tv, parallel_type);
+    const DomainType domain_type = parallel_type == ParallelType::Stream
+        ? DomainType::kAllocation
+        : DomainType::kLoop;
+    IterDomain* sharded_id =
+        getShardedIterDomain(tv, parallel_type, domain_type);
     if (sharded_id == nullptr) {
       continue;
     }

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -38,7 +38,7 @@ TensorView* scheduleReductionTV(
   // scheduler only schedules the remaining domains while leaving the DIDx
   // domain unchanged.
   IterDomain* sharded_id =
-      getShardedIterDomain(reduction_tv, ParallelType::DIDx);
+      getShardedIterDomain(reduction_tv, ParallelType::DIDx, DomainType::kLoop);
   if (sharded_id != nullptr) {
     NVF_ERROR_EQ(reduction_tv->getDeviceMesh().rank(), 1);
     NVF_ERROR_EQ(


### PR DESCRIPTION
## Summary
- add a DomainType enum so callers can specify which TensorView domain they intend to inspect
- extend getShardedIterDomain to accept the desired DomainType and update all call sites accordingly
- ensure stream sharding checks always use allocation domains while device-parallel dims continue to use loop domains

## Testing
- pre-commit (lintrunner)