### PR TITLE
Narrow ATen include in base.h to ATen/core/Tensor.h

### DIFF
--- a/csrc/base.h
+++ b/csrc/base.h
@@ -22,7 +22,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
 #include <c10/core/thread_pool.h>
 
 #include <debug.h>


### PR DESCRIPTION
Replace broad `<ATen/ATen.h>` with `<ATen/core/Tensor.h>` in base.h since only at::Tensor is used from ATen in this file.

Made with [Cursor](https://cursor.com)