### PR TITLE
fix: typo in nvfuser_common/lib ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ build
 
 nvfuser_common/version.py
 nvfuser_common/include
-nvfuser_comon/lib
+nvfuser_common/lib
 nvfuser_common/share
 nvfuser_common/cmake
 


### PR DESCRIPTION
This PR fixes a typo in `.gitignore`: typo in nvfuser_common/lib ignore pattern.

## Changes
- `.gitignore`: typo in nvfuser_common/lib ignore pattern.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/test_repo_config.py`