### PR TITLE
[RFC] RaggedIterDomain for nested tensors

### DIFF
--- a/doc/dev/ragged_iter_domain_design_doc.md
+++ b/doc/dev/ragged_iter_domain_design_doc.md
@@ -715,9 +715,9 @@ The output tensor, `tv_result`, is a nested tensor. The extents of the nested do
 ```cpp
 template <typename DT, int rank>
 struct NestedTensor {
-	DT* ptr;
-	int64_t extents[rank];
-	int64_t nested_domain_extents[ragged_dimension_rank];
+    DT* ptr;
+    int64_t extents[rank];
+    int64_t nested_domain_extents[ragged_dimension_rank];
 };
 ```
 


### PR DESCRIPTION
This is a design document for a new type of iteration domain called `RaggedIterDomain`. The motivation is to support nested tensors for expert parallelism.