### PR TITLE
lower_to_communication: includes, error macros, and validation

### DIFF
--- a/csrc/host_ir/lower_to_communication.cpp
+++ b/csrc/host_ir/lower_to_communication.cpp
@@ -381,9 +381,9 @@ CommunicationInfo getCommunicationInfo(Expr* e) {
   };
 
   const PairwiseLogicalDomainMap pairwise_map(producer, consumer);
-  const std::unordered_map<IterDomain*, IterDomain*>& p2c =
+  const std::unordered_map<IterDomain*, IterDomain*> p2c =
       pairwise_map.mapProducerToConsumer();
-  const std::unordered_map<IterDomain*, IterDomain*>& c2p =
+  const std::unordered_map<IterDomain*, IterDomain*> c2p =
       pairwise_map.mapConsumerToProducer();
 
   // This ignores device dimensions on reduction axis.


### PR DESCRIPTION
## Summary

Cleanups and consistency in `lower_to_communication.cpp`:

- **Includes**: Add explicit STL headers (`<algorithm>`, `<iterator>`, `<optional>`, `<vector>`) and remove unused includes (e.g. `container.h`, `all_nodes.h`, `kernel_ir.h`, `all_ops.h`). Add `logical_domain_map.h` where needed.
- **Error macros**: Use `NVF_ERROR_EQ` / `NVF_ERROR_GE` for rank, size, and position checks instead of `NVF_ERROR(cond, ...)`.
- **Error messages**: Pass `TensorView` / `Expr` / `IterDomain` directly to error macros instead of `.toString()` where the macro supports it.
- **Validation**: Add `NVF_ERROR_EQ` checks for `e->inputs().size() == 1` and `e->outputs().size() == 1` in `getCommunicationInfo` before indexing.
- **getCommunicationInfo**: Use `PairwiseLogicalDomainMap` with local refs `p2c` / `c2p` (from `mapProducerToConsumer()` / `mapConsumerToProducer()`) instead of `p2c_map` / `c2p_map`; fix `pairwise_map` type to `const PairwiseLogicalDomainMap`.