### PR TITLE
skip test nvfp4_gemm on unsupported arches

### DIFF
--- a/tests/python/direct/test_cutlass_nvfp4_gemm.py
+++ b/tests/python/direct/test_cutlass_nvfp4_gemm.py
@@ -6,11 +6,11 @@
 import pytest
 import torch
 from nvfuser_direct import nvf_cutlass
+from python.direct_utils import microarchitecture_is
 
-compute_cap = torch.cuda.get_device_capability()
-if compute_cap < (10, 0) or compute_cap >= (12, 0):
+if not microarchitecture_is(10, 0):
     pytest.skip(
-        reason="Nvfp4 Requires compute capability 10.",
+        reason="Nvfp4 Requires compute capability 10.0, other arches are not tested.",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
Same as https://github.com/NVIDIA/Fuser/pull/5810
err msg `Exception raised from runGemm at /opt/pytorch/nvfuser/cutlass/nvfp4_scaled_mm.cu:255`