### PR TITLE
Add a missing scheduler_utils::parallelizeAllLike

### DIFF
--- a/tests/cpp/test_resize.cpp
+++ b/tests/cpp/test_resize.cpp
@@ -280,6 +280,9 @@ TEST_F(ResizeTest, Pad6) {
 
   tv4->axis(0)->parallelize(ParallelType::BIDx);
   tv4->axis(1)->parallelize(ParallelType::TIDx);
+  scheduler_utils::parallelizeAllLike(tv4);
+
+  scheduler_utils::promoteProducerMemoryTypes(&fusion, {});
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -340,12 +343,12 @@ TEST_F(ResizeTest, Pad7) {
   testValidate(&fusion, cg_outputs, {t0}, __LINE__, __FILE__);
 }
 
+// Stencil-like pattern
+//
 // Disable for now. Unclear what would be the best way to handle
 // when a tensor is resized multiple times. It would likely need a
 // different transform propagator.
-#if 0
-// Stencil-like pattern
-TEST_F(ResizeTest, Pad8) {
+TEST_F(ResizeTest, DISABLED_Pad8) {
   Fusion fusion;
   FusionGuard fg(&fusion);
 
@@ -371,7 +374,7 @@ TEST_F(ResizeTest, Pad8) {
   tv4->axis(1)->parallelize(ParallelType::TIDx);
   scheduler_utils::parallelizeAllLike(tv4);
 
-  scheduler_utils::promoteProducerMemoryTypesOfResizedTensors(&fusion, {});
+  scheduler_utils::promoteProducerMemoryTypes(&fusion, {});
 
   auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA, 0);
 
@@ -385,7 +388,6 @@ TEST_F(ResizeTest, Pad8) {
 
   testValidate(&fusion, cg_outputs, {t0}, {ref}, __LINE__, __FILE__);
 }
-#endif
 
 TEST_F(ResizeTest, PadScheduler1) {
   auto fusion = std::make_unique<Fusion>();


### PR DESCRIPTION
As a side effect, this speeds up the test from 13 seconds to 0.2 seconds. 

Before:
```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ResizeTest
[ RUN      ] ResizeTest.Pad6
Inputs:
  T0_g_float[iS24{344}, iS25{32}]
  T1_g_float[iS15{350}, iS16{32}]
Outputs:
  T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )

%kernel {
T2_l_float[iS21{344}, iS22{32}]
   = T0_g_float[iS24{344}, iS25{32}]
   + double(1);
T3_l_float[iS18{350}, iS19{32}] ca_pos( 2 )
   = pad( T2_l_float[iS21{344}, iS22{32}], {0, 0, 1, 1} )
T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )
   = T3_l_float[iS18{350}, iS19{32}] ca_pos( 2 )
   + T1_g_float[iS15{350}, iS16{32}];

TransformPrinter :
T0_g_float[iS24{344}, iS25{32}]
  logical domain: (iS0{99}, iS1{111})
  contiguity: f f
    Merge: iS0{99} and iS1{111} -> iS23{10989}
    Split: iS23{10989} by factor 32 -> iS24{344}, iS25{32}
  loop domain: (iS24{344}, iS25{32})
T2_l_float[iS21{344}, iS22{32}]
  logical domain: (iS4{99}, iS5{111})
  contiguity: t t
    Merge: iS4{99} and iS5{111} -> iS20{10989}
    Split: iS20{10989} by factor 32 -> iS21{344}, iS22{32}
  loop domain: (iS21{344}, iS22{32})
T3_l_float[iS18{350}, iS19{32}] ca_pos( 2 )
  root domain: (iS6{99}, iS7{111}rf)
    Resize: iS7{111}rf by 1 and 1 -> iS8{113}rf
  logical domain: (iS6{99}, iS8{113}rf)
  contiguity: t t
    Resize: iS7{111}rf by 1 and 1 -> iS8{113}rf
    Merge: iS6{99} and iS8{113}rf -> iS17{11187}
    Split: iS17{11187} by factor 32 -> iS18{350}, iS19{32}
  loop domain: (iS18{350}, iS19{32})
T1_g_float[iS15{350}, iS16{32}]
  logical domain: (iS2{99}, iS3{113})
  contiguity: f f
    Merge: iS2{99} and iS3{113} -> iS14{11187}
    Split: iS14{11187} by factor 32 -> iS15{350}, iS16{32}
  loop domain: (iS15{350}, iS16{32})
T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )
  logical domain: (iS9{99}, iS10{113})
  contiguity: t t
    Merge: iS9{99} and iS10{113} -> iS11{11187}
    Split: iS11{11187} by factor 32 -> iblockIdx.x12{350}, ithreadIdx.x13{32}
  loop domain: (iblockIdx.x12{350}, ithreadIdx.x13{32})
} // %kernel
[       OK ] ResizeTest.Pad6 (193 ms)
[----------] 1 test from ResizeTest (193 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (193 ms total)
[  PASSED  ] 1 test.
```

After:
```
$ NVFUSER_DUMP=fusion_ir bin/test_nvfuser --gtest_filter='*Pad6'
Running main() from /opt/pytorch/nvfuser/third_party/googletest/googletest/src/gtest_main.cc
Note: Google Test filter = *Pad6
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ResizeTest
[ RUN      ] ResizeTest.Pad6
Inputs:
  T0_g_float[iS24{344}, iS25{32}]
  T1_g_float[iS15{350}, iS16{32}]
Outputs:
  T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )

%kernel {
T2_g_float[iblockIdx.x21{344}, ithreadIdx.x22{32}]
   = T0_g_float[iS24{344}, iS25{32}]
   + double(1);
T3_l_float[iblockIdx.x18{350}, ithreadIdx.x19{32}] ca_pos( 2 )
   = pad( T2_g_float[iblockIdx.x21{344}, ithreadIdx.x22{32}], {0, 0, 1, 1} )
T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )
   = T3_l_float[iblockIdx.x18{350}, ithreadIdx.x19{32}] ca_pos( 2 )
   + T1_g_float[iS15{350}, iS16{32}];

TransformPrinter :
T0_g_float[iS24{344}, iS25{32}]
  logical domain: (iS0{99}, iS1{111})
  contiguity: f f
    Merge: iS0{99} and iS1{111} -> iS23{10989}
    Split: iS23{10989} by factor 32 -> iS24{344}, iS25{32}
  loop domain: (iS24{344}, iS25{32})
T2_g_float[iblockIdx.x21{344}, ithreadIdx.x22{32}]
  logical domain: (iS4{99}, iS5{111})
  contiguity: t t
    Merge: iS4{99} and iS5{111} -> iS20{10989}
    Split: iS20{10989} by factor 32 -> iblockIdx.x21{344}, ithreadIdx.x22{32}
  loop domain: (iblockIdx.x21{344}, ithreadIdx.x22{32})
T3_l_float[iblockIdx.x18{350}, ithreadIdx.x19{32}] ca_pos( 2 )
  root domain: (iS6{99}, iS7{111}rf)
    Resize: iS7{111}rf by 1 and 1 -> iS8{113}rf
  logical domain: (iS6{99}, iS8{113}rf)
  contiguity: t t
    Resize: iS7{111}rf by 1 and 1 -> iS8{113}rf
    Merge: iS6{99} and iS8{113}rf -> iS17{11187}
    Split: iS17{11187} by factor 32 -> iblockIdx.x18{350}, ithreadIdx.x19{32}
  loop domain: (iblockIdx.x18{350}, ithreadIdx.x19{32})
T1_g_float[iS15{350}, iS16{32}]
  logical domain: (iS2{99}, iS3{113})
  contiguity: f f
    Merge: iS2{99} and iS3{113} -> iS14{11187}
    Split: iS14{11187} by factor 32 -> iS15{350}, iS16{32}
  loop domain: (iS15{350}, iS16{32})
T4_g_float[iblockIdx.x12{350}, ithreadIdx.x13{32}] ca_pos( 2 ) produce_pos( 2 )
  logical domain: (iS9{99}, iS10{113})
  contiguity: t t
    Merge: iS9{99} and iS10{113} -> iS11{11187}
    Split: iS11{11187} by factor 32 -> iblockIdx.x12{350}, ithreadIdx.x13{32}
  loop domain: (iblockIdx.x12{350}, ithreadIdx.x13{32})
} // %kernel
[       OK ] ResizeTest.Pad6 (190 ms)
[----------] 1 test from ResizeTest (190 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (190 ms total)
[  PASSED  ] 1 test.
```