### PR TITLE
check hardware constraints when setting threads per sm

### DIFF
--- a/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
+++ b/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
@@ -161,10 +161,10 @@ void getHeuristics(
                       int64_t inner_batch) {
     int64_t reg_per_thread =
         getEstimatedRegisterUsage(inner_vect * inner_batch);
-    int64_t threads_per_sm = getThreadsPerSMGivenRegPerThread(reg_per_thread);
-    // limit threads per sm by hardware limitation
-    threads_per_sm = std::min(
-        threads_per_sm, (int64_t)dev_prop->maxThreadsPerMultiProcessor);
+    // Limit threads per SM by register usage and hardware constraints
+    int64_t threads_per_sm = std::min(
+        getThreadsPerSMGivenRegPerThread(reg_per_thread),
+        static_cast<int64_t>(dev_prop->maxThreadsPerMultiProcessor));
     int64_t blocks_per_sm =
         getBlocksPerSM(threads_per_sm, threads_per_block, dev_prop->warpSize);
     int64_t gdimy = blocks_per_sm * device_multiprocessor_count;


### PR DESCRIPTION
To avoid error on hardware allows a small number of threads per sm