### PR TITLE
Check nullptr attributes in Expr::sameOp

### DIFF
--- a/csrc/ir/base_nodes.cpp
+++ b/csrc/ir/base_nodes.cpp
@@ -429,7 +429,10 @@ bool Expr::sameOp(const Expr* other) const {
     return false;
   }
   for (const auto i : arange(attributes().size())) {
-    if (!attribute(i)->sameAs(other->attribute(i))) {
+    if (attribute(i) == nullptr && other->attribute(i) != nullptr) {
+      return false;
+    }
+    if (attribute(i) != nullptr && !attribute(i)->sameAs(other->attribute(i))) {
       return false;
     }
   }


### PR DESCRIPTION
The `BlockQuantizationOp` creates `nullptr` attributes for `logical_index` and `global_scale`. This PR updates `Expr::sameOp` to check for this correctly.

See https://github.com/NVIDIA/Fuser/blob/main/csrc/ops/arith.cpp#L2733-L2734.