### PR TITLE
ensure there are enough mbarriers 

### DIFF
--- a/tests/cpp/test_circular_buffering_ping_pong.cpp
+++ b/tests/cpp/test_circular_buffering_ping_pong.cpp
@@ -54,7 +54,9 @@ TEST_P(PingPongCircularBuffering, StageSlicePositionComputeAt) {
   }
 
   constexpr int64_t dim1 = 128;
-  constexpr int64_t stages = 6;
+  // When stage_slice_position is 4, all rows and warp groups are decoupled,
+  // which means we need at least rows_per_stage * compute_warp_groups mbarriers
+  constexpr int64_t stages = rows_per_stage * compute_warp_groups;
 
   TensorView* tv0 = makeContigConcreteTensor({dim0, dim1}, DataType::Float);
   fusion->addInput(tv0);


### PR DESCRIPTION
Ensure there are enough mbarriers when `stage_slice_position` is to the right of rows per stage domain, e.g. `[CircularLoop, BIDx, TIDy(compute warp groups), Row per stage (stage_slice_position)]`

Before this PR, test `StageSlicePositionComputeAt` always use 6 circular buffer stages,  when `stage_slice_position = 4`, the kernel is issuing `rows_per_stage * compute_warp_groups = 4 x 2 = 8` **independent TMA loads each uses a dedicated mbarrier**, to avoid conflict, we should have at least 8 mbarriers, which means at least 8 stages.

kernel before this PR: **6 mbarriers are used by 8 independent TMA loads**, warp-group-0 is visiting mbarriers-0/1/2/3 and warp-group-1 is visiting mbarriers-4/5/0/1. Conflict happened at mbarriers-0/1

```
  if ((((nvfuser_index_t)threadIdx.y) >= 2)) {
    #pragma unroll 5
    for(nvfuser_index_t i2 = 0; i2 < 12; ++i2) {
      #pragma unroll
      for(nvfuser_index_t i3 = 0; i3 < 2; ++i3) {
        #pragma unroll
        for(nvfuser_index_t i4 = 0; i4 < 4; ++i4) {
          if (((((((nvfuser_index_t)threadIdx.x) / 32ULL) == 0ULL) && Hopper::electSync(4294967295U)) && ((-12672 + (4 * ((nvfuser_index_t)blockIdx.x))) < (((-(1056 * i2)) - (528 * i3)) - i4)))) {
            mbarrier::waitParity(toSmem((&T4[(((((8 * i2) + (4 * i3)) + i4) % 6) + 6LL)])), __to_uint32((((((8 * i2) + (4 * i3)) + i4) / 6) % 2)));
            mbarrier::arriveExpectTX(toSmem((&T4[((((8 * i2) + (4 * i3)) + i4) % 6)])), 512U);
            Hopper::cpAsyncBulkG2S((Hopper::CpAsyncBulkG2SIndex{ ((((T0.data + (512 * ((nvfuser_index_t)blockIdx.x))) + (135168 * i2)) + (67584 * i3)) + (128 * i4)), 512U, toSmem((&T4[((((8 * i2) + (4 * i3)) + i4) % 6)])) }), (toSmem(T1) + (512 * ((((8 * i2) + (4 * i3)) + i4) % 6))));
          }
        }
      }
    }
    return;
  } else {
    #pragma unroll
    for(nvfuser_index_t i5 = 0; i5 < 6; ++i5) {
      if ((((nvfuser_index_t)threadIdx.y) == 0)) {
        mbarrier::arrive(toSmem((&T4[(i5 + 6LL)])));
      }
    }
    #pragma unroll
    for(nvfuser_index_t i6 = 0; i6 < 12; ++i6) {
      Array<float, 4, 1> T2;
      #pragma unroll
      for(nvfuser_index_t i7 = 0; i7 < 4; ++i7) {
        if ((((-12672 + (528 * ((nvfuser_index_t)threadIdx.y))) + (4 * ((nvfuser_index_t)blockIdx.x))) < ((-(1056 * i6)) - i7))) {
          mbarrier::waitParity(toSmem((&T4[((((4 * ((nvfuser_index_t)threadIdx.y)) + (8 * i6)) + i7) % 6)])), __to_uint32((((((4 * ((nvfuser_index_t)threadIdx.y)) + (8 * i6)) + i7) / 6) % 2)));
        }
        T2[i7]
           = T1[(((nvfuser_index_t)threadIdx.x) + (128 * ((((4 * ((nvfuser_index_t)threadIdx.y)) + (8 * i6)) + i7) % 6)))];
        mbarrier::arrive(toSmem((&T4[(((((4 * ((nvfuser_index_t)threadIdx.y)) + (8 * i6)) + i7) % 6) + 6LL)])));
      }
      #pragma unroll
      for(nvfuser_index_t i8 = 0; i8 < 4; ++i8) {
        if (((((nvfuser_index_t)threadIdx.y) < 2) && (((-12672 + (528 * ((nvfuser_index_t)threadIdx.y))) + (4 * ((nvfuser_index_t)blockIdx.x))) < ((-(1056 * i6)) - i8)))) {
          T3[((((((nvfuser_index_t)threadIdx.x) + (67584 * ((nvfuser_index_t)threadIdx.y))) + (512 * ((nvfuser_index_t)blockIdx.x))) + (135168 * i6)) + (128 * i8))]
            = T2[i8]
            + T2[i8];
        }
      }
    }
  }
```