### PR TITLE
Fix IWYU validator includes in tests

### DIFF
--- a/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
+++ b/tests/cpp/cluster_runtime_test/test_cluster_device_func.cpp
@@ -14,7 +14,7 @@
 
 #include "tests/cpp/cluster_runtime_test/cluster_test_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/kernel_db/test_nvfuser_kernel_db_open.cpp
+++ b/tests/cpp/kernel_db/test_nvfuser_kernel_db_open.cpp
@@ -15,7 +15,7 @@
 #include "kernel_db/kernel_db.h"
 #include "kernel_db/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 // RUN CMD: bin/test_jit --gtest_filter="NVFuserTest*KernelDb_Open*"
 

--- a/tests/cpp/kernel_db/test_nvfuser_kernel_db_query.cpp
+++ b/tests/cpp/kernel_db/test_nvfuser_kernel_db_query.cpp
@@ -13,7 +13,7 @@
 #include "kernel_db/kernel_db.h"
 #include "kernel_db/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 // RUN CMD: bin/test_jit --gtest_filter="NVFuserTest*KernelDb_Query*"
 

--- a/tests/cpp/kernel_db/test_nvfuser_kernel_db_write.cpp
+++ b/tests/cpp/kernel_db/test_nvfuser_kernel_db_write.cpp
@@ -13,7 +13,7 @@
 #include "kernel_db/kernel_db.h"
 #include "kernel_db/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 // RUN CMD: bin/test_jit --gtest_filter="NVFuserTest*KernelDb_Write*"
 

--- a/tests/cpp/multidevice.cpp
+++ b/tests/cpp/multidevice.cpp
@@ -19,6 +19,8 @@
 #endif
 #include <torch/cuda.h>
 
+#include <gmock/gmock-matchers.h>
+
 #include "fusion_segmenter.h"
 #include "ir/all_nodes.h"
 #include "ir/iostream.h"
@@ -27,7 +29,7 @@
 #include "ops/all_ops.h"
 #include "options.h"
 #include "runtime/allocations.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_allocation_domain.cpp
+++ b/tests/cpp/test_allocation_domain.cpp
@@ -17,7 +17,7 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_allocation_order_inference.cpp
+++ b/tests/cpp/test_allocation_order_inference.cpp
@@ -17,7 +17,7 @@
 #include "preseg_passes/mark_aliases_prepare.h"
 #include "runtime/executor.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_argsort.cpp
+++ b/tests/cpp/test_argsort.cpp
@@ -18,7 +18,7 @@
 #include "runtime/executor.h"
 #include "scheduler/tools/cub_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_argsort_device_func.cpp
+++ b/tests/cpp/test_argsort_device_func.cpp
@@ -15,7 +15,7 @@
 
 #include "tests/cpp/argsort_test_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_bfs.cpp
+++ b/tests/cpp/test_bfs.cpp
@@ -13,8 +13,8 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "val_graph_visitor.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_circular_buffering.cpp
+++ b/tests/cpp/test_circular_buffering.cpp
@@ -13,7 +13,7 @@
 #include "ops/all_ops.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -13,7 +13,7 @@
 #include "ops/all_ops.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_cluster.cpp
+++ b/tests/cpp/test_cluster.cpp
@@ -9,6 +9,8 @@
 #include <sstream>
 #include <tuple>
 
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
 #include <gtest/gtest.h>
 
 #include "logical_domain_map.h"
@@ -17,8 +19,8 @@
 #include "scheduler/matmul_utils.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_compute_at_map.cpp
+++ b/tests/cpp/test_compute_at_map.cpp
@@ -13,7 +13,7 @@
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_compute_with.cpp
+++ b/tests/cpp/test_compute_with.cpp
@@ -45,9 +45,9 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_cutlass_scheduler.cpp
+++ b/tests/cpp/test_cutlass_scheduler.cpp
@@ -28,7 +28,7 @@
 #include "scheduler/runtime_info.h"
 #include "scheduler/scheduler_types.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_dynamic_transform.cpp
+++ b/tests/cpp/test_dynamic_transform.cpp
@@ -16,7 +16,7 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_embedding_node.cpp
+++ b/tests/cpp/test_embedding_node.cpp
@@ -14,7 +14,7 @@
 #include "ops/all_ops.h"
 #include "ops/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_exceptions.cpp
+++ b/tests/cpp/test_exceptions.cpp
@@ -15,7 +15,7 @@
 
 #include "exceptions.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_expr_simplifier.cpp
+++ b/tests/cpp/test_expr_simplifier.cpp
@@ -21,7 +21,7 @@
 #include "expr_simplifier.h"
 #include "ops/all_ops.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 namespace {

--- a/tests/cpp/test_external_src.cpp
+++ b/tests/cpp/test_external_src.cpp
@@ -14,8 +14,8 @@
 #include "fusion.h"
 #include "runtime/executor_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_fusion_hash.cpp
+++ b/tests/cpp/test_fusion_hash.cpp
@@ -19,7 +19,7 @@
 #include "scheduler/all_schedulers.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_fusion_profiler.cpp
+++ b/tests/cpp/test_fusion_profiler.cpp
@@ -18,7 +18,7 @@
 #include "scheduler/tools/inlining.h"
 #include "sys_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_gpu1.cpp
+++ b/tests/cpp/test_gpu1.cpp
@@ -46,10 +46,10 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_gpu2.cpp
+++ b/tests/cpp/test_gpu2.cpp
@@ -47,10 +47,10 @@
 #include "scheduler/utils.h"
 #include "tensor_metadata.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_gpu3.cpp
+++ b/tests/cpp/test_gpu3.cpp
@@ -52,9 +52,9 @@
 #include "scheduler/tools/loop_domain_scheduler.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_host_ir_jit.cpp
+++ b/tests/cpp/test_host_ir_jit.cpp
@@ -14,7 +14,7 @@
 #include "ir/all_nodes.h"
 #include "ops/all_ops.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_id_model.cpp
+++ b/tests/cpp/test_id_model.cpp
@@ -22,9 +22,9 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/tools/resize_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_iter.h"
 #include "val_graph_visitor.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_index_put.cpp
+++ b/tests/cpp/test_index_put.cpp
@@ -11,7 +11,7 @@
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_index_select.cpp
+++ b/tests/cpp/test_index_select.cpp
@@ -11,7 +11,7 @@
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_indexing.cpp
+++ b/tests/cpp/test_indexing.cpp
@@ -27,7 +27,7 @@
 #include "scheduler/tools/resize_utils.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_indexing_advanced.cpp
+++ b/tests/cpp/test_indexing_advanced.cpp
@@ -14,7 +14,7 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_inlining.cpp
+++ b/tests/cpp/test_inlining.cpp
@@ -16,7 +16,7 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_interval_analysis.cpp
+++ b/tests/cpp/test_interval_analysis.cpp
@@ -17,7 +17,7 @@
 #include "iter_visitor.h"
 #include "ops/all_ops.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_loop_domain_scheduling.cpp
+++ b/tests/cpp/test_loop_domain_scheduling.cpp
@@ -14,7 +14,7 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/tools/loop_domain_scheduler.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_math_opt.cpp
+++ b/tests/cpp/test_math_opt.cpp
@@ -13,7 +13,7 @@
 #include "ops/all_ops.h"
 #include "runtime/executor.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_matmul.cpp
+++ b/tests/cpp/test_matmul.cpp
@@ -12,6 +12,8 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
 #include <gtest/gtest.h>
 
 #include <c10/cuda/CUDAStream.h>
@@ -52,10 +54,10 @@
 #include "scheduler/utils.h"
 #include "sys_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_matmul_aten_evaluation.cpp
+++ b/tests/cpp/test_matmul_aten_evaluation.cpp
@@ -17,7 +17,7 @@
 #include "scheduler/all_schedulers.h"
 #include "scheduler/mma_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_matmul_scheduler.cpp
+++ b/tests/cpp/test_matmul_scheduler.cpp
@@ -21,7 +21,7 @@
 #include "scheduler/matmul_heuristic_plugin_api.h"
 #include "scheduler/mma_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_mbarrier.cpp
+++ b/tests/cpp/test_mbarrier.cpp
@@ -15,7 +15,7 @@
 #include "ops/all_ops.h"
 #include "runtime/executor.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_memory.cpp
+++ b/tests/cpp/test_memory.cpp
@@ -24,9 +24,9 @@
 #include "scheduler/mma_utils.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_mma.cpp
+++ b/tests/cpp/test_mma.cpp
@@ -20,7 +20,7 @@
 #include "scheduler/mma_utils.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_moe.cpp
+++ b/tests/cpp/test_moe.cpp
@@ -17,7 +17,7 @@
 #include "runtime/executor.h"
 #include "runtime/executor_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_move_repeat_forward.cpp
+++ b/tests/cpp/test_move_repeat_forward.cpp
@@ -15,7 +15,7 @@
 #include "runtime/executor_utils.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_mps.cpp
+++ b/tests/cpp/test_mps.cpp
@@ -87,7 +87,7 @@
 #include "runtime/executor_utils.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 // This test requires CUDA 13.0+ for CUctxCreateParams
 

--- a/tests/cpp/test_multidevice_communications.cpp
+++ b/tests/cpp/test_multidevice_communications.cpp
@@ -20,7 +20,7 @@
 #include "ops/arith.h"
 #include "ops/utils.h"
 #include "tests/cpp/multidevice.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_multidevice_lower_communication_cuda.cpp
+++ b/tests/cpp/test_multidevice_lower_communication_cuda.cpp
@@ -23,7 +23,7 @@
 #include "runtime/communication_executor.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/multidevice.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -15,7 +15,7 @@
 #include "ops/all_ops.h"
 #include "tests/cpp/multidevice.h"
 #include "tests/cpp/multidevice_transformer.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_mutator.cpp
+++ b/tests/cpp/test_mutator.cpp
@@ -15,7 +15,7 @@
 #include "ops/all_ops.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_outer_reduction.cpp
+++ b/tests/cpp/test_outer_reduction.cpp
@@ -28,8 +28,8 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_pdl.cpp
+++ b/tests/cpp/test_pdl.cpp
@@ -14,7 +14,7 @@
 #include "ops/all_ops.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_pointwise.cpp
+++ b/tests/cpp/test_pointwise.cpp
@@ -17,8 +17,8 @@
 #include "scheduler/tools/domain_map.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_predicate_elimination.cpp
+++ b/tests/cpp/test_predicate_elimination.cpp
@@ -12,7 +12,7 @@
 #include "ir/all_nodes.h"
 #include "ops/all_ops.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_reduction.cpp
+++ b/tests/cpp/test_reduction.cpp
@@ -42,9 +42,9 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
 #include "transform_rfactor.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_reduction_pointwise.cpp
+++ b/tests/cpp/test_reduction_pointwise.cpp
@@ -13,7 +13,7 @@
 #include "scheduler/reduction_utils.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_remove_bcast_squeeze.cpp
+++ b/tests/cpp/test_remove_bcast_squeeze.cpp
@@ -18,7 +18,7 @@
 #include "preseg_passes/pre_segmenter.h"
 #include "preseg_passes/remove_bcast_squeeze.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_remove_trivial_ops.cpp
+++ b/tests/cpp/test_remove_trivial_ops.cpp
@@ -13,7 +13,7 @@
 #include "ops/all_ops.h"
 #include "runtime/executor.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_replay.cpp
+++ b/tests/cpp/test_replay.cpp
@@ -6,14 +6,15 @@
  */
 // clang-format on
 #include <gmock/gmock-matchers.h>
+#include <gmock/gmock-more-matchers.h>
 #include <gtest/gtest.h>
 
 #include "fusion.h"
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_replay.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_rng.cpp
+++ b/tests/cpp/test_rng.cpp
@@ -19,7 +19,7 @@
 #include "scheduler/all_schedulers.h"
 #include "tests/cpp/rng_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_rope.cpp
+++ b/tests/cpp/test_rope.cpp
@@ -14,7 +14,7 @@
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_runtime.cpp
+++ b/tests/cpp/test_runtime.cpp
@@ -17,7 +17,7 @@
 #include "global_allocator.h"
 #include "ops/arith.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_scalar_hoisting.cpp
+++ b/tests/cpp/test_scalar_hoisting.cpp
@@ -12,7 +12,7 @@
 #include "runtime/executor.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_scan.cpp
+++ b/tests/cpp/test_scan.cpp
@@ -17,7 +17,7 @@
 #include "runtime/fusion_executor_cache.h"
 #include "scheduler/tools/cub_utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_scan_device_func.cpp
+++ b/tests/cpp/test_scan_device_func.cpp
@@ -15,7 +15,7 @@
 
 #include "tests/cpp/scan_test_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_sdpa_node.cpp
+++ b/tests/cpp/test_sdpa_node.cpp
@@ -17,7 +17,7 @@
 #include "preseg_passes/move_split_cat.h"
 #include "preseg_passes/propagate_shardings.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_segmentation.cpp
+++ b/tests/cpp/test_segmentation.cpp
@@ -13,7 +13,7 @@
 #include "optimization_pass.h"
 #include "preseg_passes/mark_aliases_prepare.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_select.cpp
+++ b/tests/cpp/test_select.cpp
@@ -11,7 +11,7 @@
 #include "ops/all_ops.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_serial_gridreduce.cpp
+++ b/tests/cpp/test_serial_gridreduce.cpp
@@ -28,8 +28,8 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_smem_reuse.cpp
+++ b/tests/cpp/test_smem_reuse.cpp
@@ -23,8 +23,8 @@
 #include "scheduler/tools/inlining.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_statement_guard.cpp
+++ b/tests/cpp/test_statement_guard.cpp
@@ -13,7 +13,7 @@
 #include "ops/arith.h"
 #include "statement_guard.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_stream.cpp
+++ b/tests/cpp/test_stream.cpp
@@ -20,7 +20,7 @@
 #include "preseg_passes/propagate_shardings.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_swizzle.cpp
+++ b/tests/cpp/test_swizzle.cpp
@@ -17,8 +17,8 @@
 #include "scheduler/tools/inlining.h"
 #include "swizzle.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "transform_iter.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_tensor_factories.cpp
+++ b/tests/cpp/test_tensor_factories.cpp
@@ -17,7 +17,7 @@
 #include "runtime/executor.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_tmem.cpp
+++ b/tests/cpp/test_tmem.cpp
@@ -13,8 +13,8 @@
 #include "ops/arith.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_topk.cpp
+++ b/tests/cpp/test_topk.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include "csrc/exceptions.h"
@@ -23,7 +24,7 @@
 #include "scheduler/tools/cub_utils.h"
 #include "tests/cpp/topk_test_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_topk_device_func.cpp
+++ b/tests/cpp/test_topk_device_func.cpp
@@ -15,7 +15,7 @@
 
 #include "tests/cpp/topk_test_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_translate_mma.cpp
+++ b/tests/cpp/test_translate_mma.cpp
@@ -35,7 +35,7 @@
 #include "scheduler/reduction_utils.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_transpose.cpp
+++ b/tests/cpp/test_transpose.cpp
@@ -20,7 +20,7 @@
 #include "scheduler/transpose.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_tutorial.cpp
+++ b/tests/cpp/test_tutorial.cpp
@@ -16,8 +16,8 @@
 #include "ops/utils.h"
 #include "scheduler/tools/inlining.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_unary.cpp
+++ b/tests/cpp/test_unary.cpp
@@ -13,7 +13,7 @@
 #include "ops/arith.h"
 #include "runtime/fusion_executor_cache.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -23,8 +23,8 @@
 #include "scheduler/utils.h"
 #include "scheduler/vectorize_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_vectorization.cpp
+++ b/tests/cpp/test_vectorization.cpp
@@ -15,7 +15,7 @@
 #include "ops/all_ops.h"
 #include "scheduler/vectorize_helper.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 

--- a/tests/cpp/test_welford.cpp
+++ b/tests/cpp/test_welford.cpp
@@ -11,9 +11,9 @@
 #include "ops/all_ops.h"
 #include "scheduler/utils.h"
 #include "tests/cpp/utils.h"
-#include "tests/cpp/validator.h"
 #include "type.h"
 #include "utils.h"
+#include "validator_utils.h"
 
 namespace nvfuser {
 


### PR DESCRIPTION
Replace unnecessary tests/cpp/validator.h includes with validator_utils.h and add back required gmock/validator headers where matcher helpers are used to satisfy IWYU.