### PR TITLE
Move unique_ptr<Fusion> to FusionExecutorCache

### DIFF
--- a/python/python_direct/lru_cache.h
+++ b/python/python_direct/lru_cache.h
@@ -45,23 +45,21 @@ class LRUCache {
  private:
   // Item is a tuple of key, value, and visits per key
   struct Item {
-    std::shared_ptr<Fusion> fusion;
+    Fusion* fusion;
     std::unique_ptr<FusionExecutorCache> executor_cache;
     size_t visits;
   };
 
   // Custom Hasher Functor for Fusion
   struct FusionHasher {
-    size_t operator()(const std::shared_ptr<Fusion>& fusion) const {
+    size_t operator()(const Fusion* fusion) const {
       return fusion->hash();
     }
   };
 
   // Custom Equality Functor for Fusion
   struct FusionEqualTo {
-    bool operator()(
-        const std::shared_ptr<Fusion>& lhs,
-        const std::shared_ptr<Fusion>& rhs) const {
+    bool operator()(const Fusion* lhs, const Fusion* rhs) const {
       return lhs->sameDefinition(*rhs);
     }
   };
@@ -80,7 +78,7 @@ class LRUCache {
   // The map provides O(1) access to list nodes.
   // It stores keys and iterators to the corresponding pairs in the list.
   std::unordered_map<
-      std::shared_ptr<Fusion>,
+      Fusion*,
       typename std::list<Item>::iterator,
       FusionHasher,
       FusionEqualTo>

--- a/python/python_direct/runtime.cpp
+++ b/python/python_direct/runtime.cpp
@@ -232,7 +232,7 @@ void bindFusionExecutorCache(py::module& nvfuser) {
           py::init([](std::unique_ptr<Fusion> fusion,
                       int64_t fusion_id,
                       bool auto_schedule) {
-            // Make a copy of the fusion for FusionExecutorCache to own.
+            // Move fusion to FusionExecutorCache.
             return std::make_unique<FusionExecutorCache>(
                 std::move(fusion), fusion_id, auto_schedule);
           }),

--- a/tests/python/direct/test_python_direct.py
+++ b/tests/python/direct/test_python_direct.py
@@ -670,6 +670,7 @@ def test_lru_cache():
 
     assert cache.num_fusions() == 0
     fd0.fec = cache.cache_compile(fd0.fusion)
+    del fd0._fusion
     # Check that LRUCache caches the first fusion
     assert cache.num_fusions() == 1
 
@@ -678,6 +679,7 @@ def test_lru_cache():
 
     assert cache.num_fusions() == 1
     fd1.fec = cache.cache_compile(fd1.fusion)
+    del fd1._fusion
     # Check that LRUCache creates a separate entry for second fusion
     assert cache.num_fusions() == 2
 


### PR DESCRIPTION
* Represent `Fusion` as `py::smart_holder`
* Change `FusionExecutorCache` constructor to accept `std::unique_ptr<Fusion>`
* Change `LRUCache::cacheCompile` to move ownership of `std::unique_ptr<Fusion>` to the `FusionExecutorCache`.
* After `LRUCache::cacheCompile`, the python `FusionDefinition` gets the corresponding `FusionExecutorCache` then deletes its Fusion.
* If a cached `FusionExecutorCache` is used, then its underlying `Fusion` will not match the existing Fusion. Then, accessing TensorViews for this Fusion will be undefined.