### PR TITLE
Enable PDL for all cutlass kernels

### DIFF
--- a/cutlass/group_mm.cu
+++ b/cutlass/group_mm.cu
@@ -368,7 +368,12 @@ void run_group_mm(
   auto status = gemm_op.initialize(args, workspace.data_ptr());
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
 
-  status = gemm_op.run(args, workspace.data_ptr(), stream);
+  status = gemm_op.run(
+      args,
+      workspace.data_ptr(),
+      stream,
+      /*cuda_adapter=*/nullptr,
+      /*launch_with_pdl=*/true);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 #else

--- a/cutlass/mxfp8_scaled_mm.cu
+++ b/cutlass/mxfp8_scaled_mm.cu
@@ -258,7 +258,12 @@ void runGemm(
   auto status = gemm.initialize(arguments, workspace.data_ptr(), stream);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
 
-  status = gemm.run(arguments, workspace.data_ptr(), stream);
+  status = gemm.run(
+      arguments,
+      workspace.data_ptr(),
+      stream,
+      /*cuda_adapter=*/nullptr,
+      /*launch_with_pdl=*/true);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 #else

--- a/cutlass/nvfp4_scaled_group_mm.cu
+++ b/cutlass/nvfp4_scaled_group_mm.cu
@@ -514,7 +514,12 @@ void run_nvfp4_scaled_group_mm(
   auto status = gemm_op.initialize(args, workspace.data_ptr());
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
 
-  status = gemm_op.run(args, workspace.data_ptr(), stream);
+  status = gemm_op.run(
+      args,
+      workspace.data_ptr(),
+      stream,
+      /*cuda_adapter=*/nullptr,
+      /*launch_with_pdl=*/true);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 #else

--- a/cutlass/nvfp4_scaled_mm.cu
+++ b/cutlass/nvfp4_scaled_mm.cu
@@ -251,7 +251,12 @@ void runGemm(
   auto status = gemm.initialize(arguments, workspace.data_ptr(), stream);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
 
-  status = gemm.run(arguments, workspace.data_ptr(), stream);
+  status = gemm.run(
+      arguments,
+      workspace.data_ptr(),
+      stream,
+      /*cuda_adapter=*/nullptr,
+      /*launch_with_pdl=*/true);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 #else

--- a/cutlass/nvfp4_scaled_mm_blockscale.cu
+++ b/cutlass/nvfp4_scaled_mm_blockscale.cu
@@ -298,7 +298,12 @@ void runGemm(
   auto status = gemm.initialize(arguments, workspace.data_ptr(), stream);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to initialize GEMM");
 
-  status = gemm.run(arguments, workspace.data_ptr(), stream);
+  status = gemm.run(
+      arguments,
+      workspace.data_ptr(),
+      stream,
+      /*cuda_adapter=*/nullptr,
+      /*launch_with_pdl=*/true);
   NVF_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 #else


### PR DESCRIPTION
This PR sets `launch_with_pdl` to `true` for [cutlass::gemm::device::GemmUniversalAdapter::run](https://github.com/NVIDIA/cutlass/blob/main/include/cutlass/gemm/device/gemm_universal_adapter.h#L581-L588)