### PR TITLE
PUBLIC codegen_internal ASAN compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,7 +501,7 @@ target_link_libraries(nvfuser_codegen PRIVATE
 )
 
 if(NVFUSER_BUILD_WITH_ASAN)
-  target_compile_options(codegen_internal PRIVATE -fsanitize=address)
+  target_compile_options(codegen_internal PUBLIC -fsanitize=address)
   target_link_options(codegen_internal PUBLIC -fsanitize=address)
   target_link_options(nvfuser_codegen PUBLIC -fsanitize=address)
 endif()


### PR DESCRIPTION
Tests and Benchmark targets will fail to compile w/ `PCH=1` and `ASAN=1`. This happens because tests and benchmarks depend on the `codegen_internal` target, when the ASAN flags are `PRIVATE` they are not propogated to tests and benchmarks. Using `PUBLIC` propogates the flags to dependent targets.