### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let pr;
@@ -114,7 +114,7 @@ jobs:
       - name: Check all conditions for auto-merge
         id: check
         if: fromJSON(steps.pr.outputs.result).should_skip == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prData = ${{ steps.pr.outputs.result }};
@@ -338,7 +338,7 @@ jobs:
 
       - name: Update auto-merge status comment
         if: always() && fromJSON(steps.pr.outputs.result).should_skip == false
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prData = ${{ steps.pr.outputs.result }};
@@ -433,7 +433,7 @@ jobs:
 
       - name: Merge PR
         if: steps.check.outputs.result != '' && fromJSON(steps.check.outputs.result).ready == true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const checkResult = ${{ steps.check.outputs.result }};

--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
           ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
   clang-build-23:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Restore ccache
@@ -62,10 +62,10 @@ jobs:
   dynamic-type-meson:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Run meson build of dynamic type library

--- a/.github/workflows/cleanup-auto-merge-label.yml
+++ b/.github/workflows/cleanup-auto-merge-label.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Remove enable-auto-merge label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pr_number = context.payload.pull_request.number;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
   check-license:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Look for missing license headers
@@ -30,10 +30,10 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Run lintrunner
@@ -76,10 +76,10 @@ jobs:
   lintrunner:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Run lintrunner

--- a/.github/workflows/nvfuser-ci-trigger.yml
+++ b/.github/workflows/nvfuser-ci-trigger.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
           ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: reject files larger than 5 MB
         run: |
           max_bytes=$((5 * 1024 * 1024))

--- a/.github/workflows/upload-ci-logs-v2.yml
+++ b/.github/workflows/upload-ci-logs-v2.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Trigger auto-merge check
         if: inputs.context == 'nvfuser-ci' && inputs.state == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // Check if PR has enable-auto-merge label


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v2`](https://github.com/actions/checkout/releases/tag/v2), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | blossom-ci.yml, build.yml, lint.yml, nvfuser-ci-trigger.yml, pull.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | auto-merge.yml, cleanup-auto-merge-label.yml, upload-ci-logs-v2.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build.yml, lint.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
