### PR TITLE
CUTLASS in GH build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           wait
           source tools/setup-env.sh
 
+          export NVFUSER_CUTLASS_MAX_JOBS=1
           export NVFUSER_BUILD_CPP_STANDARD=23
           pip install -v -e ./python --no-build-isolation
       - name: Show ccache statistics


### PR DESCRIPTION
Since the default pool size is set to 2 we might be able to enable cutlass builds in github...

Edit:
Looks like GH runners have 7GB memory capacity, setting max jobs = 1 for cutlass.