### PR TITLE
Add TensorView inner/outer split aliases

### DIFF
--- a/python/python_direct/ir.cpp
+++ b/python/python_direct/ir.cpp
@@ -370,6 +370,52 @@ inner_split : bool, optional
 
 Returns
 -------
+      TensorView
+    A TensorView with the split axes in its loop domain.
+)")
+      .def(
+          "inner_split",
+          [](TensorView* self, int64_t axis, int64_t factor) {
+            return self->split(axis, factor, true);
+          },
+          py::arg("axis"),
+          py::arg("factor"),
+          py::return_value_policy::reference,
+          R"(
+Split an axis into inner-first order (alias of split with inner_split=True).
+
+Parameters
+----------
+axis : int
+    The axis to split.
+factor : int
+    The factor to split by (inner size).
+
+Returns
+-------
+TensorView
+    A TensorView with the split axes in its loop domain.
+)")
+      .def(
+          "outer_split",
+          [](TensorView* self, int64_t axis, int64_t factor) {
+            return self->split(axis, factor, false);
+          },
+          py::arg("axis"),
+          py::arg("factor"),
+          py::return_value_policy::reference,
+          R"(
+Split an axis into outer-first order (alias of split with inner_split=False).
+
+Parameters
+----------
+axis : int
+    The axis to split.
+factor : int
+    The factor to split by (outer size).
+
+Returns
+-------
 TensorView
     A TensorView with the split axes in its loop domain.
 )")

--- a/tests/python/direct/test_stream.py
+++ b/tests/python/direct/test_stream.py
@@ -16,7 +16,7 @@ def test_matmul(nvfuser_direct_test):
         out = fd.ops.matmul(inp, w)
         fd.add_output(out)
 
-        out.split(1, c, inner_split=False)
+        out.outer_split(1, c)
         out.axis(1).parallelize(ParallelType.stream)
         # With NVFUSER_DUMP=host_ir, you'll see the host IR container like the
         # following:
@@ -55,7 +55,7 @@ def test_two_matmuls(nvfuser_direct_test):
         out = fd.ops.matmul(out, w2)
         fd.add_output(out)
 
-        inp.split(0, c, inner_split=False)
+        inp.outer_split(0, c)
         inp.axis(0).parallelize(ParallelType.stream)
         # With NVFUSER_DUMP=host_ir, you'll see the host IR container like the
         # following:

--- a/tests/python/multidevice/fusion_definition_wrapper.py
+++ b/tests/python/multidevice/fusion_definition_wrapper.py
@@ -54,7 +54,7 @@ class FusionDefinitionWrapper:
             placement: Placement = in_dtensor.placements[0]
             if placement.is_shard():
                 dim = cast(Shard, placement).dim
-                in_tv.split(dim, mesh.size, inner_split=False)
+                in_tv.outer_split(dim, mesh.size)
                 in_tv.axis(dim).parallelize(nvfuser.ParallelType.mesh_x)
 
     def _get_or_create_fusion_definition(

--- a/tests/python/multidevice/test_communication.py
+++ b/tests/python/multidevice/test_communication.py
@@ -25,7 +25,7 @@ def test_allgather(multidevice_direct_test):
 
         for inp in fd.fusion.inputs():
             inp.set_device_mesh(mesh)
-            inp.split(0, d, inner_split=False)
+            inp.outer_split(0, d)
             inp.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     unsharded = torch.randn(d * 4)
@@ -74,7 +74,7 @@ def test_allreduce(multidevice_direct_test):
     def _multidevice_schedule(fd: FusionDefinition):
         for inp in fd.fusion.inputs():
             inp.set_device_mesh(mesh)
-            inp.split(1, d, inner_split=False)
+            inp.outer_split(1, d)
             inp.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     m = 2
@@ -109,7 +109,7 @@ def test_reduce_scatter(multidevice_direct_test):
 
         for out in fd.fusion.outputs():
             out.set_device_mesh(mesh)
-            out.split(-1, d, inner_split=False)
+            out.outer_split(-1, d)
             out.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     unsharded = torch.randn(d, d * 4)
@@ -150,7 +150,7 @@ def test_reduce_scatter_noncontiguous(multidevice_direct_test):
 
         for out in fd.fusion.outputs():
             out.set_device_mesh(mesh)
-            out.split(-1, d, inner_split=False)
+            out.outer_split(-1, d)
             out.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     unsharded = torch.randn(d, 3, d * 4)

--- a/tests/python/multidevice/test_matmul.py
+++ b/tests/python/multidevice/test_matmul.py
@@ -80,7 +80,7 @@ def test_column_parallel_linear(multidevice_direct_test):
 
         # Shard N for weight (N, K) and bias (N)
         for t in [weight, bias]:
-            t.split(0, d, inner_split=False)
+            t.outer_split(0, d)
             t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)
@@ -129,7 +129,7 @@ def test_row_parallel_linear(multidevice_direct_test):
         inp, weight = fd.fusion.inputs()
         for t in [inp, weight]:
             t.set_device_mesh(mesh)
-            t.split(-1, d, inner_split=False)
+            t.outer_split(-1, d)
             t.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)
@@ -169,7 +169,7 @@ def test_row_parallel_linear_with_bias(multidevice_direct_test):
         inp, weight, _ = fd.fusion.inputs()
         for t in [inp, weight]:
             t.set_device_mesh(mesh)
-            t.split(-1, d, inner_split=False)
+            t.outer_split(-1, d)
             t.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)
@@ -210,11 +210,11 @@ def test_linear_reduce_scatter(multidevice_direct_test):
         (out,) = fd.fusion.outputs()
         for t in [inp, weight, out]:
             t.set_device_mesh(mesh)
-            t.split(-1, d, inner_split=False)
+            t.outer_split(-1, d)
             t.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
         # Scatter
-        out.split(1, d, inner_split=False)
+        out.outer_split(1, d)
         out.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)
@@ -263,12 +263,12 @@ def test_column_parallel_matmul(multidevice_direct_test):
             t.set_device_mesh(mesh)
 
         # Shard N for weight (K, N)
-        weight.split(-1, d, inner_split=False)
+        weight.outer_split(-1, d)
         weight.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
         # Output of linear: {.., i{M}, i{N}, r{K}}
         # Shard N -> axis(-2)
-        out.split(-2, d, inner_split=False)
+        out.outer_split(-2, d)
         out.axis(-3).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)
@@ -316,15 +316,15 @@ def test_row_parallel_matmul(multidevice_direct_test):
             t.set_device_mesh(mesh)
 
         # Shard K for inp (M, K)
-        inp.split(-1, d, inner_split=False)
+        inp.outer_split(-1, d)
         inp.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
         # Shard K for weight (K, N)
-        weight.split(0, d, inner_split=False)
+        weight.outer_split(0, d)
         weight.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
         # [i{M}, i{N}, r{K}]
-        out.split(-1, d, inner_split=False)
+        out.outer_split(-1, d)
         # [i{M}, i{N}, r{d}, r{K//d}]
         local_out = out.rfactor(axes=[-1])
         # local_out = [i{M}, i{N}, i{d}, r{K//d}]
@@ -370,7 +370,7 @@ def test_column_parallel_grouped_mm(multidevice_direct_test):
         for t in [inp, w, offsets]:
             t.set_device_mesh(mesh)
 
-        w.split(1, d, inner_split=False)
+        w.outer_split(1, d)
         w.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     m = 32
@@ -413,10 +413,10 @@ def test_row_parallel_grouped_mm(multidevice_direct_test):
         for t in [inp, w, offsets]:
             t.set_device_mesh(mesh)
 
-        inp.split(-1, d, inner_split=False)
+        inp.outer_split(-1, d)
         inp.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
-        w.split(-1, d, inner_split=False)
+        w.outer_split(-1, d)
         w.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     m = 32
@@ -462,7 +462,7 @@ def test_issue4729(multidevice_direct_test):
         x, y, w = fd.fusion.inputs()
         for t in [x, y, w]:
             t.set_device_mesh(mesh)
-            t.split(-1, d, inner_split=False)
+            t.outer_split(-1, d)
             t.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
     x_ref = torch.randint(-2, 3, (1, 1, d * 3), dtype=torch.bfloat16)
@@ -504,11 +504,11 @@ def test_sequence_parallel_linear(multidevice_direct_test):
         inp, weight, bias = fd.fusion.inputs()
         for t in [weight, bias]:
             t.set_device_mesh(mesh)
-            t.split(0, d, inner_split=False)
+            t.outer_split(0, d)
             t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
         inp.set_device_mesh(mesh)
-        inp.split(1, d, inner_split=False)
+        inp.outer_split(1, d)
         inp.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     torch.cuda.set_device(multidevice_direct_test.local_rank)

--- a/tests/python/multidevice/test_multidevice.py
+++ b/tests/python/multidevice/test_multidevice.py
@@ -240,7 +240,7 @@ def test_sdpa_loop_split(multidevice_direct_test, qkv_format: QkvFormat):
     def _multidevice_schedule(fd: FusionDefinition) -> None:
         for t in fd.fusion.inputs():
             t.set_device_mesh(mesh)
-            t.split(1, d, inner_split=False)
+            t.outer_split(1, d)
             t.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     b, s = 2, 1024
@@ -323,7 +323,7 @@ def test_privatize_squeeze(multidevice_direct_test):
     def _multidevice_schedule(fd: FusionDefinition):
         for t in fd.fusion.inputs():
             t.set_device_mesh(mesh)
-            t.split(0, d, inner_split=False)
+            t.outer_split(0, d)
             t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     with FusionDefinition() as fd:
@@ -351,7 +351,7 @@ def test_inner_reduction(multidevice_direct_test):
     def _multidevice_schedule(fd: FusionDefinition) -> None:
         for t in fd.fusion.inputs():
             t.set_device_mesh(mesh)
-            t.split(0, d, inner_split=False)
+            t.outer_split(0, d)
             t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     unsharded = torch.ones(d * 3, 5)
@@ -378,7 +378,7 @@ def test_insert_resharding_after(multidevice_direct_test):
     def _multidevice_schedule(fd: FusionDefinition):
         for t in fd.fusion.inputs():
             t.set_device_mesh(mesh)
-            t.split(0, d, inner_split=False)
+            t.outer_split(0, d)
             t.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
         (out,) = fd.fusion.outputs()
@@ -409,7 +409,7 @@ def test_welford(multidevice_direct_test):
     def _multidevice_schedule(fd: FusionDefinition):
         (inp,) = fd.fusion.inputs()
         inp.set_device_mesh(mesh)
-        inp.split(1, d, inner_split=False)
+        inp.outer_split(1, d)
         inp.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     unsharded = torch.randn(b, s, e)

--- a/tests/python/multidevice/test_transformer.py
+++ b/tests/python/multidevice/test_transformer.py
@@ -389,14 +389,14 @@ def transformer_forward_multidevice_schedule(fd: FusionDefinition, num_devices: 
         mlp_linear0_weight,
         mlp_linear0_bias,
     ]:
-        tv.split(0, num_devices, inner_split=False)
+        tv.outer_split(0, num_devices)
         tv.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     for tv in [
         mha_linear1_weight,
         mlp_linear1_weight,
     ]:
-        tv.split(-1, num_devices, inner_split=False)
+        tv.outer_split(-1, num_devices)
         tv.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
 
@@ -1001,14 +1001,14 @@ def transformer_backward_multidevice_schedule(fd: FusionDefinition, num_devices:
         mha_linear0_weight,
         mlp_linear0_weight,
     ]:
-        tv.split(0, num_devices, inner_split=False)
+        tv.outer_split(0, num_devices)
         tv.axis(0).parallelize(nvfuser.ParallelType.mesh_x)
 
     for tv in [
         sdpa_out,
         sdpa_logsum_exp,
     ]:
-        tv.split(1, num_devices, inner_split=False)
+        tv.outer_split(1, num_devices)
         tv.axis(1).parallelize(nvfuser.ParallelType.mesh_x)
 
     for tv in [
@@ -1017,7 +1017,7 @@ def transformer_backward_multidevice_schedule(fd: FusionDefinition, num_devices:
         mha_linear1_weight,
         mlp_linear1_weight,
     ]:
-        tv.split(-1, num_devices, inner_split=False)
+        tv.outer_split(-1, num_devices)
         tv.axis(-2).parallelize(nvfuser.ParallelType.mesh_x)
 
 


### PR DESCRIPTION
## Summary
- expose TensorView.inner_split and TensorView.outer_split on the python bindings so scheduling code can use descriptive helpers
- update direct and multidevice tests to call the aliases instead of passing inner_split flags

## Testing
- not run (not requested)