### PR TITLE
[pointwise TMA] Fix TMA compatibility check for mixed-precision inputs

### DIFF
--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -338,8 +338,10 @@ bool mayHaveTmaCompatibleInputs(
     if (!tv->isFusionInput()) {
       continue;
     }
-    auto dtype_bits =
-        dataTypeSizeBit(tv->getDataType().value(), prop.index_type);
+    // If the minimum dtype size is suitable, then all other dtypes are
+    // suitable.
+    auto dtype_bits = prop.min_dtype_size_bit_for_vectorization;
+
     // Note: The actual element count should consider the breakpoint and be
     // computed individually for each input. Here, the largest output is used
     // as a conservative estimate. If the largest output fails these checks,

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -2079,4 +2079,32 @@ TEST_F(TmaPointwiseTestF, SplitGridDim2D) {
   testValidate(
       executor_cache.fusion(), out_tensors, {t0, t1, t2}, __LINE__, __FILE__);
 }
+
+TEST_F(TmaPointwiseTestF, MixedPrecisionIllegalTma) {
+  int64_t dim0 = 16384 + 8;
+  auto fusion_ptr = std::make_unique<Fusion>();
+  auto fusion = fusion_ptr.get();
+  FusionGuard fg(fusion);
+  // tv1 is suitable for TMA, tv0 is not. Then non-TMA version is used.
+  auto tv0 = makeContigTensor(1, DataType::BFloat16);
+  auto tv1 = makeContigTensor(1, DataType::Float);
+  fusion->addInput(tv0);
+  fusion->addInput(tv1);
+  auto tv2 = castOp(DataType::Float, tv0);
+  auto tv3 = add(tv2, tv1);
+  fusion->addOutput(tv3);
+
+  auto options = at::TensorOptions().dtype(at::kBFloat16).device(at::kCUDA, 0);
+  auto options_float =
+      at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
+  auto t0 = at::randn({dim0}, options);
+  auto t1 = at::randn({dim0}, options_float);
+
+  FusionExecutorCache executor_cache(std::move(fusion_ptr));
+  auto out_tensors = executor_cache.runFusionWithInputs({t0, t1});
+  EXPECT_FALSE(tma_check::hasTmaLoad(executor_cache));
+  testValidate(
+      executor_cache.fusion(), out_tensors, {t0, t1}, __LINE__, __FILE__);
+}
+
 } // namespace nvfuser


### PR DESCRIPTION
**Issue:**

The heuristic in `mayHaveTmaCompatibleInputs()` was checking each input individually using its own dtype size to determine TMA compatibility. However, this is inconsistent with how `getTmaDomainInner()` works, which uses `min_dtype_size_bit_for_vectorization` to ensure the TMA domain size works for all vectorizable inputs.

This mismatch could cause issues with mixed-precision inputs. For example, if a fusion has:
- Input 0: BFloat16 (2 bytes) 
- Input 1: Float32 (4 bytes)

The old logic would check each input with its own dtype size, but `getTmaDomainInner()` would later be called with the minimum size (2 bytes). This inconsistency could lead to incorrect TMA selection when mixed-precision inputs don't all meet TMA requirements at the minimum dtype size.

**Changes:**

- Modified `mayHaveTmaCompatibleInputs()` in `csrc/scheduler/pointwise.cpp` to use `prop.min_dtype_size_bit_for_vectorization` instead of per-tensor dtype size when evaluating TMA compatibility.
- Added test case `MixedPrecisionIllegalTma` to verify that non-TMA scheduler is correctly selected for mixed-precision inputs where not all inputs are TMA-compatible at the minimum dtype size.

**Rationale:**

Using the minimum dtype size in `mayHaveTmaCompatibleInputs()` ensures consistency with `getTmaDomainInner()`. If the minimum dtype size meets TMA requirements, all larger dtypes will also be suitable. This conservative approach prevents incorrectly selecting TMA when the actual TMA domain calculation (using min dtype size) would fail for some inputs.

**Alternative Approach (Not Implemented):**

Another option would be to check inputs individually and use TMA only for compatible inputs. However, this would require either:
1. Saving which TensorView is TMA-suitable in the heuristics, or  
2. Passing runtime info to the schedule function to check TMA compatibility there.

The current approach is simpler and maintains consistency between the compatibility check and the actual TMA domain calculation.