### PR TITLE
fix NVFuserTest.Translate1Welford on L40

### DIFF
--- a/tests/cpp/test_welford.cpp
+++ b/tests/cpp/test_welford.cpp
@@ -725,10 +725,11 @@ TEST_F(NVFuserTest, Translate1Welford) {
   const int64_t smem_buffer_count =
       ceilDiv(deviceAvailableSharedMemoryBytes(), 4);
   const int64_t total_elements = sm_per_cluster == 1
-      ? scheduler_utils::roundUpPow2Or8(smem_buffer_count)
+      ? std::max(
+            scheduler_utils::roundUpPow2Or8(smem_buffer_count),
+            regs_buffer_count)
       : regs_buffer_count * sm_per_cluster;
   auto runtime2 = run_test(total_elements + 1024);
-
   bool found_welford = false;
   for (auto group : runtime2->fusionSegments()->groups()) {
     for (auto expr : group->exprs()) {


### PR DESCRIPTION
**Fix incorrect max-input-size calculation in `Translate1Welford`.**

Translate1Welford computes the maximum supported input size for Welford translate. The current logic uses the shared-memory-based buffer count when SM clustering is not supported (sm_per_cluster == 1). However, on L40 the available shared memory can be smaller than the register buffer capacity, so the max size must be determined by registers instead.

This PR updates the calculation to **use the register-based limit when it is the tighter constraint**, ensuring the max-input-size computation is correct on L40 and similar GPUs.