### PR TITLE
scheduler: standardize include style in cpp

### DIFF
--- a/csrc/scheduler/cache_policy_refiner.cpp
+++ b/csrc/scheduler/cache_policy_refiner.cpp
@@ -6,13 +6,14 @@
  */
 // clang-format on
 
-#include <fusion.h>
-#include <ir/base_nodes.h>
-#include <ir/internal_nodes.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/debug_utils.h>
+#include "scheduler/cache_policy_refiner.h"
+
+#include "fusion.h"
+#include "ir/base_nodes.h"
+#include "ir/internal_nodes.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "scheduler/debug_utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/communication.cpp
+++ b/csrc/scheduler/communication.cpp
@@ -6,15 +6,16 @@
  */
 // clang-format on
 
-#include <alias_analysis.h>
-#include <ir/utils.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <scheduler/communication.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
+#include "scheduler/communication.h"
+
+#include "alias_analysis.h"
+#include "ir/utils.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/cutlass.cpp
+++ b/csrc/scheduler/cutlass.cpp
@@ -6,19 +6,20 @@
  */
 // clang-format on
 
-#include <cutlass/gemm.h>
-#include <device_lower/utils.h>
-#include <exceptions.h>
-#include <instrumentation.h>
-#include <ir/all_nodes.h>
-#include <ops/all_ops.h>
-#include <scheduler/cutlass.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/nvmmh.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
+#include "scheduler/cutlass.h"
 
 #include <ATen/cuda/CUDAContextLight.h>
+
+#include "cutlass/gemm.h"
+#include "device_lower/utils.h"
+#include "exceptions.h"
+#include "instrumentation.h"
+#include "ir/all_nodes.h"
+#include "ops/all_ops.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/nvmmh.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/expr_eval_sched.cpp
+++ b/csrc/scheduler/expr_eval_sched.cpp
@@ -6,12 +6,13 @@
  */
 // clang-format on
 
-#include <alias_analysis.h>
-#include <ir/utils.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/expr_eval_sched.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
+#include "scheduler/expr_eval_sched.h"
+
+#include "alias_analysis.h"
+#include "ir/utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/greedy.cpp
+++ b/csrc/scheduler/greedy.cpp
@@ -6,34 +6,35 @@
  */
 // clang-format on
 
-#include <debug.h>
-#include <device_lower/analysis/fusion_info.h>
-#include <device_lower/analysis/sync_information.h>
-#include <device_lower/utils.h>
-#include <exceptions.h>
-#include <id_model/id_model.h>
-#include <id_model/to_string.h>
-#include <instrumentation.h>
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <ops/all_ops.h>
-#include <options.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/greedy.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/cub_utils.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/tools/loop_domain_scheduler.h>
-#include <scheduler/tools/maxinfo_propagator.h>
-#include <scheduler/utils.h>
-#include <transform_replay.h>
-#include <val_graph_visitor.h>
-
-#include <ATen/cuda/CUDAContext.h>
+#include "scheduler/greedy.h"
 
 #include <ranges>
 #include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include "debug.h"
+#include "device_lower/analysis/fusion_info.h"
+#include "device_lower/analysis/sync_information.h"
+#include "device_lower/utils.h"
+#include "exceptions.h"
+#include "id_model/id_model.h"
+#include "id_model/to_string.h"
+#include "instrumentation.h"
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "ops/all_ops.h"
+#include "options.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/cub_utils.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/tools/loop_domain_scheduler.h"
+#include "scheduler/tools/maxinfo_propagator.h"
+#include "scheduler/utils.h"
+#include "transform_replay.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/heuristic.cpp
+++ b/csrc/scheduler/heuristic.cpp
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/heuristic.h>
+#include "scheduler/heuristic.h"
 
-#include <fusion.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
+#include "fusion.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 HeuristicParamsList::HeuristicParamsList(

--- a/csrc/scheduler/mark_aliases.cpp
+++ b/csrc/scheduler/mark_aliases.cpp
@@ -5,12 +5,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <alias_analysis.h>
-#include <ir/internal_nodes.h>
-#include <ir/utils.h>
-#include <options.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/mark_aliases.h>
+#include "scheduler/mark_aliases.h"
+
+#include "alias_analysis.h"
+#include "ir/internal_nodes.h"
+#include "ir/utils.h"
+#include "options.h"
+#include "scheduler/debug_utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/matmul.cpp
+++ b/csrc/scheduler/matmul.cpp
@@ -5,22 +5,20 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <device_lower/analysis/circular_buffer.h>
-#include <instrumentation.h>
-#include <multidevice/utils.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/matmul.h>
-#include <scheduler/matmul_hopper+.h>
-#include <scheduler/matmul_utils.h>
-#include <scheduler/mma_utils.h>
-#include <scheduler/tools/abstract_tensor.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
+#include "scheduler/matmul.h"
 
-// NOTE: included to avoid compilation error caused by missing destructor in
-// 'SchedulerRuntimeInfo'
-#include <runtime/executor_utils.h>
+#include "device_lower/analysis/circular_buffer.h"
+#include "instrumentation.h"
 #include "mma_type.h"
+#include "multidevice/utils.h"
+#include "runtime/executor_utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/matmul_hopper+.h"
+#include "scheduler/matmul_utils.h"
+#include "scheduler/mma_utils.h"
+#include "scheduler/tools/abstract_tensor.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/matmul_heuristic_plugin.cpp
+++ b/csrc/scheduler/matmul_heuristic_plugin.cpp
@@ -6,16 +6,18 @@
  */
 // clang-format on
 
-#include <ir/interface_nodes.h>
-#include <mma_type.h>
-#include <scheduler/matmul_heuristic_plugin.h>
-#include <scheduler/mma_utils.h>
-#include <sys_utils.h>
-#include "base.h"
+#include "scheduler/matmul_heuristic_plugin.h"
 
 #include <cstdint>
 #include <memory>
+
 #include <mutex>
+
+#include "base.h"
+#include "ir/interface_nodes.h"
+#include "mma_type.h"
+#include "scheduler/mma_utils.h"
+#include "sys_utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/matmul_hopper+.cpp
+++ b/csrc/scheduler/matmul_hopper+.cpp
@@ -5,31 +5,30 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <device_lower/analysis/circular_buffer.h>
-#include <device_lower/utils.h>
-#include <disjoint_set.h>
-#include <id_model/schedule.h>
-#include <instrumentation.h>
-#include <ir/utils.h>
-#include <mma_type.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/matmul.h>
-#include <scheduler/matmul_heuristic.h>
-#include <scheduler/matmul_hopper+.h>
-#include <scheduler/matmul_utils.h>
-#include <scheduler/mma_utils.h>
-#include <scheduler/tools/abstract_tensor.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-#include <val_graph.h>
-#include <val_graph_visitor.h>
-#include "base.h"
-
-// NOTE: included to avoid compilation error caused by missing destructor in
-// 'SchedulerRuntimeInfo'
-#include <runtime/executor_utils.h>
+#include "scheduler/matmul_hopper+.h"
 
 #include <cmath>
+
+#include "base.h"
+#include "device_lower/analysis/circular_buffer.h"
+#include "device_lower/utils.h"
+#include "disjoint_set.h"
+#include "id_model/schedule.h"
+#include "instrumentation.h"
+#include "ir/utils.h"
+#include "mma_type.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/matmul.h"
+#include "scheduler/matmul_heuristic.h"
+#include "scheduler/matmul_utils.h"
+#include "scheduler/mma_utils.h"
+#include "scheduler/tools/abstract_tensor.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "val_graph.h"
+#include "val_graph_visitor.h"
+
+#include "runtime/executor_utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/matmul_utils.cpp
+++ b/csrc/scheduler/matmul_utils.cpp
@@ -5,32 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/matmul_heuristic.h>
-#include <scheduler/matmul_heuristic_plugin.h>
-#include <scheduler/matmul_utils.h>
-#include <scheduler/mma_utils.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-
-// NOTE: included to avoid compilation error caused by missing destructor in
-// 'SchedulerRuntimeInfo'
-#include <cuda_utils.h>
-#include <debug.h>
-#include <id_model/id_model.h>
-#include <ir/base_nodes.h>
-#include <ir/composite_nodes.h>
-#include <ir/interface_nodes.h>
-#include <ir/internal_nodes.h>
-#include <ir/utils.h>
-#include <mma_type.h>
-#include <options.h>
-#include <runtime/executor_utils.h>
-#include <scheduler/matmul_heuristic.h>
-#include <scheduler/mma_utils.h>
-#include <type.h>
-#include <val_graph.h>
-#include "base.h"
+#include "scheduler/matmul_utils.h"
 
 #include <algorithm>
 #include <limits>
@@ -39,6 +14,27 @@
 #include <utility>
 
 #include <ATen/cuda/CUDAContext.h>
+
+#include "base.h"
+#include "cuda_utils.h"
+#include "debug.h"
+#include "id_model/id_model.h"
+#include "ir/base_nodes.h"
+#include "ir/composite_nodes.h"
+#include "ir/interface_nodes.h"
+#include "ir/internal_nodes.h"
+#include "ir/utils.h"
+#include "mma_type.h"
+#include "options.h"
+#include "runtime/executor_utils.h"
+#include "scheduler/matmul_heuristic.h"
+#include "scheduler/matmul_heuristic_plugin.h"
+#include "scheduler/mma_utils.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
+#include "type.h"
+#include "val_graph.h"
 
 namespace nvfuser {
 namespace matmul_utils {

--- a/csrc/scheduler/mma_utils.cpp
+++ b/csrc/scheduler/mma_utils.cpp
@@ -5,34 +5,29 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/mma_utils.h>
-
-#include <ranges>
-#include <variant>
-
-#include <scheduler/mma_utils.h>
+#include "scheduler/mma_utils.h"
 
 #include <ranges>
 #include <variant>
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <compute_at_map.h>
-#include <device_lower/utils.h>
-#include <disjoint_set.h>
-#include <id_model/id_model.h>
-#include <ir/printer.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <mma_type.h>
-#include <ops/all_ops.h>
-#include <ops/utils.h>
-#include <options.h>
-#include <scheduler/tools/abstract_tensor.h>
-#include <scheduler/utils.h>
-#include <type.h>
-#include <val_graph.h>
 #include "base.h"
+#include "compute_at_map.h"
+#include "device_lower/utils.h"
+#include "disjoint_set.h"
+#include "id_model/id_model.h"
+#include "ir/printer.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "mma_type.h"
+#include "ops/all_ops.h"
+#include "ops/utils.h"
+#include "options.h"
+#include "scheduler/tools/abstract_tensor.h"
+#include "scheduler/utils.h"
+#include "type.h"
+#include "val_graph.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/no_op.cpp
+++ b/csrc/scheduler/no_op.cpp
@@ -6,16 +6,17 @@
  */
 // clang-format on
 
-#include <ir/utils.h>
-#include <multidevice/utils.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/no_op.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
+#include "scheduler/no_op.h"
 
 #include <algorithm>
 #include <ranges>
+
+#include "ir/utils.h"
+#include "multidevice/utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/normalization_inner.cpp
+++ b/csrc/scheduler/normalization_inner.cpp
@@ -5,20 +5,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <instrumentation.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/normalization_inner.h>
-#include <scheduler/normalization_inner_non_tma.h>
-#include <scheduler/normalization_inner_tma.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
+#include "scheduler/normalization_inner.h"
+
+#include <memory>
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <memory>
+#include "instrumentation.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/normalization_inner_non_tma.h"
+#include "scheduler/normalization_inner_tma.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 using PersistentKernelProperties =

--- a/csrc/scheduler/normalization_inner_non_tma.cpp
+++ b/csrc/scheduler/normalization_inner_non_tma.cpp
@@ -5,22 +5,23 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <instrumentation.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/normalization_inner_non_tma.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-
-#include <ATen/cuda/CUDAContext.h>
+#include "scheduler/normalization_inner_non_tma.h"
 
 #include <algorithm>
 #include <iostream>
 #include <memory>
 #include <utility>
 #include <vector>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include "instrumentation.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 namespace normalization_inner {

--- a/csrc/scheduler/normalization_inner_outer.cpp
+++ b/csrc/scheduler/normalization_inner_outer.cpp
@@ -5,18 +5,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <instrumentation.h>
-#include <options.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/normalization_inner_outer_multi_wave.h>
-#include <scheduler/normalization_inner_outer_tma_ws.h>
-#include <scheduler/normalization_inner_outer_utils.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-
 #include <ATen/cuda/CUDAContext.h>
+
+#include "instrumentation.h"
+#include "options.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/normalization_inner_outer_multi_wave.h"
+#include "scheduler/normalization_inner_outer_tma_ws.h"
+#include "scheduler/normalization_inner_outer_utils.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 namespace {

--- a/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
+++ b/csrc/scheduler/normalization_inner_outer_multi_wave.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <options.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-
 #include <ATen/cuda/CUDAContext.h>
+
+#include "options.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
 
 namespace nvfuser {
 namespace inner_outer_multi_wave {

--- a/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
+++ b/csrc/scheduler/normalization_inner_outer_tma_ws.cpp
@@ -5,15 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ops/arith.h>
-#include <options.h>
-#include <scheduler/normalization_inner_outer_utils.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include "base.h"
-
 #include <ATen/cuda/CUDAContext.h>
+
+#include "base.h"
+#include "ops/arith.h"
+#include "options.h"
+#include "scheduler/normalization_inner_outer_utils.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
 namespace nvfuser {
 namespace inner_outer_tma_warp_specialized {
 void getHeuristics(

--- a/csrc/scheduler/normalization_inner_outer_utils.cpp
+++ b/csrc/scheduler/normalization_inner_outer_utils.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <instrumentation.h>
-#include <options.h>
-#include <scheduler/normalization_inner_outer_utils.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
+#include "scheduler/normalization_inner_outer_utils.h"
 
 #include <ATen/cuda/CUDAContext.h>
+
+#include "instrumentation.h"
+#include "options.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 namespace inner_outer_utils {

--- a/csrc/scheduler/normalization_inner_tma.cpp
+++ b/csrc/scheduler/normalization_inner_tma.cpp
@@ -5,15 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ops/arith.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/normalization_inner_tma.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-
-#include <ATen/cuda/CUDAContext.h>
+#include "scheduler/normalization_inner_tma.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -21,9 +13,17 @@
 #include <optional>
 #include <ranges>
 
-#include <exceptions.h>
-#include <iter_visitor.h>
-#include <runtime/executor_params.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "exceptions.h"
+#include "iter_visitor.h"
+#include "ops/arith.h"
+#include "runtime/executor_params.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 namespace normalization_inner {

--- a/csrc/scheduler/normalization_outer.cpp
+++ b/csrc/scheduler/normalization_outer.cpp
@@ -5,17 +5,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <instrumentation.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/normalization_outer.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
+#include "scheduler/normalization_outer.h"
 
 #include <ATen/cuda/CUDAContext.h>
+
+#include "instrumentation.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/normalization_utils.cpp
+++ b/csrc/scheduler/normalization_utils.cpp
@@ -5,24 +5,25 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <expr_evaluator.h>
-#include <grouped_reduction.h>
-#include <id_model/id_model.h>
-#include <instrumentation.h>
-#include <iter_visitor.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/domain_map.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-#include <val_graph_visitor.h>
-#include "base.h"
+#include "scheduler/normalization_utils.h"
 
 #include <ATen/cuda/CUDAContext.h>
+
+#include "base.h"
+#include "expr_evaluator.h"
+#include "grouped_reduction.h"
+#include "id_model/id_model.h"
+#include "instrumentation.h"
+#include "iter_visitor.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/domain_map.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 namespace normalization_scheduler_utils {

--- a/csrc/scheduler/nvmmh.cpp
+++ b/csrc/scheduler/nvmmh.cpp
@@ -6,16 +6,16 @@
  */
 // clang-format on
 
-#include <device_lower/utils.h>
-#include <exceptions.h>
-#include <instrumentation.h>
-#include <ir/all_nodes.h>
-#include <ops/all_ops.h>
-#include <scheduler/cutlass.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-
 #include <dlfcn.h>
+
+#include "device_lower/utils.h"
+#include "exceptions.h"
+#include "instrumentation.h"
+#include "ir/all_nodes.h"
+#include "ops/all_ops.h"
+#include "scheduler/cutlass.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/pointwise.cpp
+++ b/csrc/scheduler/pointwise.cpp
@@ -6,18 +6,20 @@
  */
 // clang-format on
 
-#include <scheduler/pointwise.h>
+#include "scheduler/pointwise.h"
+
+#include <ranges>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <instrumentation.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/pointwise_non_tma.h>
-#include <scheduler/pointwise_tma.h>
-#include <scheduler/pointwise_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-#include <ranges>
+
+#include "instrumentation.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/pointwise_non_tma.h"
+#include "scheduler/pointwise_tma.h"
+#include "scheduler/pointwise_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/pointwise_non_tma.cpp
+++ b/csrc/scheduler/pointwise_non_tma.cpp
@@ -6,19 +6,20 @@
  */
 // clang-format on
 
-#include <scheduler/pointwise_non_tma.h>
+#include "scheduler/pointwise_non_tma.h"
 
 #include <ATen/cuda/CUDAContext.h>
-#include <debug.h>
-#include <ir/printer.h>
-#include <multidevice/utils.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-#include <scheduler/vectorize_helper.h>
+
+#include "debug.h"
 #include "exceptions.h"
+#include "ir/printer.h"
+#include "multidevice/utils.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "scheduler/vectorize_helper.h"
 
 namespace nvfuser {
 namespace pointwise {

--- a/csrc/scheduler/pointwise_tma.cpp
+++ b/csrc/scheduler/pointwise_tma.cpp
@@ -6,18 +6,20 @@
  */
 // clang-format on
 
+#include "scheduler/pointwise_tma.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <ir/utils.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/pointwise_tma.h>
-#include <scheduler/pointwise_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-#include <scheduler/vectorize_helper.h>
-#include <transform_iter.h>
-#include <transform_replay.h>
+
 #include "exceptions.h"
+#include "ir/utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/pointwise_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "scheduler/vectorize_helper.h"
+#include "transform_iter.h"
+#include "transform_replay.h"
 
 namespace nvfuser {
 namespace pointwise {

--- a/csrc/scheduler/pointwise_utils.cpp
+++ b/csrc/scheduler/pointwise_utils.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/pointwise_utils.h>
+#include "scheduler/pointwise_utils.h"
 
 #include <ATen/cuda/CUDAContext.h>
-#include <ir/printer.h>
-#include <multidevice/utils.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
+
+#include "ir/printer.h"
+#include "multidevice/utils.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 namespace pointwise_utils {

--- a/csrc/scheduler/reduction.cpp
+++ b/csrc/scheduler/reduction.cpp
@@ -5,16 +5,18 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "scheduler/reduction.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <debug.h>
-#include <instrumentation.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/reduction.h>
-#include <scheduler/reduction_non_tma.h>
-#include <scheduler/reduction_tma.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
+
+#include "debug.h"
+#include "instrumentation.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/reduction_non_tma.h"
+#include "scheduler/reduction_tma.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/reduction_non_tma.cpp
+++ b/csrc/scheduler/reduction_non_tma.cpp
@@ -6,21 +6,23 @@
  */
 // clang-format on
 
+#include "scheduler/reduction_non_tma.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <debug.h>
-#include <instrumentation.h>
-#include <multidevice/utils.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/reduction.h>
-#include <scheduler/reduction_non_tma.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/domain_map.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
-#include <scheduler/vectorize_helper.h>
+
+#include "debug.h"
+#include "instrumentation.h"
+#include "multidevice/utils.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/reduction.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/domain_map.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "scheduler/vectorize_helper.h"
 
 namespace nvfuser {
 namespace reduction {

--- a/csrc/scheduler/reduction_tma.cpp
+++ b/csrc/scheduler/reduction_tma.cpp
@@ -6,13 +6,15 @@
  */
 // clang-format on
 
+#include "scheduler/reduction_tma.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/reduction_tma.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/utils.h>
+
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 namespace reduction {

--- a/csrc/scheduler/reduction_utils.cpp
+++ b/csrc/scheduler/reduction_utils.cpp
@@ -5,20 +5,22 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "scheduler/reduction_utils.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <expr_evaluator.h>
-#include <ir/cloner.h>
-#include <ir/iostream.h>
-#include <ir/utils.h>
-#include <multidevice/utils.h>
-#include <ops/arith.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/maxinfo_propagator.h>
-#include <scheduler/utils.h>
-#include <transform_replay.h>
+
 #include "base.h"
+#include "expr_evaluator.h"
+#include "ir/cloner.h"
+#include "ir/iostream.h"
+#include "ir/utils.h"
+#include "multidevice/utils.h"
+#include "ops/arith.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/maxinfo_propagator.h"
+#include "scheduler/utils.h"
+#include "transform_replay.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/registry.cpp
+++ b/csrc/scheduler/registry.cpp
@@ -5,19 +5,21 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "scheduler/registry.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <instrumentation.h>
-#include <scheduler/all_schedulers.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/greedy.h>
-#include <scheduler/heuristic.h>
-#include <scheduler/matmul_utils.h>
-#include <scheduler/registry.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/resize.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/utils.h>
-#include <visibility.h>
+
+#include "instrumentation.h"
+#include "scheduler/all_schedulers.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/greedy.h"
+#include "scheduler/heuristic.h"
+#include "scheduler/matmul_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/resize.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/utils.h"
+#include "visibility.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/registry_utils.cpp
+++ b/csrc/scheduler/registry_utils.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <multidevice/utils.h>
-#include <runtime/executor_kernel_arg.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/tools/resize_utils.h>
-#include <scheduler/utils.h>
+#include "scheduler/registry_utils.h"
+
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "multidevice/utils.h"
+#include "runtime/executor_kernel_arg.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/tools/resize_utils.h"
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/resize.cpp
+++ b/csrc/scheduler/resize.cpp
@@ -6,25 +6,26 @@
  */
 // clang-format on
 
-#include <debug.h>
-#include <instrumentation.h>
-#include <ir/utils.h>
-#include <scheduler/cache_policy_refiner.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/mark_aliases.h>
-#include <scheduler/pointwise_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/resize.h>
-#include <scheduler/resize_heuristic.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/tools/loop_domain_scheduler.h>
-#include <scheduler/tools/resize_utils.h>
-#include <scheduler/tools/static_repeat.h>
-#include <val_graph_visitor.h>
+#include "scheduler/resize.h"
 
 #include <memory>
 #include <ranges>
+
+#include "debug.h"
+#include "instrumentation.h"
+#include "ir/utils.h"
+#include "scheduler/cache_policy_refiner.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/mark_aliases.h"
+#include "scheduler/pointwise_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/resize_heuristic.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/tools/loop_domain_scheduler.h"
+#include "scheduler/tools/resize_utils.h"
+#include "scheduler/tools/static_repeat.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/runtime_info.cpp
+++ b/csrc/scheduler/runtime_info.cpp
@@ -5,12 +5,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
+#include "scheduler/runtime_info.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <instrumentation.h>
-#include <runtime/executor_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <tensor_metadata.h>
+
+#include "instrumentation.h"
+#include "runtime/executor_utils.h"
+#include "scheduler/registry_utils.h"
+#include "tensor_metadata.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/scheduler_types.cpp
+++ b/csrc/scheduler/scheduler_types.cpp
@@ -6,8 +6,9 @@
  */
 // clang-format on
 
-#include <exceptions.h>
-#include <scheduler/scheduler_types.h>
+#include "scheduler/scheduler_types.h"
+
+#include "exceptions.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/tools/cub_utils.cpp
+++ b/csrc/scheduler/tools/cub_utils.cpp
@@ -6,7 +6,8 @@
  */
 // clang-format on
 
-#include <scheduler/tools/cub_utils.h>
+#include "scheduler/tools/cub_utils.h"
+
 #include "base.h"
 
 namespace nvfuser {

--- a/csrc/scheduler/tools/domain_map.cpp
+++ b/csrc/scheduler/tools/domain_map.cpp
@@ -5,10 +5,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/tools/domain_map.h>
-#include <scheduler/utils.h>
+#include "scheduler/tools/domain_map.h"
 
 #include <ranges>
+
+#include "scheduler/utils.h"
 
 namespace nvfuser {
 namespace scheduler_tools {

--- a/csrc/scheduler/tools/inlining.cpp
+++ b/csrc/scheduler/tools/inlining.cpp
@@ -5,14 +5,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <id_model/utils.h>
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <logical_domain_map.h>
-#include <scheduler/tools/inlining.h>
-#include <transform_iter.h>
+#include "scheduler/tools/inlining.h"
 
 #include <utility>
+
+#include "id_model/utils.h"
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "logical_domain_map.h"
+#include "transform_iter.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/tools/loop_domain_scheduler.cpp
+++ b/csrc/scheduler/tools/loop_domain_scheduler.cpp
@@ -6,16 +6,17 @@
  */
 // clang-format on
 
-#include <dispatch.h>
-#include <id_model/id_model.h>
-#include <id_model/schedule.h>
-#include <ir/internal_nodes.h>
-#include <ir/utils.h>
-#include <scheduler/tools/loop_domain_scheduler.h>
-#include <val_graph_visitor.h>
+#include "scheduler/tools/loop_domain_scheduler.h"
 
 #include <ranges>
 #include <unordered_set>
+
+#include "dispatch.h"
+#include "id_model/id_model.h"
+#include "id_model/schedule.h"
+#include "ir/internal_nodes.h"
+#include "ir/utils.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 namespace scheduler_tools {

--- a/csrc/scheduler/tools/maxinfo_propagator.cpp
+++ b/csrc/scheduler/tools/maxinfo_propagator.cpp
@@ -5,9 +5,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <scheduler/tools/maxinfo_propagator.h>
+#include "scheduler/tools/maxinfo_propagator.h"
+
+#include "ir/utils.h"
+#include "logical_domain_map.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/tools/resize_utils.cpp
+++ b/csrc/scheduler/tools/resize_utils.cpp
@@ -6,14 +6,15 @@
  */
 // clang-format on
 
-#include <id_model/id_model.h>
-#include <ir/cloner.h>
-#include <ir/utils.h>
-#include <iter_visitor.h>
-#include <logical_domain_map.h>
-#include <scheduler/tools/loop_domain_scheduler.h>
-#include <scheduler/tools/resize_utils.h>
-#include <val_graph_visitor.h>
+#include "scheduler/tools/resize_utils.h"
+
+#include "id_model/id_model.h"
+#include "ir/cloner.h"
+#include "ir/utils.h"
+#include "iter_visitor.h"
+#include "logical_domain_map.h"
+#include "scheduler/tools/loop_domain_scheduler.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 namespace scheduler_tools {

--- a/csrc/scheduler/tools/static_repeat.cpp
+++ b/csrc/scheduler/tools/static_repeat.cpp
@@ -6,10 +6,11 @@
  */
 // clang-format on
 
-#include <ir/all_nodes.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <scheduler/tools/static_repeat.h>
+#include "scheduler/tools/static_repeat.h"
+
+#include "ir/all_nodes.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
 
 namespace nvfuser {
 namespace scheduler_tools {

--- a/csrc/scheduler/transpose.cpp
+++ b/csrc/scheduler/transpose.cpp
@@ -6,17 +6,19 @@
  */
 // clang-format on
 
+#include "scheduler/transpose.h"
+
 #include <ATen/cuda/CUDAContext.h>
-#include <debug.h>
-#include <instrumentation.h>
-#include <scheduler/debug_utils.h>
-#include <scheduler/reduction_utils.h>
-#include <scheduler/registry_utils.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/inlining.h>
-#include <scheduler/transpose.h>
-#include <scheduler/utils.h>
-#include <scheduler/vectorize_helper.h>
+
+#include "debug.h"
+#include "instrumentation.h"
+#include "scheduler/debug_utils.h"
+#include "scheduler/reduction_utils.h"
+#include "scheduler/registry_utils.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/inlining.h"
+#include "scheduler/utils.h"
+#include "scheduler/vectorize_helper.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/utils.cpp
+++ b/csrc/scheduler/utils.cpp
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/utils.h>
-#include "base.h"
+#include "scheduler/utils.h"
 
 #include <algorithm>
 #include <queue>
@@ -14,34 +13,35 @@
 
 #include <ATen/cuda/CUDAContext.h>
 
-#include <bfs.h>
-#include <contiguity.h>
-#include <cuda_utils.h>
-#include <expr_evaluator.h>
-#include <id_model/id_model.h>
-#include <id_model/schedule.h>
-#include <instrumentation.h>
-#include <ir/allocation_utils.h>
-#include <ir/builder.h>
-#include <ir/interface_nodes.h>
-#include <ir/utils.h>
-#include <logical_domain_map.h>
-#include <multidevice/allocation_utils.h>
-#include <multidevice/resharding.h>
-#include <multidevice/utils.h>
-#include <ops/all_ops.h>
-#include <runtime/executor_utils.h>
-#include <scheduler/matmul_utils.h>
-#include <scheduler/mma_utils.h>
-#include <scheduler/normalization_utils.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/loop_domain_scheduler.h>
-#include <scheduler/vectorize_helper.h>
-#include <transform_iter.h>
-#include <transform_replay.h>
-#include <type.h>
-#include <val_graph_visitor.h>
+#include "base.h"
+#include "bfs.h"
+#include "contiguity.h"
+#include "cuda_utils.h"
+#include "expr_evaluator.h"
+#include "id_model/id_model.h"
+#include "id_model/schedule.h"
+#include "instrumentation.h"
+#include "ir/allocation_utils.h"
+#include "ir/builder.h"
+#include "ir/interface_nodes.h"
+#include "ir/utils.h"
+#include "logical_domain_map.h"
+#include "multidevice/allocation_utils.h"
+#include "multidevice/resharding.h"
+#include "multidevice/utils.h"
+#include "ops/all_ops.h"
+#include "runtime/executor_utils.h"
+#include "scheduler/matmul_utils.h"
+#include "scheduler/mma_utils.h"
+#include "scheduler/normalization_utils.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/loop_domain_scheduler.h"
+#include "scheduler/vectorize_helper.h"
+#include "transform_iter.h"
+#include "transform_replay.h"
+#include "type.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 

--- a/csrc/scheduler/vectorize_helper.cpp
+++ b/csrc/scheduler/vectorize_helper.cpp
@@ -5,27 +5,27 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 // clang-format on
-#include <scheduler/vectorize_helper.h>
-
-#include <compute_at_map.h>
-#include <contiguity.h>
-#include <device_lower/analysis/divisible_split.h>
-#include <expr_evaluator.h>
-#include <expr_simplifier.h>
-#include <id_model/id_model.h>
-#include <instrumentation.h>
-#include <ir/builder.h>
-#include <ir/iostream.h>
-#include <ir/printer.h>
-#include <iter_visitor.h>
-#include <multidevice/utils.h>
-#include <scheduler/registry.h>
-#include <scheduler/runtime_info.h>
-#include <scheduler/tools/resize_utils.h>
-#include <scheduler/utils.h>
-#include <val_graph_visitor.h>
+#include "scheduler/vectorize_helper.h"
 
 #include <unordered_set>
+
+#include "compute_at_map.h"
+#include "contiguity.h"
+#include "device_lower/analysis/divisible_split.h"
+#include "expr_evaluator.h"
+#include "expr_simplifier.h"
+#include "id_model/id_model.h"
+#include "instrumentation.h"
+#include "ir/builder.h"
+#include "ir/iostream.h"
+#include "ir/printer.h"
+#include "iter_visitor.h"
+#include "multidevice/utils.h"
+#include "scheduler/registry.h"
+#include "scheduler/runtime_info.h"
+#include "scheduler/tools/resize_utils.h"
+#include "scheduler/utils.h"
+#include "val_graph_visitor.h"
 
 namespace nvfuser {
 namespace vectorize_helper {


### PR DESCRIPTION
## Summary
- standardize include ordering in scheduler implementation files
- switch project includes to quotes and group local/standard/third/project
- keep related header first across scheduler and scheduler/tools cpp

## Testing
- not run
