### PR TITLE
Use `toPolymorphicValue` to convert `py::handle` directly to `PolymorphicValue`

### DIFF
--- a/python/python_direct/direct_utils.cpp
+++ b/python/python_direct/direct_utils.cpp
@@ -23,7 +23,7 @@ PolymorphicValue toPolymorphicValue(const py::handle& obj) {
     return PolymorphicValue(py::cast<int64_t>(obj));
   } else if (py::isinstance<py::float_>(obj)) {
     return PolymorphicValue(py::cast<double>(obj));
-  } else if (py::isinstance<std::complex<double>>(obj)) {
+  } else if (PyComplex_Check(obj.ptr())) {
     return PolymorphicValue(py::cast<std::complex<double>>(obj));
   }
   NVF_THROW("Cannot convert provided py::handle to a PolymorphicValue.");


### PR DESCRIPTION
`torch::jit::toIValue` converts from `py::handle` to `IValue`. Then `KernelArgumentHolder` converts `IValue` to `PolymorphicValue`. The PyTorch function handles several types, beyond what NvFuser supports, resulting in unnecessary latency. `toPolymorphicValue` converts `py::handle` directly to `PolymorphicValue` to save latency.

* This is a prerequisite for using `nanobind`.

 ### tests/python/direct/test_python_frontend.py
| function | time |
| -------- | ---- |
| `toPolymorphicValue` | 41.04s |
| `torch::jit::toIValue` | 41.33s |

### All python tests --- 7% improvement
| function | time |
| -------- | ---- |
| `toPolymorphicValue` | 317.45s |
| `torch::jit::toIValue` | 340.92s |