### PR TITLE
Enable TensorIndexer for the legacy Python tests

### DIFF
--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -2,6 +2,23 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
+
+
+def pytest_configure(config):
+    """
+    Hook called after command line options have been parsed and all plugins
+    and initial conftest files have been loaded.
+    """
+    # Append to NVFUSER_ENABLE environment variable for all tests in this directory
+    existing = os.environ.get("NVFUSER_ENABLE", "")
+    new_options = "id_model,id_model_extra_validation"
+
+    if existing:
+        os.environ["NVFUSER_ENABLE"] = f"{existing},{new_options}"
+    else:
+        os.environ["NVFUSER_ENABLE"] = new_options
+
 
 def pytest_make_parametrize_id(config, val, argname):
     return f"{argname}={val}"

--- a/tests/python/utils/utils.py
+++ b/tests/python/utils/utils.py
@@ -322,8 +322,6 @@ class NVFuserTest(TestCase):
         with FusionDefinition() as fd:
             fusion_func(fd)
         torch.manual_seed(0)
-        if "id_model_extra_validation" not in _enable_options:
-            _enable_options.append("id_model_extra_validation")
         out = fd.execute(
             inputs,
             device=device,


### PR DESCRIPTION
Following up with #5781 