### PR TITLE
Make IdModel not copyable

### DIFF
--- a/csrc/id_model/id_model.h
+++ b/csrc/id_model/id_model.h
@@ -134,6 +134,11 @@ class NVF_API IdModel : public PolymorphicBase {
       LoopPromotionMapBuilderCallback* loop_promotion_map_builder_callback =
           nullptr);
 
+  IdModel(const IdModel&) = delete;
+  IdModel& operator=(const IdModel&) = delete;
+  IdModel(IdModel&&) noexcept = default;
+  IdModel& operator=(IdModel&&) noexcept = default;
+
   bool hasIdGraph(IdMappingMode mode) const {
     return id_graphs_.find(mode) != id_graphs_.end();
   }


### PR DESCRIPTION
`IdModel` cannot be copied because `circular_buffered_loop_index_variable_map_` stores `unique_ptr`. This PR explicitly deletes the copy constructor and copy assignment. 