### PR TITLE
Fix clang-tidy linter: use proc.stdout when text=True

### DIFF
--- a/tools/linter/adapters/clangtidy_linter.py
+++ b/tools/linter/adapters/clangtidy_linter.py
@@ -72,7 +72,7 @@ RESULTS_RE: Pattern[str] = re.compile(
 
 def run_command(
     args: List[str],
-) -> "subprocess.CompletedProcess[bytes]":
+) -> subprocess.CompletedProcess[str]:
     logging.debug("$ %s", " ".join(args))
     start_time = time.monotonic()
     try:


### PR DESCRIPTION
It's a bug introduced in my #6005. 

subprocess.run(..., text=True) makes proc.stdout a str, so calling .decode() on it raises AttributeError. Use proc.stdout directly.

Made-with: Cursor