### PR TITLE
host_ir: standardize include style

### DIFF
--- a/csrc/host_ir/jit.cpp
+++ b/csrc/host_ir/jit.cpp
@@ -21,24 +21,22 @@
 #include <c10/core/MemoryFormat.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAStream.h>
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
-#include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
-#include "llvm/ExecutionEngine/Orc/ThreadSafeModule.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/Support/Error.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
 
-#include "driver_api.h"
-#include "runtime/compiled_kernel.h"
-#include "runtime/executor.h"
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/Support/Error.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/raw_ostream.h>
 
 #include "bfs.h"
+#include "driver_api.h"
 #include "expr_evaluator.h"
 #include "fusion_profiler.h"
 #include "host_ir/evaluator.h"
@@ -51,6 +49,8 @@
 #include "linked_hash_map.h"
 #include "ops/all_ops.h"
 #include "polymorphic_value.h"
+#include "runtime/compiled_kernel.h"
+#include "runtime/executor.h"
 #include "runtime/executor_kernel_arg.h"
 #include "runtime/fusion_executor_cache.h"
 #include "runtime/fusion_kernel_runtime.h"

--- a/csrc/host_ir/jit_external.cpp
+++ b/csrc/host_ir/jit_external.cpp
@@ -16,9 +16,10 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAStream.h>
-#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
-#include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+
+#include <llvm/ExecutionEngine/Orc/CompileUtils.h>
+#include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
 
 #include "driver_api.h"
 #include "fusion_profiler.h"

--- a/csrc/host_ir/jit_external.h
+++ b/csrc/host_ir/jit_external.h
@@ -7,7 +7,7 @@
 // clang-format on
 #pragma once
 
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
 
 namespace nvfuser {
 

--- a/csrc/host_ir/jit_tensor_utils.cpp
+++ b/csrc/host_ir/jit_tensor_utils.cpp
@@ -12,10 +12,10 @@
 #include <ranges>
 #include <unordered_map>
 
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 
 #include "bfs.h"
 #include "expr_evaluator.h"

--- a/csrc/host_ir/jit_tensor_utils.h
+++ b/csrc/host_ir/jit_tensor_utils.h
@@ -10,12 +10,12 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/LLVMContext.h"
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/LLVMContext.h>
 
-#include <ir/all_nodes.h>
-#include <type.h>
+#include "ir/all_nodes.h"
+#include "type.h"
 
 namespace nvfuser {
 

--- a/csrc/host_ir/ops.cpp
+++ b/csrc/host_ir/ops.cpp
@@ -6,21 +6,21 @@
  */
 // clang-format on
 
-#include <host_ir/ops.h>
+#include "host_ir/ops.h"
 
 #include <algorithm>
 #include <optional>
 #include <ranges>
 #include <vector>
 
-#include <host_ir/ir.h>
-#include <ir/utils.h>
-#include <multidevice/allocation_utils.h>
-#include <multidevice/propagation.h>
-#include <multidevice/utils.h>
-#include <ops/all_ops.h>
-#include <transform_replay.h>
 #include "base.h"
+#include "host_ir/ir.h"
+#include "ir/utils.h"
+#include "multidevice/allocation_utils.h"
+#include "multidevice/propagation.h"
+#include "multidevice/utils.h"
+#include "ops/all_ops.h"
+#include "transform_replay.h"
 
 namespace nvfuser::hir {
 

--- a/csrc/host_ir/ops.h
+++ b/csrc/host_ir/ops.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <host_ir/ir.h>
-#include <ir/interface_nodes.h>
+#include "host_ir/ir.h"
+#include "ir/interface_nodes.h"
 
 namespace nvfuser::hir {
 


### PR DESCRIPTION
## Summary
- standardize include ordering and quote style in host_ir JIT/ops files
- add a blank line between ATen/c10 and LLVM include groups

## Testing
- not run
