### PR TITLE
Link `CUDA::cupti` to `nvfuser_direct`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -905,6 +905,7 @@ if(BUILD_PYTHON)
   target_link_libraries(nvfuser_direct PRIVATE
     nvf_py_direct_internal
     Python::Module
+    CUDA::cupti
   )
 
   # Add dead code elimination flags to reduce file size


### PR DESCRIPTION
Added `CUDA::cupti` to the `nvfuser_direct` target link libraries because `profile.cpp` includes `fusion_profiler.cpp` which includes `cupti.h`.