### PR TITLE
Reuse streams

### DIFF
--- a/tests/python/multidevice/test_overlap.py
+++ b/tests/python/multidevice/test_overlap.py
@@ -192,7 +192,7 @@ def test_row_parallel_linear_forward_reference(setup_default_process_group):
 def test_row_parallel_linear_forward_reference_benchmark(
     setup_default_process_group, benchmark
 ):
-    h, s, t = 8192, 4, 8192
+    h, s, t = 8192, 2, 8192
     d = dist.get_world_size()
     if (h * 4) % d != 0:
         pytest.skip(


### PR DESCRIPTION
With this PR, the red `cudaMalloc`s are gone. 

Before:
<img width="3040" height="992" alt="image" src="https://github.com/user-attachments/assets/55bf20d2-f2f4-4c2d-8053-d45850cb76e1" />

After:
<img width="2986" height="677" alt="image" src="https://github.com/user-attachments/assets/b38bb895-5abf-44db-97f4-a1cc4cea9df2" />
