### PR TITLE
Prune unused includes

### DIFF
--- a/csrc/device_lower/pass/loop_rotation.cpp
+++ b/csrc/device_lower/pass/loop_rotation.cpp
@@ -14,7 +14,6 @@
 #include <options.h>
 
 #include <device_lower/lower2device.h>
-#include <functional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/csrc/driver_api.cpp
+++ b/csrc/driver_api.cpp
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <iostream>
-
 #include <cuda.h>
 #include <cuda_runtime.h>
 

--- a/csrc/dynamic_transform.h
+++ b/csrc/dynamic_transform.h
@@ -19,7 +19,6 @@
 #include <transform_view.h>
 #include <utils.h>
 
-#include <functional>
 #include <memory>
 #include <vector>
 

--- a/csrc/exceptions.cpp
+++ b/csrc/exceptions.cpp
@@ -15,9 +15,9 @@
 #include <utils.h>
 #include <cstdlib>
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <optional>
+#include <ostream>
 
 namespace nvfuser {
 

--- a/csrc/expr_evaluator.cpp
+++ b/csrc/expr_evaluator.cpp
@@ -8,9 +8,6 @@
 
 #include <expr_evaluator.h>
 
-#include <functional>
-#include <iostream>
-#include <iterator>
 #include <ranges>
 
 #include <debug.h>

--- a/csrc/host_ir/container.cpp
+++ b/csrc/host_ir/container.cpp
@@ -8,8 +8,6 @@
 
 #include <host_ir/container.h>
 
-#include <iterator>
-
 #include <host_ir/host_ir.h>
 #include <ir/builder.h>
 #include <ir/cloner.h>

--- a/csrc/host_ir/evaluator.cpp
+++ b/csrc/host_ir/evaluator.cpp
@@ -7,7 +7,6 @@
 // clang-format on
 
 #include <algorithm>
-#include <iterator>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/csrc/id_model/utils.h
+++ b/csrc/id_model/utils.h
@@ -14,10 +14,6 @@
 #include <options.h>
 #include <utils.h>
 
-#include <functional>
-#include <iostream>
-#include <sstream>
-
 namespace nvfuser {
 
 // Options to enable the IdModel-based tensor indexer selectively

--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -20,7 +20,6 @@
 
 #include <torch/csrc/jit/ir/ir.h>
 
-#include <iostream>
 #include <string>
 #include <unordered_map>
 

--- a/csrc/ir/base_nodes.h
+++ b/csrc/ir/base_nodes.h
@@ -17,7 +17,6 @@
 #include <visibility.h>
 
 #include <cstdint>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <stdexcept>

--- a/csrc/ir/iostream.h
+++ b/csrc/ir/iostream.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <iostream>
+#include <iosfwd>
 
 #include <dispatch.h>
 #include <exceptions.h>

--- a/csrc/ir/printer.h
+++ b/csrc/ir/printer.h
@@ -10,7 +10,7 @@
 #include <ir/iostream.h>
 #include <iter_visitor.h>
 
-#include <iostream>
+#include <iosfwd>
 
 namespace nvfuser {
 

--- a/csrc/kernel.cpp
+++ b/csrc/kernel.cpp
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <iostream>
-
 #include <ATen/cuda/CUDAContext.h>
 
 #include <debug.h>

--- a/csrc/kernel_ir.cpp
+++ b/csrc/kernel_ir.cpp
@@ -20,7 +20,6 @@
 #include <type.h>
 
 #include <cctype>
-#include <iostream>
 #include <regex>
 
 namespace nvfuser::kir {

--- a/csrc/mma_type.cpp
+++ b/csrc/mma_type.cpp
@@ -8,7 +8,6 @@
 #include <fusion.h>
 #include <ir/all_nodes.h>
 #include <mma_type.h>
-#include <functional>
 
 namespace nvfuser {
 

--- a/csrc/parallel_dimension_map.cpp
+++ b/csrc/parallel_dimension_map.cpp
@@ -16,7 +16,6 @@
 #include <iter_visitor.h>
 #include <scheduler/utils.h>
 
-#include <functional>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/csrc/polymorphic_value.h
+++ b/csrc/polymorphic_value.h
@@ -11,7 +11,6 @@
 #include <any>
 #include <complex>
 #include <cstddef>
-#include <functional>
 #include <numeric>
 #include <ostream>
 #include <unordered_map>

--- a/csrc/scheduler/debug_utils.h
+++ b/csrc/scheduler/debug_utils.h
@@ -11,7 +11,7 @@
 #include <options.h>
 #include <utils.h>
 
-#include <iostream>
+#include <ostream>
 
 namespace nvfuser {
 

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -32,7 +32,6 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <functional>
 #include <ranges>
 #include <vector>
 

--- a/csrc/scheduler/matmul_heuristic.h
+++ b/csrc/scheduler/matmul_heuristic.h
@@ -11,7 +11,6 @@
 #include <mma_type.h>
 #include <scheduler/heuristic.h>
 #include <utils.h>
-#include <functional>
 
 #include <sstream>
 #include "type.h"

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -31,9 +31,6 @@
 #include <val_graph.h>
 
 #include <algorithm>
-#include <deque>
-#include <iostream>
-#include <iterator>
 #include <limits>
 #include <memory>
 #include <sstream>

--- a/csrc/serde/polymorphic_value.h
+++ b/csrc/serde/polymorphic_value.h
@@ -12,7 +12,6 @@
 #include <serde/factory.h>
 #include <serde/fusion_cache_generated.h>
 #include <visibility.h>
-#include <functional>
 #include <memory>
 
 namespace nvfuser::serde {

--- a/csrc/tensor_metadata.cpp
+++ b/csrc/tensor_metadata.cpp
@@ -18,7 +18,6 @@
 #include <polymorphic_value.h>
 #include <tensor_metadata.h>
 
-#include <iterator>
 #include <ranges>
 
 namespace nvfuser {

--- a/csrc/tensor_view.cpp
+++ b/csrc/tensor_view.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <iterator>
 #include <ranges>
 
 #include <compute_at.h>

--- a/csrc/type.h
+++ b/csrc/type.h
@@ -10,7 +10,7 @@
 #include <array>
 #include <complex>
 #include <cstdint>
-#include <iostream>
+#include <iosfwd>
 #include <optional>
 #include <ranges>
 #include <string>

--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -17,7 +17,6 @@
 #include <utils.h>
 
 #include <cstdlib>
-#include <iostream>
 #include <optional>
 
 namespace nvfuser {

--- a/csrc/val_graph.h
+++ b/csrc/val_graph.h
@@ -11,7 +11,7 @@
 #include <ir/all_nodes.h>
 #include <val_graph_nodes.h>
 
-#include <iostream>
+#include <ostream>
 #include <ranges>
 #include <string>
 #include <type_traits>

--- a/python/python_frontend/fusion_definition.h
+++ b/python/python_frontend/fusion_definition.h
@@ -7,8 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <unordered_map>
 
 #include <distributed_tensor.h>

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <iostream>
 #include <optional>
 #include <tuple>
 

--- a/tests/cpp/test_compute_with.cpp
+++ b/tests/cpp/test_compute_with.cpp
@@ -48,7 +48,6 @@
 #include <c10/cuda/CUDAStream.h>
 
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <thread>
 

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <functional>
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/tests/cpp/test_expr_sort.cpp
+++ b/tests/cpp/test_expr_sort.cpp
@@ -6,7 +6,6 @@
  */
 // clang-format on
 
-#include <iostream>
 #include <list>
 #include <memory>
 #include <unordered_set>

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -50,7 +50,6 @@
 
 #include <algorithm>
 #include <complex>
-#include <iostream>
 #include <sstream>
 #include <thread>
 

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -51,7 +51,6 @@
 #include <c10/cuda/CUDAStream.h>
 
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <thread>
 

--- a/tests/cpp/test_host_ir_stream_lowering.cpp
+++ b/tests/cpp/test_host_ir_stream_lowering.cpp
@@ -7,7 +7,6 @@
 // clang-format on
 
 #include <algorithm>
-#include <iostream>
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>

--- a/tests/cpp/test_host_irs.cpp
+++ b/tests/cpp/test_host_irs.cpp
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 #include <c10/cuda/CUDAStream.h>

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -16,9 +16,6 @@
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
-#include <fstream>
-#include <iostream>
-
 namespace nvfuser {
 
 namespace {

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -20,7 +20,6 @@
 #include <scheduler/tools/inlining.h>
 #include <algorithm>
 #include <bit>
-#include <iterator>
 #include <unordered_map>
 
 namespace nvfuser {

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -19,8 +19,6 @@
 #include <ops/arith.h>
 #include <ops/utils.h>
 
-#include <iostream>
-
 namespace nvfuser {
 
 class CommunicationTest

--- a/tests/cpp/test_multidevice_host_ir.cpp
+++ b/tests/cpp/test_multidevice_host_ir.cpp
@@ -5,8 +5,6 @@
 * SPDX-License-Identifier: BSD-3-Clause
 */
 // clang-format on
-#include <cuda_profiler_api.h>
-
 #include <torch/torch.h>
 
 #include <fusion.h>

--- a/tests/cpp/test_multidevice_ipc.cpp
+++ b/tests/cpp/test_multidevice_ipc.cpp
@@ -6,7 +6,6 @@
 */
 // clang-format on
 #include <cuda.h>
-#include <cuda_profiler_api.h>
 #include <fusion.h>
 #include <host_ir/container.h>
 #include <host_ir/evaluator.h>

--- a/tests/cpp/test_multidevice_stream_parallel_type.cpp
+++ b/tests/cpp/test_multidevice_stream_parallel_type.cpp
@@ -5,9 +5,6 @@
 * SPDX-License-Identifier: BSD-3-Clause
 */
 // clang-format on
-#include <iterator>
-
-#include <cuda_profiler_api.h>
 
 #include <fusion.h>
 #include <host_ir/container.h>

--- a/tests/cpp/test_mutator.cpp
+++ b/tests/cpp/test_mutator.cpp
@@ -17,8 +17,6 @@
 #include <tests/cpp/utils.h>
 #include <tests/cpp/validator.h>
 
-#include <functional>
-
 namespace nvfuser {
 
 // Test that OptOutMutator mutates expressions in a predictable way

--- a/tests/cpp/test_reshape.cpp
+++ b/tests/cpp/test_reshape.cpp
@@ -46,7 +46,6 @@
 #include <c10/cuda/CUDAStream.h>
 
 #include <algorithm>
-#include <iostream>
 
 namespace nvfuser {
 

--- a/tests/cpp/test_resharding.cpp
+++ b/tests/cpp/test_resharding.cpp
@@ -6,7 +6,6 @@
  */
 // clang-format on
 #include <algorithm>
-#include <iostream>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -27,7 +27,6 @@
 #include <c10/cuda/CUDAStream.h>
 
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <thread>
 

--- a/tests/cpp/test_smem_reuse.cpp
+++ b/tests/cpp/test_smem_reuse.cpp
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <complex>
-#include <iostream>
 #include <sstream>
 #include <thread>
 


### PR DESCRIPTION
## Summary
- drop redundant `#include <functional>`, `#include <iterator>`, `#include <iostream>`, and other STL headers across runtime, python bindings, and tests to reduce rebuild churn
- switch a few headers to lighter `<iosfwd>`/`<ostream>` includes where only stream declarations are used
- rerun `_bn` to make sure the project still builds after the cleanup

## Testing
- `_bn`
