### PR TITLE
Move shared inner-reduction functions into reduction_utils.cpp

### DIFF
--- a/csrc/scheduler/reduction_non_tma.cpp
+++ b/csrc/scheduler/reduction_non_tma.cpp
@@ -1299,36 +1299,36 @@ std::unique_ptr<ReductionParams> outerReductionHeuristic(
 }
 
 std::unique_ptr<ReductionParams> reductionHeuristic(
-    const reduction_scheduler_utils::ReductionKernelParams& k_params) {
-  if (k_params.fastest_dim_reduction) {
-    if (k_params.total_reduction_numel == k_params.inner_most_dimension_numel) {
+    const reduction_scheduler_utils::FusionRuntimeProperties& prop) {
+  if (prop.fastest_dim_reduction) {
+    if (prop.total_reduction_numel == prop.inner_most_dimension_numel) {
       return inner2dReductionHeuristic(
-          k_params.total_reduction_numel,
-          k_params.total_iteration_numel,
-          (int64_t)k_params.n_tensor_inputs,
-          (int64_t)k_params.max_dtype_size_bit_for_vectorization,
-          (int64_t)k_params.vectorize_factor,
-          k_params.has_mufu_computation);
+          prop.total_reduction_numel,
+          prop.total_iteration_numel,
+          (int64_t)prop.n_tensor_inputs,
+          (int64_t)prop.max_dtype_size_bit_for_vectorization,
+          (int64_t)prop.vectorize_factor,
+          prop.has_mufu_computation);
     } else {
       return inner3dReductionHeuristic(
-          k_params.total_reduction_numel,
-          k_params.total_iteration_numel,
-          k_params.inner_most_dimension_numel,
-          (int64_t)k_params.n_tensor_inputs,
-          (int64_t)k_params.max_dtype_size_bit_for_vectorization,
-          k_params.vectorize_factor,
-          k_params.has_mufu_computation);
+          prop.total_reduction_numel,
+          prop.total_iteration_numel,
+          prop.inner_most_dimension_numel,
+          (int64_t)prop.n_tensor_inputs,
+          (int64_t)prop.max_dtype_size_bit_for_vectorization,
+          prop.vectorize_factor,
+          prop.has_mufu_computation);
     }
 
   } else {
     // 3D schedules not enabled for outer reductions
     return outerReductionHeuristic(
-        k_params.total_reduction_numel,
-        k_params.total_iteration_numel,
-        (int64_t)k_params.n_tensor_inputs,
-        (int64_t)k_params.max_dtype_size_bit_for_vectorization,
-        k_params.vectorize_factor,
-        k_params.has_mufu_computation);
+        prop.total_reduction_numel,
+        prop.total_iteration_numel,
+        (int64_t)prop.n_tensor_inputs,
+        (int64_t)prop.max_dtype_size_bit_for_vectorization,
+        prop.vectorize_factor,
+        prop.has_mufu_computation);
   }
 }
 
@@ -1338,10 +1338,10 @@ std::unique_ptr<ReductionParams> getReductionHeuristics(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicDataCache* data_cache) {
-  auto k_params = reduction_scheduler_utils::getReductionKernelParams(
+  auto prop = reduction_scheduler_utils::getFusionRuntimeProperties(
       fusion, runtime_info, data_cache);
 
-  auto heuristic = reductionHeuristic(k_params);
+  auto heuristic = reductionHeuristic(prop);
   heuristic->cparams.index_type = runtime_info.getIndexType();
   return heuristic;
 }

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -1236,7 +1236,7 @@ int64_t getL1L2WarpSize(
   return std::min(warp_size_based_on_l1, warp_size_based_on_l2);
 }
 
-ReductionKernelParams getReductionKernelParams(
+FusionRuntimeProperties getFusionRuntimeProperties(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicDataCache* data_cache) {
@@ -1339,18 +1339,18 @@ ReductionKernelParams getReductionKernelParams(
 
   bool has_mufu_computation = scheduler_utils::hasExpensiveMUFUops(fusion);
 
-  ReductionKernelParams k_params;
-  k_params.total_reduction_numel = properties.total_reduction_numel;
-  k_params.total_iteration_numel = properties.total_iteration_numel;
-  k_params.inner_most_dimension_numel = properties.inner_most_dimension_numel;
-  k_params.fastest_dim_reduction = properties.fastest_dim_reduction;
-  k_params.n_tensor_inputs = n_tensor_inputs;
-  k_params.max_dtype_size_bit_for_vectorization =
+  FusionRuntimeProperties prop;
+  prop.total_reduction_numel = properties.total_reduction_numel;
+  prop.total_iteration_numel = properties.total_iteration_numel;
+  prop.inner_most_dimension_numel = properties.inner_most_dimension_numel;
+  prop.fastest_dim_reduction = properties.fastest_dim_reduction;
+  prop.n_tensor_inputs = n_tensor_inputs;
+  prop.max_dtype_size_bit_for_vectorization =
       max_dtype_size_bit_for_vectorization;
-  k_params.vectorize_factor = vectorize_factor;
-  k_params.has_mufu_computation = has_mufu_computation;
+  prop.vectorize_factor = vectorize_factor;
+  prop.has_mufu_computation = has_mufu_computation;
 
-  return k_params;
+  return prop;
 }
 } // namespace reduction_scheduler_utils
 } // namespace nvfuser

--- a/csrc/scheduler/reduction_utils.h
+++ b/csrc/scheduler/reduction_utils.h
@@ -168,7 +168,7 @@ int64_t getVectUnroll(
     const int64_t target_threads_per_sm,
     const bool has_mufu_computation);
 
-struct ReductionKernelParams {
+struct FusionRuntimeProperties {
   int64_t total_reduction_numel = 0;
   int64_t total_iteration_numel = 0;
   int64_t inner_most_dimension_numel = 0;
@@ -179,7 +179,7 @@ struct ReductionKernelParams {
   bool has_mufu_computation = false;
 };
 
-ReductionKernelParams getReductionKernelParams(
+FusionRuntimeProperties getFusionRuntimeProperties(
     Fusion* fusion,
     SchedulerRuntimeInfo& runtime_info,
     HeuristicDataCache* data_cache);


### PR DESCRIPTION
Code motion:
- `getL1L2WarpSize()`
- `getVectUnroll()`
- `reduction::non_tma::reductionHeuristic()`: The logic inside this function is used both non-TMA and TMA schedulers. Add a new struct `ReductionKernelParams` to hold the output of its logic. Move that logic into new function `reduction_scheduler_utils::getReductionKernelParams()`

Also:
- Delete duplicates of `getReductionHeuristics()` and `scheduleReduction()` added by [PR#5614](https://github.com/NVIDIA/Fuser/pull/5614). There were 2 copies of both these functions, one copy inside the anonymous namespace of `reduction_non_tma.cpp`, and one copy outside that namespace.