### PR TITLE
Rename log_sumexp to logsumexp

### DIFF
--- a/csrc/ir/composite_nodes.cpp
+++ b/csrc/ir/composite_nodes.cpp
@@ -185,7 +185,7 @@ std::vector<PolymorphicValue> LinearOp::evaluate(
 SdpaFwdOp::SdpaFwdOp(
     IrBuilderPasskey passkey,
     TensorView* output,
-    TensorView* log_sumexp,
+    TensorView* logsumexp,
     TensorView* philox_seed,
     TensorView* philox_offset,
     TensorView* query,
@@ -198,7 +198,7 @@ SdpaFwdOp::SdpaFwdOp(
     Val* scale)
     : Expr(passkey) {
   addOutput(output);
-  addOutput(log_sumexp);
+  addOutput(logsumexp);
   addOutput(philox_seed);
   addOutput(philox_offset);
 
@@ -367,7 +367,7 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
   }
 
   // 4D SDPA
-  auto [output, log_sumexp, philox_seed, philox_offset] = [&]() {
+  auto [output, logsumexp, philox_seed, philox_offset] = [&]() {
     if (query.is_meta()) {
       return sdpa_meta::_scaled_dot_product_attention_meta(query, value);
     }
@@ -396,7 +396,7 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
           "dropout_p is 0.0.");
       auto philox_seed = at::empty({2}, query.options().dtype(at::kUInt64));
       auto philox_offset = at::empty({}, query.options().dtype(at::kUInt64));
-      auto [out, log_sumexp] = at::_scaled_dot_product_attention_math(
+      auto [out, logsumexp] = at::_scaled_dot_product_attention_math(
           query,
           key,
           value,
@@ -432,7 +432,7 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
                 .permute(ir_utils::inversePermutation(*permutation));
       out = flattenBatchDims(out);
 
-      return std::make_tuple(out, log_sumexp, philox_seed, philox_offset);
+      return std::make_tuple(out, logsumexp, philox_seed, philox_offset);
     }
 
     // Flash attention require the last dimension to be padded to 8.
@@ -452,7 +452,7 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
 
     auto
         [out,
-         log_sumexp,
+         logsumexp,
          cum_seq_q,
          cum_seq_k,
          query_seq_len,
@@ -473,19 +473,19 @@ std::vector<PolymorphicValue> SdpaFwdOp::evaluate(
     if (out.size(-1) != last_dim_size) {
       out = out.slice(-1, 0, last_dim_size);
     }
-    return std::make_tuple(out, log_sumexp, philox_seed, philox_offset);
+    return std::make_tuple(out, logsumexp, philox_seed, philox_offset);
   }();
 
   if (batch_dims.size() > 1) {
     output = unflattenBatchDim(output, batch_dims);
-    log_sumexp = unflattenBatchDim(log_sumexp, batch_dims);
+    logsumexp = unflattenBatchDim(logsumexp, batch_dims);
   }
 
   // We ignore cum_seq_q/k outputs since they are undefined tensors for
   // non-nested tensors. We do not store query/key_seq_len since they can be
   // computed in non-nested tensor directly. debug_attn_mask is ignored
   // since `return_debug_mask=false`.
-  return {output, log_sumexp, philox_seed, philox_offset};
+  return {output, logsumexp, philox_seed, philox_offset};
 }
 
 SdpaBwdOp::SdpaBwdOp(
@@ -498,7 +498,7 @@ SdpaBwdOp::SdpaBwdOp(
     TensorView* key,
     TensorView* value,
     TensorView* output,
-    TensorView* log_sumexp,
+    TensorView* logsumexp,
     Val* dropout_p,
     Val* is_causal,
     TensorView* philox_seed,
@@ -513,7 +513,7 @@ SdpaBwdOp::SdpaBwdOp(
   addInput(key);
   addInput(value);
   addInput(output);
-  addInput(log_sumexp);
+  addInput(logsumexp);
   addInput(dropout_p);
   addInput(is_causal);
   addInput(philox_seed);

--- a/csrc/ir/composite_nodes.h
+++ b/csrc/ir/composite_nodes.h
@@ -133,7 +133,7 @@ class SdpaFwdOp : public Expr {
   SdpaFwdOp(
       IrBuilderPasskey,
       TensorView* output,
-      TensorView* log_sumexp,
+      TensorView* logsumexp,
       TensorView* philox_seed,
       TensorView* philox_offset,
       TensorView* query,
@@ -266,7 +266,7 @@ class SdpaBwdOp : public Expr {
       TensorView* key,
       TensorView* value,
       TensorView* output,
-      TensorView* log_sumexp,
+      TensorView* logsumexp,
       Val* dropout_p,
       Val* is_causal,
       TensorView* philox_seed,

--- a/csrc/ops/composite.h
+++ b/csrc/ops/composite.h
@@ -119,7 +119,7 @@ NVF_API TensorView* cutlass_nvfp4_grouped_mm(
 // Scaled Dot Product Flash Attention Forward Result
 struct SdpfaFwdResult {
   TensorView* output = nullptr;
-  TensorView* log_sumexp = nullptr;
+  TensorView* logsumexp = nullptr;
   TensorView* philox_seed = nullptr;
   TensorView* philox_offset = nullptr;
 };
@@ -151,7 +151,7 @@ NVF_API SdpfaBwdResult sdpfa_bwd(
     TensorView* key,
     TensorView* value,
     TensorView* output,
-    TensorView* log_sumexp,
+    TensorView* logsumexp,
     Val* dropout_p,
     Val* is_causal,
     TensorView* philox_seed,

--- a/python/python_direct/ops.cpp
+++ b/python/python_direct/ops.cpp
@@ -3361,7 +3361,7 @@ void bindSdpaOps(py::module_& ops) {
          ScalarVariant dropout_p,
          ScalarVariant is_causal,
          ScalarVariant scale) -> decltype(auto) {
-        auto [output, log_sumexp, philox_seed, philox_offset] = sdpfa_fwd(
+        auto [output, logsumexp, philox_seed, philox_offset] = sdpfa_fwd(
             query,
             key,
             value,
@@ -3370,7 +3370,7 @@ void bindSdpaOps(py::module_& ops) {
             convertToVal(dropout_p),
             convertToVal(is_causal, DataType::Bool),
             convertToVal(scale));
-        return py::make_tuple(output, log_sumexp, philox_seed, philox_offset);
+        return py::make_tuple(output, logsumexp, philox_seed, philox_offset);
       },
       py::arg("query"),
       py::arg("key"),
@@ -3405,7 +3405,7 @@ scale : Val, optional
 Returns
 -------
 tuple[TensorView, TensorView, TensorView, TensorView]
-    A tuple of (output, log_sumexp, philox_seed, philox_offset).
+    A tuple of (output, logsumexp, philox_seed, philox_offset).
       )",
       py::return_value_policy::reference);
   ops.def(
@@ -3415,7 +3415,7 @@ tuple[TensorView, TensorView, TensorView, TensorView]
          TensorView* key,
          TensorView* value,
          TensorView* output,
-         TensorView* log_sumexp,
+         TensorView* logsumexp,
          ScalarVariant dropout_p,
          ScalarVariant is_causal,
          TensorView* philox_seed,
@@ -3427,7 +3427,7 @@ tuple[TensorView, TensorView, TensorView, TensorView]
             key,
             value,
             output,
-            log_sumexp,
+            logsumexp,
             convertToVal(dropout_p),
             convertToVal(is_causal, DataType::Bool),
             philox_seed,
@@ -3440,7 +3440,7 @@ tuple[TensorView, TensorView, TensorView, TensorView]
       py::arg("key"),
       py::arg("value"),
       py::arg("output"),
-      py::arg("log_sumexp"),
+      py::arg("logsumexp"),
       py::arg("dropout_p"),
       py::arg("is_causal"),
       py::arg("philox_seed"),
@@ -3461,7 +3461,7 @@ value : TensorView
     The value tensor.
 output : TensorView
     The output tensor.
-log_sumexp : TensorView
+logsumexp : TensorView
     The log of the sum of the exponential of the key.
 dropout_p : Val, optional
     The dropout probability.

--- a/python/python_frontend/fusion_record.h
+++ b/python/python_frontend/fusion_record.h
@@ -3091,7 +3091,7 @@ struct SdpaFwdOpRecord : RecordFunctor {
     auto output =
         sdpfa_fwd(query, key, value, bias, mask, dropout_p, is_causal, scale);
     fd.setFusionState(outputs_.at(0).index, output.output);
-    fd.setFusionState(outputs_.at(1).index, output.log_sumexp);
+    fd.setFusionState(outputs_.at(1).index, output.logsumexp);
     fd.setFusionState(outputs_.at(2).index, output.philox_seed);
     fd.setFusionState(outputs_.at(3).index, output.philox_offset);
   }
@@ -3115,7 +3115,7 @@ struct SdpaBwdOpRecord : RecordFunctor {
     auto key = fd.getFusionState(args_.at(2).index)->as<TensorView>();
     auto value = fd.getFusionState(args_.at(3).index)->as<TensorView>();
     auto output = fd.getFusionState(args_.at(4).index)->as<TensorView>();
-    auto log_sumexp = fd.getFusionState(args_.at(5).index)->as<TensorView>();
+    auto logsumexp = fd.getFusionState(args_.at(5).index)->as<TensorView>();
 
     auto dropout_p = (args_.at(6).stype == serde::StateType::Scalar)
         ? fd.getFusionState(args_.at(6).index)->as<Val>()
@@ -3137,7 +3137,7 @@ struct SdpaBwdOpRecord : RecordFunctor {
         key,
         value,
         output,
-        log_sumexp,
+        logsumexp,
         dropout_p,
         is_causal,
         philox_seed,

--- a/python/python_frontend/python_bindings.cpp
+++ b/python/python_frontend/python_bindings.cpp
@@ -3543,7 +3543,7 @@ void initNvFuserPythonBindings(PyObject* module) {
          Tensor key,
          Tensor value,
          Tensor output,
-         Tensor log_sumexp,
+         Tensor logsumexp,
          std::optional<Scalar> dropout_p,
          std::optional<Scalar> is_causal,
          Tensor philox_seed,
@@ -3574,7 +3574,7 @@ void initNvFuserPythonBindings(PyObject* module) {
              fd->recordingState(key()),
              fd->recordingState(value()),
              fd->recordingState(output()),
-             fd->recordingState(log_sumexp()),
+             fd->recordingState(logsumexp()),
              dropout_p_state,
              is_causal_state,
              fd->recordingState(philox_seed()),
@@ -3590,7 +3590,7 @@ void initNvFuserPythonBindings(PyObject* module) {
       py::arg("key"),
       py::arg("value"),
       py::arg("output"),
-      py::arg("log_sumexp"),
+      py::arg("logsumexp"),
       py::arg("dropout_p").none(true) = py::none(),
       py::arg("is_causal").none(true) = py::none(),
       py::arg("philox_seed"),
@@ -3615,7 +3615,7 @@ void initNvFuserPythonBindings(PyObject* module) {
         FusionDefinition* fd = self.fusion_definition;
         size_t ndims = query.dims;
         Tensor output = fd->defineTensor(/*dims=*/ndims);
-        Tensor log_sumexp = fd->defineTensor(/*dims=*/ndims - 1);
+        Tensor logsumexp = fd->defineTensor(/*dims=*/ndims - 1);
 #if NVF_TORCH_VERSION_NO_LESS(2, 7, 0)
         int64_t philox_ndims = 1;
 #else
@@ -3650,10 +3650,10 @@ void initNvFuserPythonBindings(PyObject* module) {
              is_causal_state,
              scale_state},
             {fd->recordingState(output()),
-             fd->recordingState(log_sumexp()),
+             fd->recordingState(logsumexp()),
              fd->recordingState(philox_seed()),
              fd->recordingState(philox_offset())}));
-        return std::make_tuple(output, log_sumexp, philox_seed, philox_offset);
+        return std::make_tuple(output, logsumexp, philox_seed, philox_offset);
       },
       py::arg("query"),
       py::arg("key"),

--- a/tests/cpp/multidevice_transformer.h
+++ b/tests/cpp/multidevice_transformer.h
@@ -84,7 +84,7 @@ class DistributedTransformer {
       TensorView* w1,
       TensorView* mask,
       TensorView* sdpa_output,
-      TensorView* sdpa_log_sumexp,
+      TensorView* sdpa_logsumexp,
       TensorView* sdpa_seed,
       TensorView* sdpa_offset,
       TensorView* grad,

--- a/tests/cpp/test_allocation_order_inference.cpp
+++ b/tests/cpp/test_allocation_order_inference.cpp
@@ -352,12 +352,12 @@ TEST_F(AllocationOrderInferenceTest, QkvSplitSdpaForward) {
       /*is_causal=*/IrBuilder::create<Val>(true),
       /*scale=*/nullptr);
   fusion.addOutput(outs.output);
-  fusion.addOutput(outs.log_sumexp);
+  fusion.addOutput(outs.logsumexp);
 
   OptimizationPass<preseg_passes::MarkAliasesPreparePass>::runPass(&fusion);
   OptimizationPass<preseg_passes::AllocationDomainPass>::runPass(&fusion);
   EXPECT_THAT(getAllocationOrder(outs.output), ElementsAre(0, 2, 1, 3));
-  EXPECT_THAT(getAllocationOrder(outs.log_sumexp), ElementsAre(0, 1, 2));
+  EXPECT_THAT(getAllocationOrder(outs.logsumexp), ElementsAre(0, 1, 2));
 }
 
 TEST_F(AllocationOrderInferenceTest, SdpaBackward) {

--- a/tests/cpp/test_multidevice_transformer.cpp
+++ b/tests/cpp/test_multidevice_transformer.cpp
@@ -142,7 +142,7 @@ std::vector<at::Tensor> reference_mha_backwards(
   }
   auto
       [sdpa_output,
-       log_sumexp,
+       logsumexp,
        cum_seq_q,
        cum_seq_k,
        query_seq_len,
@@ -176,7 +176,7 @@ std::vector<at::Tensor> reference_mha_backwards(
           qkv[1],
           qkv[2],
           sdpa_output,
-          log_sumexp,
+          logsumexp,
           cum_seq_q,
           cum_seq_k,
           /*max_q=*/*query_seq_len.maybe_as_int(),
@@ -199,7 +199,7 @@ std::vector<at::Tensor> reference_mha_backwards(
   // and become inputs to the nvfuser mha backwards pass
   std::vector<at::Tensor> tensors = {
       sdpa_output,
-      log_sumexp,
+      logsumexp,
       philox_seed,
       philox_offset,
       dropout_grad,
@@ -583,7 +583,7 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
   TensorView* tvmask = makeContigConcreteTensor({B * S, E}, DataType::Bool);
   TensorView* tvsdpa_out =
       makeContigConcreteTensor({D, B, H / D, S, E / H}, dtype);
-  TensorView* tvsdpa_log_sumexp =
+  TensorView* tvsdpa_logsumexp =
       makeContigConcreteTensor({D, B, H / D, S}, DataType::Float);
   auto [tvsdpa_seed, tvsdpa_offset] = createSdpaRngTvs();
   TensorView* linear0 = makeSymbolicTensor(3, dtype);
@@ -594,7 +594,7 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
   fusion->addInput(tvgrad);
   fusion->addInput(tvmask);
   fusion->addInput(tvsdpa_out);
-  fusion->addInput(tvsdpa_log_sumexp);
+  fusion->addInput(tvsdpa_logsumexp);
   fusion->addInput(tvsdpa_seed);
   fusion->addInput(tvsdpa_offset);
   fusion->addInput(linear0);
@@ -605,7 +605,7 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
       tvw1,
       tvmask,
       tvsdpa_out,
-      tvsdpa_log_sumexp,
+      tvsdpa_logsumexp,
       tvsdpa_seed,
       tvsdpa_offset,
       tvgrad,
@@ -641,7 +641,7 @@ TEST_P(DistributedTransformerTest, MHA_Backward) {
       grad,
       mask,
       shardTensor1D(reference_outs[0], 1, mesh).unsqueeze(0), // sdpa.output
-      shardTensor1D(reference_outs[1], 1, mesh).unsqueeze(0), // sdpa.log_sumexp
+      shardTensor1D(reference_outs[1], 1, mesh).unsqueeze(0), // sdpa.logsumexp
       reference_outs[2], // sdpa.seed
       reference_outs[3], // sdpa.offset
       shardTensor1D(reference_outs[13], 1, mesh).unsqueeze(0) // linear0

--- a/tests/python/direct/test_sdpa.py
+++ b/tests/python/direct/test_sdpa.py
@@ -280,7 +280,7 @@ def test_sdpa_bwd(nvfuser_direct_test):
             dtype=DataType.BFloat16,
             is_cpu=False,
         )
-        log_sumexp = fd.define_tensor(
+        logsumexp = fd.define_tensor(
             shape=[-1, -1, -1],
             contiguity=True,
             dtype=DataType.Float,
@@ -302,7 +302,7 @@ def test_sdpa_bwd(nvfuser_direct_test):
             k,
             v,
             output,
-            log_sumexp,
+            logsumexp,
             dropout_p,
             is_causal,
             philox_seed,
@@ -325,7 +325,7 @@ def test_sdpa_bwd(nvfuser_direct_test):
 
             (
                 output,
-                log_sumexp,
+                logsumexp,
                 cum_seq_q,
                 cum_seq_k,
                 query_seq_len,
@@ -348,7 +348,7 @@ def test_sdpa_bwd(nvfuser_direct_test):
                 k,
                 v,
                 output,
-                log_sumexp,
+                logsumexp,
                 cum_seq_q,
                 cum_seq_k,
                 query_seq_len,
@@ -370,7 +370,7 @@ def test_sdpa_bwd(nvfuser_direct_test):
                 k,
                 v,
                 output,
-                log_sumexp,
+                logsumexp,
                 philox_seed,
                 philox_offset,
             ]
@@ -436,7 +436,7 @@ def test_sdpa_fwd_bwd(nvfuser_direct_test):
         if has_scale:
             scale = fd.define_scalar(value=None, dtype=DataType.Double)
 
-        output, log_sumexp, philox_seed, philox_offset = fd.ops.sdpfa_fwd(
+        output, logsumexp, philox_seed, philox_offset = fd.ops.sdpfa_fwd(
             q, k, v, dropout_p=dropout_p, is_causal=is_causal, scale=scale
         )
         grad_query, grad_key, grad_value = fd.ops.sdpfa_bwd(
@@ -445,7 +445,7 @@ def test_sdpa_fwd_bwd(nvfuser_direct_test):
             k,
             v,
             output,
-            log_sumexp,
+            logsumexp,
             dropout_p,
             is_causal,
             philox_seed,

--- a/tests/python/multidevice/test_multidevice.py
+++ b/tests/python/multidevice/test_multidevice.py
@@ -89,7 +89,7 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
         # positive probability.
         dropout_p = fd.define_scalar(0.0, dtype=DataType.Double)
         is_causal = fd.define_scalar(True, dtype=DataType.Bool)
-        attn, log_sumexp, seed, offset = fd.ops.sdpfa_fwd(
+        attn, logsumexp, seed, offset = fd.ops.sdpfa_fwd(
             q, k, v, dropout_p=dropout_p, is_causal=is_causal
         )
 
@@ -99,7 +99,7 @@ def test_sdpa(multidevice_test, qkv_format: QkvFormat):
             k,
             v,
             attn,
-            log_sumexp,
+            logsumexp,
             dropout_p,
             is_causal,
             seed,
@@ -206,7 +206,7 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
         # positive probability.
         dropout_p = fd.define_scalar(0.0, dtype=DataType.Double)
         is_causal = fd.define_scalar(True, dtype=DataType.Bool)
-        attn, log_sumexp, seed, offset = fd.ops.sdpfa_fwd(
+        attn, logsumexp, seed, offset = fd.ops.sdpfa_fwd(
             q, k, v, dropout_p=dropout_p, is_causal=is_causal
         )
 
@@ -216,7 +216,7 @@ def test_sdpa_loop_split(multidevice_test, qkv_format: QkvFormat):
             k,
             v,
             attn,
-            log_sumexp,
+            logsumexp,
             dropout_p,
             is_causal,
             seed,

--- a/tests/python/multidevice/test_transformer.py
+++ b/tests/python/multidevice/test_transformer.py
@@ -1097,7 +1097,7 @@ def test_transformer_backward(multidevice_test, benchmark, parallelism: Parallel
         b, h, s, e // h, dtype=torch.bfloat16, device="cpu"
     )
 
-    sdpa_log_sumexp = torch.testing.make_tensor(
+    sdpa_logsumexp = torch.testing.make_tensor(
         b, h, s, dtype=torch.float32, device="cpu"
     )
     mha_linear0_weight = torch.testing.make_tensor(
@@ -1133,7 +1133,7 @@ def test_transformer_backward(multidevice_test, benchmark, parallelism: Parallel
         .transpose(1, 2)
         .contiguous()
         .transpose(1, 2),
-        multidevice_test.shard_tensor_1d(sdpa_log_sumexp, 1, mesh),
+        multidevice_test.shard_tensor_1d(sdpa_logsumexp, 1, mesh),
         sdpa_philox_seed,
         sdpa_philox_offset,
         multidevice_test.shard_tensor_1d(mha_linear0_weight, 0, mesh),


### PR DESCRIPTION
Rename log_sumexp to logsumexp across composite ops, SDPA bindings, and tests to use the conventional spelling.