### PR TITLE
[IR Container] Phase 2.5 Copy-Move Semantics

### DIFF
--- a/csrc/fusion.cpp
+++ b/csrc/fusion.cpp
@@ -112,8 +112,10 @@ void Fusion::swap(Fusion& a, Fusion& b) {
     return;
   }
 
-  NVF_ERROR(a.ir_container_ != nullptr, "Fusion::swap: a has null ir_container_");
-  NVF_ERROR(b.ir_container_ != nullptr, "Fusion::swap: b has null ir_container_");
+  NVF_ERROR(
+      a.ir_container_ != nullptr, "Fusion::swap: a has null ir_container_");
+  NVF_ERROR(
+      b.ir_container_ != nullptr, "Fusion::swap: b has null ir_container_");
 
   // Collect statements owned by each Fusion BEFORE swap so we can update
   // Statement::ir_container_ pointers afterward.
@@ -319,6 +321,11 @@ Fusion::Fusion(const Fusion& other) : ir_container_(other.ir_container_) {
 }
 
 // Move constructor
+// Not marked noexcept: Fusion::swap allocates local std::vectors to collect
+// statement ownership before the swap, which can throw. Since Fusions are not
+// expected to be moved into containers, the performance trade-off is
+// acceptable.
+// NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations)
 Fusion::Fusion(Fusion&& other) : Fusion() {
   FUSER_PERF_SCOPE("Fusion move");
   swap(*this, other);
@@ -335,6 +342,8 @@ Fusion& Fusion::operator=(const Fusion& other) {
   return *this;
 }
 
+// Not marked noexcept: See move constructor above.
+// NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations)
 Fusion& Fusion::operator=(Fusion&& other) {
   FUSER_PERF_SCOPE("Fusion move assign");
   if (this != &other) {

--- a/csrc/fusion.h
+++ b/csrc/fusion.h
@@ -180,9 +180,18 @@ class NVF_API Fusion : public PolymorphicBase {
   Fusion();
 
   Fusion(const Fusion& other);
+
+  // Not marked noexcept: Fusion::swap allocates local std::vectors to collect
+  // statement ownership before the swap, which can throw. Since Fusions are not
+  // expected to be moved into containers, the performance trade-off is
+  // acceptable.
+  // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations)
   Fusion(Fusion&& other);
 
   Fusion& operator=(const Fusion& other);
+
+  // Not marked noexcept: See move constructor above.
+  // NOLINTNEXTLINE(cppcoreguidelines-noexcept-move-operations)
   Fusion& operator=(Fusion&& other);
 
   ~Fusion() override;


### PR DESCRIPTION
#### Summary

Implement shared-container-aware copy, move, and swap operations, plus per-Fusion name counters that ensure cloned Vals get matching names. This PR combines the originally planned Tasks 3 and 4 — per-Fusion name counters were required to fix CI failures from the copy implementation (553 failures from duplicate TV names when name counter synchronization was missing).

#### Changes

**Copy semantics:**
- **Copy constructor & assignment op**: Share container pointer via `shared_ptr`, register with container, delegate to `Fusion::copy`
- **`Fusion::copy`**: Clear destination, create `IrCloner` targeting dest, clone source's `deterministic_vals` into shared container, clone Fusion-level state (inputs, outputs, axioms, metadata)

**Move semantics:**
- **Move constructor**: Create empty Fusion, swap with source
- **Move assignment**: Clear, swap

**Swap:**
- Ownership-filtered pointer swap handling three distinct cases:
  1. Two Fusions with different containers
  2. Two Fusions sharing the same container
  3. Swap with third-party Fusions sharing a container

**Per-Fusion name counters:**
- `val_type_name_map_` and `expr_name_counter_` added as Fusion members
- `getValName(ValType)` and `getExprName()` methods on Fusion
- Counter lifecycle: sync in copy, swap in swap, reset in clear

#### Copy Semantics in Detail

```
BEFORE:
  Fusion A ──→ shared_ptr<Container C> ──→ {val_0(A), val_1(A), expr_0(A)}
  Container C: sharing_fusions_ = {A}

COPY: Fusion B(A)   // copy constructor

AFTER:
  Fusion A ─┐
             ├──→ shared_ptr<Container C> ──→ {val_0(A), val_1(A), expr_0(A),
  Fusion B ─┘                                  val_0'(B), val_1'(B), expr_0'(B)}
  Container C: sharing_fusions_ = {A, B}

  // B's clones have matching names: val_0'->name() == val_0->name()
  // IR graphs are independent: modifying B's clone doesn't affect A
```

The copy constructor shares the container (increments `shared_ptr` refcount), then clones A's nodes into the same shared storage. Per-Fusion tracking ensures each Fusion's accessors still return only their own nodes.

#### Swap: Three Cases

```
Case 1: Different containers
  BEFORE:  A ──→ C1 ──→ {val_0(A)}     B ──→ C2 ──→ {val_1(B)}
  AFTER:   A ──→ C2 ──→ {val_1(A)}     B ──→ C1 ──→ {val_0(B)}
  Statement pointers updated: val_0→B, val_1→A

Case 2: Same container
  BEFORE:  A ─┐                         B ─┐
              ├──→ C ──→ {val_0(A), val_1(B)}
  AFTER:   A ─┐                         B ─┐
              ├──→ C ──→ {val_0(B), val_1(A)}
  Container pointer swap is a no-op; ownership flips.

Case 3: Third-party sharing
  BEFORE:  A ─┐
              ├──→ C1 ──→ {val_0(A), val_2(X)}     B ──→ C2 ──→ {val_1(B)}
         X ─┘
  AFTER:   A ──→ C2 ──→ {val_1(A)}
          B ─┐
              ├──→ C1 ──→ {val_0(B), val_2(X)}
         X ─┘
  Critical: X's statements are NEVER modified.
```

#### Why Name Counters Were Merged Into This PR

The initial implementation of `Fusion::copy` replaced the old `IrContainer::copy` with direct `IrCloner`-based cloning but dropped name counter synchronization. Without per-Fusion counters, cloned Vals in a shared container received names starting past the source's last name (e.g., T10–T19 instead of T0–T9), breaking `alias_memory.cpp` (duplicate `tv->name()` assertions) and cascading into 553 CI failures across codegen, validation, and numerical checks.

The fix — per-Fusion name counters as Fusion members — is architecturally cleaner than the originally planned IrContainer-level maps, avoids indirection, and aligns with the per-Fusion state model established in earlier tasks.

#### Relationship to Phase 2

Copy/move/swap are the operations that make shared containers *usable*. Without them, the `shared_ptr` and tracking infrastructure from PRs 1–2 are inert. This PR enables the core Phase 2 scenario:

```
SegmentedFusion::makeFusion (Phase 2 — separate containers):
  auto fusion_segment = make_unique<Fusion>();     // New container
  Fusion::copy(completeFusion(), fusion_segment);  // Clone into separate container

SegmentedFusion::makeFusion (Phase 3 — shared containers):
  auto fusion_segment = make_unique<Fusion>(*completeFusion());  // Copy ctor → shared!
  // Scalars reused, non-scalars cloned into shared container
```

Phase 2 establishes the copy/move/swap mechanics. Phase 3 simply changes `makeFusion` from default-ctor + `Fusion::copy` to copy-ctor (shared container), and the infrastructure from this PR handles everything correctly.

Per-Fusion name counters are critical for cross-clone name correspondence required by `GreedyParams::at(tv->name())` and `normalization_utils` — both of which look up Vals by name as a map key across clone boundaries.

#### CI Risk

**Medium.** Copy/move/swap are well-defined operations with clear semantics. The 553-failure CI regression from missing name counters was identified and fixed before merge.
