### PR TITLE
Use quoted includes and order preseg pass headers

### DIFF
--- a/csrc/preseg_passes/add_axioms.cpp
+++ b/csrc/preseg_passes/add_axioms.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/add_axioms.h>
+#include "preseg_passes/add_axioms.h"
 
 #include <unordered_set>
 #include <vector>
 
-#include <ir/utils.h>
+#include "ir/utils.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/add_axioms.h
+++ b/csrc/preseg_passes/add_axioms.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/allocation_order_inference.cpp
+++ b/csrc/preseg_passes/allocation_order_inference.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <id_model/id_model.h>
-#include <ir/all_nodes.h>
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <logical_domain_map.h>
-#include <preseg_passes/allocation_order_inference.h>
+#include "preseg_passes/allocation_order_inference.h"
 
 #include <ranges>
+
+#include "id_model/id_model.h"
+#include "ir/all_nodes.h"
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "logical_domain_map.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/allocation_order_inference.h
+++ b/csrc/preseg_passes/allocation_order_inference.h
@@ -9,8 +9,8 @@
 
 #include <unordered_map>
 
-#include <fusion.h>
-#include <optimization_pass.h>
+#include "fusion.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/consecutive_cast.cpp
+++ b/csrc/preseg_passes/consecutive_cast.cpp
@@ -5,14 +5,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/consecutive_cast.h>
+#include "preseg_passes/consecutive_cast.h"
 
-#include <ir/utils.h>
-#include <ops/arith.h>
-#include <ops/utils.h>
-#include <transform_iter.h>
-#include <transform_replay.h>
-#include <type.h>
+#include "ir/utils.h"
+#include "ops/arith.h"
+#include "ops/utils.h"
+#include "transform_iter.h"
+#include "transform_replay.h"
+#include "type.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/consecutive_cast.h
+++ b/csrc/preseg_passes/consecutive_cast.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/decompose_reshardings.cpp
+++ b/csrc/preseg_passes/decompose_reshardings.cpp
@@ -5,24 +5,24 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/decompose_reshardings.h>
+#include "preseg_passes/decompose_reshardings.h"
 
-#include <device_lower/utils.h>
-#include <fusion.h>
-#include <host_ir/lower_to_communication.h>
-#include <ir/base_nodes.h>
-#include <ir/interface_nodes.h>
-#include <ir/iostream.h>
-#include <ir/utils.h>
-#include <linked_hash_map.h>
-#include <multidevice/propagation.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <ops/alias.h>
-#include <ops/arith.h>
-#include <ops/composite.h>
-#include <ops/utils.h>
-#include <transform_replay.h>
+#include "device_lower/utils.h"
+#include "fusion.h"
+#include "host_ir/lower_to_communication.h"
+#include "ir/base_nodes.h"
+#include "ir/interface_nodes.h"
+#include "ir/iostream.h"
+#include "ir/utils.h"
+#include "linked_hash_map.h"
+#include "multidevice/propagation.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "ops/alias.h"
+#include "ops/arith.h"
+#include "ops/composite.h"
+#include "ops/utils.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 namespace {

--- a/csrc/preseg_passes/decompose_reshardings.h
+++ b/csrc/preseg_passes/decompose_reshardings.h
@@ -7,9 +7,9 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
-
 #include <string>
+
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.cpp
@@ -5,12 +5,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <debug.h>
-#include <id_model/id_model.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <options.h>
-#include <preseg_passes/exact_mapped_extent_substitution.h>
+#include "preseg_passes/exact_mapped_extent_substitution.h"
+
+#include "debug.h"
+#include "id_model/id_model.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "options.h"
+
 namespace nvfuser::preseg_passes {
 
 namespace {

--- a/csrc/preseg_passes/exact_mapped_extent_substitution.h
+++ b/csrc/preseg_passes/exact_mapped_extent_substitution.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/finalize_multidevice_domains.cpp
+++ b/csrc/preseg_passes/finalize_multidevice_domains.cpp
@@ -5,19 +5,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/finalize_multidevice_domains.h>
+#include "preseg_passes/finalize_multidevice_domains.h"
 
-#include <fusion.h>
-#include <ir/allocation_utils.h>
-#include <ir/interface_nodes.h>
-#include <ir/iostream.h>
-#include <ir/utils.h>
-#include <linked_hash_map.h>
-#include <multidevice/allocation_utils.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <scheduler/utils.h>
-#include <type.h>
+#include "fusion.h"
+#include "ir/allocation_utils.h"
+#include "ir/interface_nodes.h"
+#include "ir/iostream.h"
+#include "ir/utils.h"
+#include "linked_hash_map.h"
+#include "multidevice/allocation_utils.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "scheduler/utils.h"
+#include "type.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/finalize_multidevice_domains.h
+++ b/csrc/preseg_passes/finalize_multidevice_domains.h
@@ -7,11 +7,10 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
-
 #include <string>
 
-#include <fusion.h>
+#include "fusion.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/mark_aliases_prepare.cpp
+++ b/csrc/preseg_passes/mark_aliases_prepare.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <alias_analysis.h>
-#include <debug.h>
-#include <ir/iostream.h> // for operator<<(ostream&, TensorView*)
-#include <ir/utils.h>
-#include <ops/alias.h>
-#include <options.h>
-#include <preseg_passes/mark_aliases_prepare.h>
-#include <transform_replay.h>
+#include "preseg_passes/mark_aliases_prepare.h"
+
+#include "alias_analysis.h"
+#include "debug.h"
+#include "ir/iostream.h" // for operator<<(ostream&, TensorView*)
+#include "ir/utils.h"
+#include "ops/alias.h"
+#include "options.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/mark_aliases_prepare.h
+++ b/csrc/preseg_passes/mark_aliases_prepare.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_gather.cpp
+++ b/csrc/preseg_passes/move_gather.cpp
@@ -5,20 +5,20 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/move_gather.h>
+#include "preseg_passes/move_gather.h"
 
-#include <expr_simplifier.h>
-#include <fusion.h>
-#include <ir/builder.h>
-#include <ir/interface_nodes.h>
-#include <ir/internal_base_nodes.h>
-#include <ir/utils.h>
-#include <ops/alias.h>
-#include <ops/arith.h>
-#include <ops/indexing.h>
-#include <ops/utils.h>
-#include <scheduler/utils.h>
-#include <transform_replay.h>
+#include "expr_simplifier.h"
+#include "fusion.h"
+#include "ir/builder.h"
+#include "ir/interface_nodes.h"
+#include "ir/internal_base_nodes.h"
+#include "ir/utils.h"
+#include "ops/alias.h"
+#include "ops/arith.h"
+#include "ops/indexing.h"
+#include "ops/utils.h"
+#include "scheduler/utils.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_gather.h
+++ b/csrc/preseg_passes/move_gather.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_pad.cpp
+++ b/csrc/preseg_passes/move_pad.cpp
@@ -5,17 +5,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/move_pad.h>
+#include "preseg_passes/move_pad.h"
 
-#include <expr_simplifier.h>
-#include <fusion.h>
-#include <ir/builder.h>
-#include <ir/interface_nodes.h>
-#include <ir/internal_base_nodes.h>
-#include <ops/alias.h>
-#include <ops/arith.h>
-#include <ops/utils.h>
-#include <transform_replay.h>
+#include "expr_simplifier.h"
+#include "fusion.h"
+#include "ir/builder.h"
+#include "ir/interface_nodes.h"
+#include "ir/internal_base_nodes.h"
+#include "ops/alias.h"
+#include "ops/arith.h"
+#include "ops/utils.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_pad.h
+++ b/csrc/preseg_passes/move_pad.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_repeat_forward.cpp
+++ b/csrc/preseg_passes/move_repeat_forward.cpp
@@ -5,17 +5,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/move_repeat_forward.h>
-
-#include <device_lower/utils.h>
-#include <dispatch.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <ops/all_ops.h>
-#include <scheduler/tools/static_repeat.h>
+#include "preseg_passes/move_repeat_forward.h"
 
 #include <unordered_map>
 #include <vector>
+
+#include "device_lower/utils.h"
+#include "dispatch.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "ops/all_ops.h"
+#include "scheduler/tools/static_repeat.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_repeat_forward.h
+++ b/csrc/preseg_passes/move_repeat_forward.h
@@ -7,8 +7,8 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
-#include <optimization_pass.h>
+#include "exceptions.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_split_cat.cpp
+++ b/csrc/preseg_passes/move_split_cat.cpp
@@ -5,18 +5,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/move_split_cat.h>
+#include "preseg_passes/move_split_cat.h"
 
 #include <vector>
 
-#include <fusion.h>
-#include <id_model/id_model.h>
-#include <ir/builder.h>
-#include <ir/interface_nodes.h>
-#include <ir/internal_base_nodes.h>
-#include <ir/utils.h>
-#include <ops/alias.h>
-#include <transform_replay.h>
+#include "fusion.h"
+#include "id_model/id_model.h"
+#include "ir/builder.h"
+#include "ir/interface_nodes.h"
+#include "ir/internal_base_nodes.h"
+#include "ir/utils.h"
+#include "ops/alias.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/move_split_cat.h
+++ b/csrc/preseg_passes/move_split_cat.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/pre_segmenter.cpp
+++ b/csrc/preseg_passes/pre_segmenter.cpp
@@ -5,31 +5,30 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <debug.h>
-#include <options.h>
+#include "preseg_passes/pre_segmenter.h"
 
-#include <preseg_passes/pre_segmenter.h>
-
-#include <instrumentation.h>
-#include <preseg_passes/add_axioms.h>
-#include <preseg_passes/allocation_order_inference.h>
-#include <preseg_passes/consecutive_cast.h>
-#include <preseg_passes/decompose_reshardings.h>
-#include <preseg_passes/exact_mapped_extent_substitution.h>
-#include <preseg_passes/finalize_multidevice_domains.h>
-#include <preseg_passes/mark_aliases_prepare.h>
-#include <preseg_passes/move_gather.h>
-#include <preseg_passes/move_pad.h>
-#include <preseg_passes/move_repeat_forward.h>
-#include <preseg_passes/move_split_cat.h>
-#include <preseg_passes/propagate_shardings.h>
-#include <preseg_passes/remove_bcast_squeeze.h>
-#include <preseg_passes/remove_empty.h>
-#include <preseg_passes/reorder_sharded_axis.h>
-#include <preseg_passes/segment_inplace_update.h>
-#include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
-#include <preseg_passes/translate_repeat_to_expand.h>
-#include <preseg_passes/translate_scatter_accumulate.h>
+#include "debug.h"
+#include "instrumentation.h"
+#include "options.h"
+#include "preseg_passes/add_axioms.h"
+#include "preseg_passes/allocation_order_inference.h"
+#include "preseg_passes/consecutive_cast.h"
+#include "preseg_passes/decompose_reshardings.h"
+#include "preseg_passes/exact_mapped_extent_substitution.h"
+#include "preseg_passes/finalize_multidevice_domains.h"
+#include "preseg_passes/mark_aliases_prepare.h"
+#include "preseg_passes/move_gather.h"
+#include "preseg_passes/move_pad.h"
+#include "preseg_passes/move_repeat_forward.h"
+#include "preseg_passes/move_split_cat.h"
+#include "preseg_passes/propagate_shardings.h"
+#include "preseg_passes/remove_bcast_squeeze.h"
+#include "preseg_passes/remove_empty.h"
+#include "preseg_passes/reorder_sharded_axis.h"
+#include "preseg_passes/segment_inplace_update.h"
+#include "preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h"
+#include "preseg_passes/translate_repeat_to_expand.h"
+#include "preseg_passes/translate_scatter_accumulate.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/pre_segmenter.h
+++ b/csrc/preseg_passes/pre_segmenter.h
@@ -7,8 +7,8 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
-#include <visibility.h>
+#include "optimization_pass.h"
+#include "visibility.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/propagate_shardings.cpp
+++ b/csrc/preseg_passes/propagate_shardings.cpp
@@ -5,16 +5,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "preseg_passes/propagate_shardings.h"
 
 #include <vector>
 
-#include <ir/interface_nodes.h>
-#include <ir/iostream.h>
-#include <ir/utils.h>
-#include <multidevice/propagation.h>
-#include <multidevice/utils.h>
-#include <preseg_passes/propagate_shardings.h>
-#include <scheduler/utils.h>
+#include "ir/interface_nodes.h"
+#include "ir/iostream.h"
+#include "ir/utils.h"
+#include "multidevice/propagation.h"
+#include "multidevice/utils.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/propagate_shardings.h
+++ b/csrc/preseg_passes/propagate_shardings.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/remove_bcast_squeeze.cpp
+++ b/csrc/preseg_passes/remove_bcast_squeeze.cpp
@@ -5,16 +5,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <debug.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <ops/alias.h>
-#include <ops/arith.h>
-#include <options.h>
-#include <preseg_passes/remove_bcast_squeeze.h>
-#include <transform_replay.h>
+#include "preseg_passes/remove_bcast_squeeze.h"
+
+#include "debug.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "ops/alias.h"
+#include "ops/arith.h"
+#include "options.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/remove_bcast_squeeze.h
+++ b/csrc/preseg_passes/remove_bcast_squeeze.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/remove_empty.cpp
+++ b/csrc/preseg_passes/remove_empty.cpp
@@ -5,19 +5,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/remove_empty.h>
-
-#include <expr_evaluator.h>
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <ops/alias.h>
-#include <ops/arith.h>
-#include <polymorphic_value.h>
+#include "preseg_passes/remove_empty.h"
 
 #include <algorithm>
 #include <limits>
 #include <unordered_set>
 #include <vector>
+
+#include "expr_evaluator.h"
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "ops/alias.h"
+#include "ops/arith.h"
+#include "polymorphic_value.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/remove_empty.h
+++ b/csrc/preseg_passes/remove_empty.h
@@ -7,9 +7,9 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
-#include <optimization_pass.h>
-#include <visibility.h>
+#include "exceptions.h"
+#include "optimization_pass.h"
+#include "visibility.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/reorder_sharded_axis.cpp
+++ b/csrc/preseg_passes/reorder_sharded_axis.cpp
@@ -5,19 +5,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/reorder_sharded_axis.h>
+#include "preseg_passes/reorder_sharded_axis.h"
 
-#include <fusion.h>
-#include <host_ir/lower_to_communication.h>
-#include <ir/allocation_utils.h>
-#include <ir/base_nodes.h>
-#include <ir/interface_nodes.h>
-#include <ir/utils.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <ops/alias.h>
-#include <scheduler/utils.h>
-#include <transform_replay.h>
+#include "fusion.h"
+#include "host_ir/lower_to_communication.h"
+#include "ir/allocation_utils.h"
+#include "ir/base_nodes.h"
+#include "ir/interface_nodes.h"
+#include "ir/utils.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "ops/alias.h"
+#include "scheduler/utils.h"
+#include "transform_replay.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/reorder_sharded_axis.h
+++ b/csrc/preseg_passes/reorder_sharded_axis.h
@@ -7,11 +7,10 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
-
 #include <string>
 
-#include <fusion.h>
+#include "fusion.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/segment_inplace_update.cpp
+++ b/csrc/preseg_passes/segment_inplace_update.cpp
@@ -5,15 +5,16 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "preseg_passes/segment_inplace_update.h"
+
 #include <deque>
 #include <vector>
 
-#include <fusion.h>
-#include <id_model/id_model.h>
-#include <id_model/to_string.h>
-#include <ir/utils.h>
-#include <ops/alias.h>
-#include <preseg_passes/segment_inplace_update.h>
+#include "fusion.h"
+#include "id_model/id_model.h"
+#include "id_model/to_string.h"
+#include "ir/utils.h"
+#include "ops/alias.h"
 
 namespace nvfuser::preseg_passes {
 // When an intermediate tensorview is aliased to a fusion input,

--- a/csrc/preseg_passes/segment_inplace_update.h
+++ b/csrc/preseg_passes/segment_inplace_update.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.cpp
@@ -5,13 +5,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <logical_domain_map.h>
-#include <ops/all_ops.h>
-#include <preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h>
+#include "preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h"
 
 #include <vector>
+
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "logical_domain_map.h"
+#include "ops/all_ops.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
+++ b/csrc/preseg_passes/translate_no_reduction_matmul_to_mul_squeeze.h
@@ -7,8 +7,8 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
-#include <optimization_pass.h>
+#include "exceptions.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_repeat_to_expand.cpp
+++ b/csrc/preseg_passes/translate_repeat_to_expand.cpp
@@ -5,14 +5,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/translate_repeat_to_expand.h>
-
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <ops/all_ops.h>
+#include "preseg_passes/translate_repeat_to_expand.h"
 
 #include <unordered_map>
 #include <vector>
+
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "ops/all_ops.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_repeat_to_expand.h
+++ b/csrc/preseg_passes/translate_repeat_to_expand.h
@@ -7,8 +7,8 @@
 // clang-format on
 #pragma once
 
-#include <exceptions.h>
-#include <optimization_pass.h>
+#include "exceptions.h"
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_scatter_accumulate.cpp
+++ b/csrc/preseg_passes/translate_scatter_accumulate.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <preseg_passes/translate_scatter_accumulate.h>
-
-#include <ir/utils.h>
-#include <ops/all_ops.h>
+#include "preseg_passes/translate_scatter_accumulate.h"
 
 #include <sstream>
+
+#include "ir/utils.h"
+#include "ops/all_ops.h"
 
 namespace nvfuser::preseg_passes {
 

--- a/csrc/preseg_passes/translate_scatter_accumulate.h
+++ b/csrc/preseg_passes/translate_scatter_accumulate.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include <optimization_pass.h>
+#include "optimization_pass.h"
 
 namespace nvfuser::preseg_passes {
 


### PR DESCRIPTION
Convert local includes to quoted form and reorder include blocks in preseg passes to follow the Google C++ style guide.