### PR TITLE
[benchmark_inference.py] Quality of life improvements

### DIFF
--- a/benchmarks/python/benchmark_inference.py
+++ b/benchmarks/python/benchmark_inference.py
@@ -641,7 +641,7 @@ class InferenceBenchmark:
         if torch.cuda.is_available():
             torch.cuda.reset_peak_memory_stats()
 
-        for _ in tqdm(range(self.config.num_iterations), disable=LOCAL_RANK != 0):
+        for idx in tqdm(range(self.config.num_iterations), disable=LOCAL_RANK != 0):
             past_key_values.reset()
 
             is_under_nsys = bool(os.environ.get("NSYS_PROFILING_SESSION_ID"))


### PR DESCRIPTION
1. Add nvtx markers for warmup, prefill, and decode
2. Rename `--enable-thunder-cudagraph` to `--enable-cudagraph` and use it for inductor backend.
3. Add flag `--use-hardcoded-model` to use hardcoded model config, avoiding the need to login to huggingface. In the future, this will also trigger hardcoded model code copied in from transformers.