### PR TITLE
Jj/grouped mm quantization math runtime

### DIFF
--- a/benchmarks/python/benchmark_inference.py
+++ b/benchmarks/python/benchmark_inference.py
@@ -51,9 +51,6 @@ from layers_for_inference_benchmark import (
     Llama4MoE,
     NVFP4InferenceGroupedSwiGLU,
     nvfuser_f16a_nvfp4weight_scaled_grouped_mm,
-    FLOAT4_E2M1_MAX,
-    FLOAT8_E4M3_EPS,
-    FLOAT8_E4M3_MAX,
 )
 from thunder.tests.distributed.test_moe import GroupedLinearColwiseParallel, GroupedLinearRowwiseParallel
 from thunder.transforms.cudagraph import CUDAGraphTransform

--- a/tests/python/direct/test_narrow_precision.py
+++ b/tests/python/direct/test_narrow_precision.py
@@ -655,6 +655,7 @@ def test_fp4_vectorization(
         atol=1e-2,
     )
 
+
 # This is adopted from the decomposed version.
 # A few things I have to change in order to pass the test:
 #     1. inputs data needs to be changed from `torch.testing.make_tensor` to `torch.randn`;
@@ -820,7 +821,7 @@ def test_block_quantize_op_and_layout_op(
     abs_diff = torch.abs(o[0] - o_decomposed_ref)
     max_diff = torch.max(abs_diff)
     assert max_diff <= 10.0, f"Max difference {max_diff:.4f} exceeds threshold of 10.0"
-    
+
     # Check that large differences (> 5.0) are rare (< 10% of elements)
     large_diff_count = torch.count_nonzero(torch.gt(abs_diff, 5.0))
     large_diff_ratio = large_diff_count / abs_diff.numel()


### PR DESCRIPTION
1. fix block quantization op without global scaling factor;
2. python example with block quantization op followed by layout and grouped_mm.

Note that: I'm pretty nervous about the numeric of block quantization op. I left the check here as relaxed as the existing python ops, as I can't get it to perform close to what decomposed version does.