### PR TITLE
Skip num_iters 32 and 128 to avoid timeout with test_many_pointwise_ops_host

### DIFF
--- a/benchmarks/python/host/test_many_pointwise_ops_host.py
+++ b/benchmarks/python/host/test_many_pointwise_ops_host.py
@@ -29,8 +29,9 @@ def pointwise_ops_fusion(fd: FusionDefinition, dtype: DataType, num_iters: int):
     fd.add_output(a)
 
 
-# NOTE: num_iters restricted due to issue #1234.
-@pytest.mark.parametrize("num_iters", [2, 8, 32, 128])
+# TODO: num_iters 32 and 128 are restricted due to issue #5531.
+# NOTE: 22 is the largest, runnable num_iters without timeout.
+@pytest.mark.parametrize("num_iters", [2, 8, 16, 22])
 @pytest.mark.parametrize("host_bench_mode", ["compile", "steady", "dynamic"])
 def test_pointwise_ops_benchmark(
     benchmark,


### PR DESCRIPTION
This PR replaces `32` and `128` with `16` and `22` to avoid timeout issue #5531 and to have the correct `num_iters` for the dashboard.