### PR TITLE
Simplify ir_utils::filterByType

### DIFF
--- a/csrc/ir/utils.h
+++ b/csrc/ir/utils.h
@@ -97,20 +97,12 @@ class FilteredView {
 
   FilteredView(InputIt first, InputIt last) : view_(makeView(first, last)) {}
 
-  const_iterator cbegin() const {
+  const_iterator begin() const {
     return view_.begin();
   }
 
-  const_iterator begin() const {
-    return cbegin();
-  }
-
-  const_iterator cend() const {
-    return view_.end();
-  }
-
   const_iterator end() const {
-    return cend();
+    return view_.end();
   }
 
   bool empty() const {


### PR DESCRIPTION
## Summary
- replace the bespoke iterator/view implementation with a ranges pipeline so filterByType is smaller and clearer
- keep the existing helpers (vector, empty, etc.) by wrapping the ranges view in a lightweight FilteredView
- report the view size as int64_t via std::ranges::distance

## Testing
- _bn