### PR TITLE
Replace getInputsInTargetDomain with getReachableIds

### DIFF
--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -14,6 +14,7 @@
 #include "ir/builder.h"
 #include "ir/internal_base_nodes.h"
 #include "ir/iostream.h"
+#include "ir/utils.h"
 #include "kernel_ir.h"
 #include "multidevice/communication.h"
 #include "multidevice/resharding.h"
@@ -320,13 +321,13 @@ void lowerToAllToAll(
 }
 
 IterDomain* getLogicalFromLoopId(TensorView* tv, IterDomain* loop_id) {
-  std::unordered_set<IterDomain*> logical_ids =
-      getInputsInTargetDomain({loop_id}, tv->getLogicalDomain());
+  std::vector<IterDomain*> logical_ids =
+      ir_utils::getReachableIds(tv->getLogicalDomain(), {loop_id});
   NVF_ERROR(
       logical_ids.size() == 1,
       "Expected exactly one logical ID producing the device dimension ",
       loop_id);
-  return *logical_ids.begin();
+  return logical_ids.front();
 }
 
 bool isLocalSizeOne(IterDomain* id) {

--- a/csrc/multidevice/propagation.cpp
+++ b/csrc/multidevice/propagation.cpp
@@ -16,6 +16,7 @@
 #include "ir/interface_nodes.h"
 #include "ir/internal_base_nodes.h"
 #include "ir/internal_nodes.h"
+#include "ir/utils.h"
 #include "linked_hash_map.h"
 #include "logical_domain_map.h"
 #include "multidevice/utils.h"
@@ -124,15 +125,15 @@ void transformLoopDomain(
     // Similarly, if target [h] -> ref [a, h/a], returns `h` for ref_id `a`.
     if (!ref2target.contains(ref_id)) {
       // Find the root domain id.
-      std::unordered_set<IterDomain*> inputs =
-          getInputsInTargetDomain({ref_id}, ref->getMaybeRootDomain());
+      std::vector<IterDomain*> inputs =
+          ir_utils::getReachableIds(ref->getMaybeRootDomain(), {ref_id});
       NVF_ERROR_EQ(
           inputs.size(),
           1,
           "Expected one input for ",
           ref_id,
           " in the root domain.");
-      ref_id = *inputs.begin();
+      ref_id = inputs.front();
     }
 
     NVF_ERROR(
@@ -291,17 +292,16 @@ void shardLoopLike(
 
     // Get input of device_id in the root / logical domain
     // that will be present in ref2target mapping.
-    std::unordered_set<IterDomain*> inputs =
-        direction == PropagateDirection::kForward
-        ? getInputsInTargetDomain({ref_id}, ref->getLogicalDomain())
-        : getInputsInTargetDomain({ref_id}, ref->getMaybeRootDomain());
+    std::vector<IterDomain*> inputs = direction == PropagateDirection::kForward
+        ? ir_utils::getReachableIds(ref->getLogicalDomain(), {ref_id})
+        : ir_utils::getReachableIds(ref->getMaybeRootDomain(), {ref_id});
     NVF_ERROR_EQ(
         inputs.size(),
         1,
         "Expected one input for ",
         ref_id,
         " in the root / logical domain.");
-    IterDomain* target_id = getOrDefault(ref2target, *inputs.begin());
+    IterDomain* target_id = getOrDefault(ref2target, inputs.front());
     if (target_id == nullptr) {
       continue;
     }

--- a/csrc/multidevice/resharding.cpp
+++ b/csrc/multidevice/resharding.cpp
@@ -256,8 +256,8 @@ bool haveDifferentShardings(
   for (const auto parallel_type : parallel_types) {
     if (IterDomain* p_loop_id =
             getOrDefault(p_parallel_type_to_id, parallel_type)) {
-      for (IterDomain* p_logical_id :
-           getInputsInTargetDomain({p_loop_id}, producer->getLogicalDomain())) {
+      for (IterDomain* p_logical_id : ir_utils::getReachableIds(
+               producer->getLogicalDomain(), {p_loop_id})) {
         if (id_to_index.count(p_logical_id) > 0) {
           continue;
         }
@@ -270,8 +270,8 @@ bool haveDifferentShardings(
   for (const auto parallel_type : parallel_types) {
     if (IterDomain* c_loop_id =
             getOrDefault(c_parallel_type_to_id, parallel_type)) {
-      for (IterDomain* c_root_id : getInputsInTargetDomain(
-               {c_loop_id}, consumer->getMaybeRootDomain())) {
+      for (IterDomain* c_root_id : ir_utils::getReachableIds(
+               consumer->getMaybeRootDomain(), {c_loop_id})) {
         if (id_to_index.count(c_root_id) > 0) {
           continue;
         }

--- a/csrc/multidevice/utils.cpp
+++ b/csrc/multidevice/utils.cpp
@@ -220,21 +220,6 @@ IterDomain* getShardedIterDomain(
   return nullptr;
 }
 
-std::unordered_set<IterDomain*> getInputsInTargetDomain(
-    const std::vector<IterDomain*>& loop_id,
-    const std::vector<IterDomain*>& target_domain) {
-  const std::vector<Val*> inputs_as_vals = IterVisitor::getInputsTo(
-      {loop_id.begin(), loop_id.end()},
-      {target_domain.begin(), target_domain.end()});
-
-  std::unordered_set<IterDomain*> inputs_as_iter_domains;
-  inputs_as_iter_domains.reserve(inputs_as_vals.size());
-  for (auto val : inputs_as_vals) {
-    inputs_as_iter_domains.insert(val->as<IterDomain>());
-  }
-  return inputs_as_iter_domains;
-}
-
 namespace {
 int64_t rankOfParallelType(ParallelType parallel_type) {
   // Currently, when reorderParallelizedToFront is called, the loop domain is

--- a/csrc/multidevice/utils.h
+++ b/csrc/multidevice/utils.h
@@ -28,10 +28,6 @@ std::ostream& operator<<(std::ostream& os, DomainType domain_type);
 // Checks that the other non-reduction axis are not parallelized on Didx
 bool isSharded(const TensorView*);
 
-std::unordered_set<IterDomain*> getInputsInTargetDomain(
-    const std::vector<IterDomain*>& loop_ids,
-    const std::vector<IterDomain*>& target_domain);
-
 // Returns the subset of tvs which elements have the different multi-device
 // sharding as ref
 //


### PR DESCRIPTION
## Summary
- remove multidevice-specific getInputsInTargetDomain wrapper
- use ir_utils::getReachableIds at all call sites
- drop redundant declaration/definition and include ir/utils where needed

## Testing
- _bn
- mpirun -np 2 bin/test_multidevice (fails: communicator setup errors; earlier run hit MultiDeviceTest.BiasAddRelu binding mismatch before timeout)