### PR TITLE
skip if seq is not divisible by number of devices

### DIFF
--- a/tests/python/multidevice/test_transformer.py
+++ b/tests/python/multidevice/test_transformer.py
@@ -1060,6 +1060,12 @@ def test_transformer_backward(multidevice_test, benchmark, parallelism: Parallel
 
     b, s, h, e = 1, 2048, 96, 12288
 
+    if parallelism == Parallelism.SEQUENCE_PARALLEL and s % d != 0:
+        pytest.skip(
+            f"Sequence length {s} must be divisible by the number \
+                    of devices {d} for sequence parallelism."
+        )
+
     torch.cuda.set_device(multidevice_test.local_rank)
 
     mlp_linear0_out = torch.testing.make_tensor(


### PR DESCRIPTION
**Changes:**
Similar to `test_transformer_forward`, need to skip if  seq is not divisible by number of devices in `backward` test.

**Context:**
I got err `RuntimeError: Expected extent % nslices == 0 . Sharded axis must be evenly divisble by mesh` in local run with:
`mpirun -np 3 -x NCCL_NVLS_ENABLE=0 pytest /opt/pytorch/nvfuser/tests/python/multidevice/test_transformer.py -vs --only-mpi`

However, if I use the exact command used in CI, there is no error reported.
```
mpirun -np 1 -x NCCL_NVLS_ENABLE=0 pytest /opt/pytorch/nvfuser/tests/python/multidevice/test_transformer.py -vs --junit-xml=test/test-reports/test_transformer.py_1767736030582703701_250731773.xml --only-mpi : -np 3 -x NCCL_NVLS_ENABLE=0 pytest /opt/pytorch/nvfuser/tests/python/multidevice/test_transformer.py -vs --only-mp
```
Should we revise CI script to use `-np 2` instead of `-np 3 ` to avoid skipping these two tests? @xwang233 