### PR TITLE
Address KernelExecutor launch_params_ class member TODO

### DIFF
--- a/csrc/runtime/executor.cpp
+++ b/csrc/runtime/executor.cpp
@@ -1080,8 +1080,12 @@ KernelArgumentHolder KernelExecutor::run(
         executor_entry->launch_params, compile_params);
   }
 
-  // TODO: Why does this need to be stored in the class?
-  launch_params_ = executor_entry->launch_params;
+  LaunchParams launch_params = executor_entry->launch_params;
+
+  // The local executor_entry may point to temporary_executor_entry which is
+  // stack-allocated. We must store a copy of the launch params for future use
+  // in testing and benchmarking through KernelExecutor::lastLaunchParams
+  last_launch_params_ = launch_params;
 
   // context manager to disable auto grad for `empty_cuda` calls later
   at::AutoDispatchBelowADInplaceOrView non_variable_type_mode;
@@ -1211,7 +1215,7 @@ KernelArgumentHolder KernelExecutor::run(
   computeArgs(*executor_entry, args);
 
   if (isDebugDumpEnabled(DebugDumpOption::LaunchParam)) {
-    launch_params_.print();
+    launch_params.print();
   }
 
   if (isDebugDumpEnabled(DebugDumpOption::KernelArgs)) {
@@ -1240,15 +1244,15 @@ KernelArgumentHolder KernelExecutor::run(
       NVFUSER_CUDA_SAFE_CALL(cuOccupancyMaxActiveBlocksPerMultiprocessor(
           &blocks_per_sm,
           compiled_kernel_->cudaExecutable()->function,
-          launch_params_.nThreads(),
-          launch_params_.smem()));
+          launch_params.nThreads(),
+          launch_params.smem()));
 
       const int64_t device_id =
           static_cast<unsigned char>(compiled_kernel_->device().index());
       const auto prop =
           at::cuda::getDeviceProperties((c10::DeviceIndex)device_id);
       const int64_t warps_per_sm =
-          ceilDiv(blocks_per_sm * launch_params_.nThreads(), prop->warpSize);
+          ceilDiv(blocks_per_sm * launch_params.nThreads(), prop->warpSize);
 
       const int hw_max_warps =
           prop->maxThreadsPerMultiProcessor / prop->warpSize;
@@ -1268,13 +1272,13 @@ KernelArgumentHolder KernelExecutor::run(
     {
       FUSER_PERF_SCOPE("ExecutorRunFusion::cuLaunchKernelEx");
       CUlaunchConfig config = {};
-      config.gridDimX = launch_params_.gdimx();
-      config.gridDimY = launch_params_.gdimy();
-      config.gridDimZ = launch_params_.gdimz();
-      config.blockDimX = launch_params_.bdimx();
-      config.blockDimY = launch_params_.bdimy();
-      config.blockDimZ = launch_params_.bdimz();
-      config.sharedMemBytes = launch_params_.smem();
+      config.gridDimX = launch_params.gdimx();
+      config.gridDimY = launch_params.gdimy();
+      config.gridDimZ = launch_params.gdimz();
+      config.blockDimX = launch_params.bdimx();
+      config.blockDimY = launch_params.bdimy();
+      config.blockDimZ = launch_params.bdimz();
+      config.sharedMemBytes = launch_params.smem();
       config.hStream = stream;
 
       std::vector<CUlaunchAttribute> launch_attributes;
@@ -1285,7 +1289,7 @@ KernelArgumentHolder KernelExecutor::run(
         // __cluster_dims__ compile-time specification.
         CUlaunchAttribute attribute;
         attribute.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-        attribute.value.clusterDim.x = launch_params_.gdimx();
+        attribute.value.clusterDim.x = launch_params.gdimx();
         attribute.value.clusterDim.y = 1;
         attribute.value.clusterDim.z = 1;
         launch_attributes.push_back(attribute);

--- a/csrc/runtime/executor.h
+++ b/csrc/runtime/executor.h
@@ -161,7 +161,7 @@ class KernelExecutor : public ExecutorAbstract {
 
   //! Returns the launch parameters from the last kernel execution
   LaunchParams lastLaunchParams() const {
-    return launch_params_;
+    return last_launch_params_;
   }
 
   static void setGlobalFusionCount(int64_t new_fusion_count) {
@@ -334,7 +334,7 @@ class KernelExecutor : public ExecutorAbstract {
   float kernel_occupancy_ = -1.0f;
 
   // Profiling support: the last launch param used
-  LaunchParams launch_params_;
+  LaunchParams last_launch_params_;
 
   // Lowering hooks that are called after the GpuLower instance is created
   // before running lowering passes.


### PR DESCRIPTION
# Summary
This change addresses a TODO and clarifies the purpose of this class member. Launch params need to be stored for future use in testing and benchmarking through `KernelExecutor::lastLaunchParams()`. However, the `local executor_entry` may point to a temporary stack-allocated entry, so we must store a copy rather than reference the entry's launch params directly.

# Changes
- `csrc/runtime/executor.cpp`: Use local `launch_params` variable during execution, copy to `last_launch_params_` for storage.
- `csrc/runtime/executor.h`: Rename member variable from `launch_params_` to `last_launch_params_`.
