### PR TITLE
Disable HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile test

### DIFF
--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -4677,7 +4677,6 @@ TEST_F(
     HopperMatmulTest,
     DISABLED_HSH_NT_UseScheduler_MultipleInstructionsPerWarpTile) {
   Fusion fusion;
-  Fusion fusion;
   FusionGuard fg(&fusion);
 
   constexpr int64_t M = 2048, N = 2048, K = 8192;


### PR DESCRIPTION
This test started failing when we moved from CUDA 13.0 to 13.1. The test is a non-warp specialized Hopper matmul which is uncommon, so it is lower priority. Hence we are disabling it for now.