### PR TITLE
Fix auto-merge workflow JSON parsing error

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -432,7 +432,7 @@ jobs:
             core.info('✅ Updated auto-merge status comment');
 
       - name: Merge PR
-        if: fromJSON(steps.check.outputs.result).ready == true
+        if: steps.check.outputs.result != '' && fromJSON(steps.check.outputs.result).ready == true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
Fixes JSON parsing error in auto-merge workflow when the check step is skipped.

## Bug
The "Merge PR" step failed with `JsonReaderException` when trying to parse empty output from a skipped "Check all conditions" step (e.g., when PR lacks the `enable-auto-merge` label).

## Fix
Added condition to verify `steps.check.outputs.result` is not empty before attempting JSON parsing.