### PR TITLE
clang-tidy check against target branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -64,11 +64,9 @@ jobs:
           cd ..
 
           # Run lintrunner on all csrc files exclude benchmark and test folders
-          this_commit=$(git rev-parse HEAD)
-          git fetch origin main
-          git checkout origin/main
-          head_commit=$(git rev-parse HEAD)
-          git checkout $this_commit
+          base_ref="${{ github.base_ref || 'main' }}"
+          git fetch origin $base_ref
+          head_commit=$(git rev-parse FETCH_HEAD)
           # diff-filter for lower case letter:
           # https://github.com/git/git/commit/7f2ea5f0f2fb056314092cce23202096ca70f076
           git --no-pager diff --diff-filter=d --name-only $head_commit | grep -e "csrc/.*\.cpp" -e "csrc/.*\.h" | xargs lintrunner --take CLANGTIDY --force-color


### PR DESCRIPTION
Currently clang-tidy always checks the file diff from a feature branch to `origin/main`. This has clang-tidy check the diff files between the PR branch and the base branch. On chained PR's / branches clang-tidy may report unexpected diffs that are not related to that PR.

There is no change for PR's targeting main.