### PR TITLE
Fix typo that disabled setting nvmmh dir in build

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -478,7 +478,7 @@ def cmake(config, relative_path):
         cmake_build_dir,
     ]
     if config.nvmmh_include_dir:
-        f"-DNVMMH_INCLUDE_DIR={config.nvmmh_include_dir}",
+        cmd_str.append(f"-DNVMMH_INCLUDE_DIR={config.nvmmh_include_dir}")
     if not config.no_ninja:
         cmd_str.append("-G")
         cmd_str.append("Ninja")


### PR DESCRIPTION
I believe there was a busted merge causing the one-line bug that this PR fixes. Before this change, setting `NVFUSER_BUILD_NVMMH_INCLUDE_DIR` would have no effect. After this PR it has the intended effect of building nvFuser with nvMatmulHeuristics support.